### PR TITLE
Update hardware button capture example controls

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,7 +142,6 @@ sdk.setDashboardPosition(
 sdk.setHeadUpAngle(angleDegrees = 20)
 sdk.setScreenDisabled(false)
 sdk.setGalleryMode(MentraGalleryMode.AUTO)
-sdk.setButtonMode(MentraButtonMode.PHOTO)
 sdk.setButtonPhotoSettings(MentraButtonPhotoSettings(size = MentraPhotoSize.MEDIUM))
 sdk.setButtonVideoRecordingSettings(
     MentraButtonVideoRecordingSettings(width = 1280, height = 720, fps = 30)
@@ -164,7 +163,6 @@ try await sdk.setDashboardPosition(
 try await sdk.setHeadUpAngle(20)
 try await sdk.setScreenDisabled(false)
 try await sdk.setGalleryMode(.auto)
-try await sdk.setButtonMode(.photo)
 try await sdk.setButtonPhotoSettings(
     MentraButtonPhotoSettings(size: .medium)
 )
@@ -177,6 +175,8 @@ try await sdk.setCameraFov(.wide)
 ```
 
 Unsupported settings should fail through a typed error or capability status, not silently succeed.
+
+`setGalleryMode` controls whether hardware-button presses also capture locally on Mentra Live. Button presses are always reported as SDK events; when local capture is enabled, a short press captures a photo and a long press starts or stops video recording. Use `setButtonPhotoSettings` and `setButtonVideoRecordingSettings` to configure those captures.
 
 ## Microphone And Audio
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -2,7 +2,7 @@
 
 This example is a minimal native Android app that calls the Mentra Bluetooth SDK Kotlin API directly.
 
-It is intentionally not a React Native or Expo app. It demonstrates scanning, connecting, receiving hardware events, refreshing device status, capturing microphone frames, routing app audio output, requesting photos, starting/stopping video recording, setting the glasses button mode, and cleaning up the SDK.
+It is intentionally not a React Native or Expo app. It demonstrates scanning, connecting, receiving hardware events, refreshing device status, capturing microphone frames, routing app audio output, requesting photos, starting/stopping video recording, configuring hardware-button capture behavior, and cleaning up the SDK.
 
 ## Configure SDK Version
 
@@ -26,7 +26,7 @@ The app is split into native Android tabs:
 
 - **Status** shows connection/data-channel state, battery, Wi-Fi, firmware/version details, and recent hardware events.
 - **Audio** exercises microphone input callbacks (`onMicPcm`, `onMicLc3`, and local transcription) and plays a short Android output tone while notifying the SDK that the app is producing audio.
-- **Camera** exercises photo requests, gallery status, saved video recording, camera settings, and hardware button modes. The photo preview flow sends a new SDK photo request with a webhook URL, then polls the local webhook server by `requestId` and displays the uploaded image.
+- **Camera** exercises photo requests, gallery status, saved video recording, camera settings, and hardware-button capture behavior. The photo preview flow sends a new SDK photo request with a webhook URL, then polls the local webhook server by `requestId` and displays the uploaded image.
 - **Display** keeps display text/settings controls for glasses models that support display output.
 - **Logs** keeps SDK debug logs hidden by default; use **Show SDK debug logs** when collecting support details.
 

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
@@ -24,7 +24,6 @@ import com.mentra.bluetoothsdk.MentraBluetoothError
 import com.mentra.bluetoothsdk.MentraBluetoothSdk
 import com.mentra.bluetoothsdk.MentraBluetoothSdkListener
 import com.mentra.bluetoothsdk.MentraBluetoothStatusUpdate
-import com.mentra.bluetoothsdk.MentraButtonMode
 import com.mentra.bluetoothsdk.MentraButtonPhotoSettings
 import com.mentra.bluetoothsdk.MentraButtonPressEvent
 import com.mentra.bluetoothsdk.MentraButtonVideoRecordingSettings
@@ -33,6 +32,7 @@ import com.mentra.bluetoothsdk.MentraDashboardPositionRequest
 import com.mentra.bluetoothsdk.MentraDeviceModel
 import com.mentra.bluetoothsdk.MentraDiscoveredDevice
 import com.mentra.bluetoothsdk.MentraDisplayTextRequest
+import com.mentra.bluetoothsdk.MentraGalleryMode
 import com.mentra.bluetoothsdk.MentraGalleryStatusEvent
 import com.mentra.bluetoothsdk.MentraGlassesStatusUpdate
 import com.mentra.bluetoothsdk.MentraLocalTranscriptionEvent
@@ -302,15 +302,25 @@ class MainActivity : Activity(), MentraBluetoothSdkListener {
             stopSavedVideoRecording()
         })
 
-        content.addView(sectionTitle("Hardware button"))
-        content.addView(button("Set button to photo") {
-            sdk.setButtonMode(MentraButtonMode.PHOTO)
-            sdk.setButtonPhotoSettings(MentraButtonPhotoSettings(MentraPhotoSize.MEDIUM))
-            appendAppLog("Set hardware button mode to photo.")
+        content.addView(sectionTitle("Hardware button capture"))
+        content.addView(
+            statusLine(
+                "Hardware button presses are always reported as events. When local capture is enabled, short press takes a photo and long press starts or stops video recording."
+            )
+        )
+        content.addView(button("Enable local button capture") {
+            sdk.setGalleryMode(MentraGalleryMode.AUTO)
+            updateCameraStatus("Camera: hardware button local capture enabled")
+            appendAppLog("Enabled local capture for hardware button presses.")
         })
-        content.addView(button("Set button to video") {
-            sdk.setButtonMode(MentraButtonMode.VIDEO)
-            appendAppLog("Set hardware button mode to video.")
+        content.addView(button("Forward button events only") {
+            sdk.setGalleryMode(MentraGalleryMode.MANUAL)
+            updateCameraStatus("Camera: hardware button local capture disabled while connected")
+            appendAppLog("Disabled local capture while connected; button events are still forwarded.")
+        })
+        content.addView(button("Set short-press photo size") {
+            sdk.setButtonPhotoSettings(MentraButtonPhotoSettings(MentraPhotoSize.MEDIUM))
+            appendAppLog("Set short-press photo size to medium.")
         })
         return content
     }


### PR DESCRIPTION
## Summary

This updates the customer-facing Android example and API docs so they match the real Mentra Live hardware-button behavior.

Instead of showing separate "Set button to photo" and "Set button to video" controls, the example now shows:

- `Enable local button capture`, which calls `sdk.setGalleryMode(MentraGalleryMode.AUTO)`.
- `Forward button events only`, which calls `sdk.setGalleryMode(MentraGalleryMode.MANUAL)`.
- `Set short-press photo size`, which calls `sdk.setButtonPhotoSettings(...)`.

The docs now explain that hardware-button presses are always reported as SDK events. Gallery mode controls whether the press also captures locally, with short press mapped to photo/stop-video and long press mapped to start/stop-video.

## Companion PR

MentraOS SDK/API cleanup: https://github.com/Mentra-Community/MentraOS/pull/2681

## Stacking Note

This PR targets `codex/remove-stale-rolling-buffer-example-controls`, which mirrors the current local Partner Kit `main` branch. That base already removes stale rolling-buffer controls that fail against the current local SDK. Using it as the base keeps this PR focused on the hardware-button capture controls only.

## Validation

- `git diff --check main...HEAD`
- `cd examples/android && /Users/philippe/dev/MentraOS-philippe-os-1178-mentra-bluetooth-sdk/mobile/android/gradlew -p /Users/philippe/dev/Mentra-Bluetooth-SDK-Partner-Kit/examples/android :app:assembleDebug`
