### PR TITLE
Use Bluetooth SDK Android package name

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -586,7 +586,7 @@ subscriptions.forEach((subscription) => subscription.remove());
 
 Common event names include `button_press`, `touch_event`, `head_up`, `battery_status`, `wifi_status_change`, `hotspot_status_change`, `photo_response`, `gallery_status`, `stream_status`, `keep_alive_ack`, `mic_pcm`, `mic_lc3`, `local_transcription`, `rgb_led_control_response`, `audio_connected`, `audio_disconnected`, `log`, `send_command_to_ble`, and `receive_command_from_ble`.
 
-## Core Models
+## SDK Models
 
 | Model | Android | iOS | React Native | Purpose |
 | --- | --- | --- | --- | --- |
@@ -594,7 +594,7 @@ Common event names include `button_press`, `touch_event`, `head_up`, `battery_st
 | Discovered device | `Device` | `Device` | `Device` | Scan result containing model, name, address/identifier, RSSI, and id. |
 | Connection state | `GlassesConnectionState` | `GlassesConnectionState` | `GlassesConnectionStatus` | Link-layer state: disconnected, scanning, connecting, bonding, or connected. React Native uses a discriminated union where `fullyBooted` only exists on the connected state. |
 | Glasses status | `GlassesStatus` / `GlassesStatusUpdate` | `GlassesStatus` / `GlassesStatusUpdate` | `GlassesStatus` | Connected device snapshot: model, firmware, serial, battery, Wi-Fi, hotspot, head-up, controller, and readiness. |
-| Bluetooth/core status | `BluetoothStatus` / `BluetoothStatusUpdate` | `BluetoothStatus` / `BluetoothStatusUpdate` | `CoreStatus` | Scanning state, discovered devices, Wi-Fi scan results, mic state, settings, and logs. |
+| Bluetooth status | `BluetoothStatus` / `BluetoothStatusUpdate` | `BluetoothStatus` / `BluetoothStatusUpdate` | `BluetoothStatus` | Scanning state, discovered devices, Wi-Fi scan results, mic state, settings, and logs. |
 | SDK error | `BluetoothException` / `BluetoothError` | `BluetoothError` | rejected promise or `log`/typed event | Permission, connection, unsupported-capability, command, or native failure. |
 
 ## Defaults

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,7 +12,7 @@ The Mentra Bluetooth SDK exposes the same core glasses lifecycle across Android,
 
 | Platform | Install package | Import |
 | --- | --- | --- |
-| Android | `com.mentra:bluetooth-sdk` | `import com.mentra.core.*` |
+| Android | `com.mentra:bluetooth-sdk` | `import com.mentra.bluetoothsdk.*` |
 | iOS | `MentraBluetoothSDK` CocoaPod | `import MentraBluetoothSDK` |
 | React Native / Expo | `@mentra/bluetooth-sdk` | `import BluetoothSdk from '@mentra/bluetooth-sdk'` |
 
@@ -56,12 +56,12 @@ const removeGlasses = BluetoothSdk.onGlassesStatus((changed) => {
   setGlassesStatus((current) => ({...current, ...changed}));
 });
 
-const removeCore = BluetoothSdk.onCoreStatus((status) => {
+const removeBluetooth = BluetoothSdk.onBluetoothStatus((status) => {
   console.log(status);
 });
 
 removeGlasses();
-removeCore();
+removeBluetooth();
 ```
 
 Keep one SDK instance per active app session. The SDK owns Bluetooth connection state, native event delivery, and cleanup. Your app owns user identity, UI state, and whether a default device record is persisted across app restarts.
@@ -174,7 +174,7 @@ React Native:
 
 ```ts
 const glasses = await BluetoothSdk.getGlassesStatus();
-const core = await BluetoothSdk.getCoreStatus();
+const bluetooth = await BluetoothSdk.getBluetoothStatus();
 ```
 
 Status snapshots are safe to read at any time. Treat command success as "command accepted"; keep UI state derived from status callbacks.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -179,12 +179,12 @@ iOS apps should include permission copy in `Info.plist`:
 
 ```kotlin
 import android.content.Context
-import com.mentra.core.Device
-import com.mentra.core.DeviceModel
-import com.mentra.core.DisplayTextRequest
-import com.mentra.core.GlassesStatusUpdate
-import com.mentra.core.MentraBluetoothSdk
-import com.mentra.core.MentraBluetoothSdkCallback
+import com.mentra.bluetoothsdk.Device
+import com.mentra.bluetoothsdk.DeviceModel
+import com.mentra.bluetoothsdk.DisplayTextRequest
+import com.mentra.bluetoothsdk.GlassesStatusUpdate
+import com.mentra.bluetoothsdk.MentraBluetoothSdk
+import com.mentra.bluetoothsdk.MentraBluetoothSdkCallback
 
 class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
     private val sdk = MentraBluetoothSdk.create(
@@ -274,11 +274,11 @@ import BluetoothSdk, {
 let glassesStatus: Partial<GlassesStatus> = createDisconnectedGlassesStatus();
 
 const firstDevice = new Promise<Device>((resolve) => {
-  let removeCore = () => {};
-  removeCore = BluetoothSdk.onCoreStatus((status) => {
+  let removeBluetooth = () => {};
+  removeBluetooth = BluetoothSdk.onBluetoothStatus((status) => {
     const device = status.searchResults?.[0];
     if (device) {
-      removeCore();
+      removeBluetooth();
       resolve(device);
     }
   });

--- a/docs/hardware-integration.md
+++ b/docs/hardware-integration.md
@@ -34,9 +34,10 @@ func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didDiscover device: Device) {
 React Native:
 
 ```ts
-const removeCore = BluetoothSdk.onCoreStatus((status) => {
+const removeBluetooth = BluetoothSdk.onBluetoothStatus((status) => {
   const device = status.searchResults?.[0];
   if (device) {
+    removeBluetooth();
     void BluetoothSdk.connect(device);
   }
 });

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -22,38 +22,38 @@ import android.provider.Settings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.mentra.core.BatteryStatusEvent
-import com.mentra.core.BluetoothError
-import com.mentra.core.MentraBluetoothSdk
-import com.mentra.core.MentraBluetoothSdkCallback
-import com.mentra.core.BluetoothStatus
-import com.mentra.core.BluetoothStatusUpdate
-import com.mentra.core.ButtonPressEvent
-import com.mentra.core.Device
-import com.mentra.core.DeviceModel
-import com.mentra.core.GalleryMode
-import com.mentra.core.GlassesConnectionState
-import com.mentra.core.GlassesStatus
-import com.mentra.core.GlassesStatusUpdate
-import com.mentra.core.HotspotErrorEvent
-import com.mentra.core.HotspotStatus
-import com.mentra.core.HotspotStatusEvent
-import com.mentra.core.MicConfig
-import com.mentra.core.PhotoCompression
-import com.mentra.core.PhotoRequest
-import com.mentra.core.PhotoResponse
-import com.mentra.core.PhotoSize
-import com.mentra.core.RgbLedAction
-import com.mentra.core.RgbLedColor
-import com.mentra.core.RgbLedRequest
-import com.mentra.core.StreamState
-import com.mentra.core.StreamKeepAliveRequest
-import com.mentra.core.StreamRequest
-import com.mentra.core.StreamStatus
-import com.mentra.core.TouchEvent
-import com.mentra.core.WifiScanResult
-import com.mentra.core.WifiStatus
-import com.mentra.core.WifiStatusEvent
+import com.mentra.bluetoothsdk.BatteryStatusEvent
+import com.mentra.bluetoothsdk.BluetoothError
+import com.mentra.bluetoothsdk.MentraBluetoothSdk
+import com.mentra.bluetoothsdk.MentraBluetoothSdkCallback
+import com.mentra.bluetoothsdk.BluetoothStatus
+import com.mentra.bluetoothsdk.BluetoothStatusUpdate
+import com.mentra.bluetoothsdk.ButtonPressEvent
+import com.mentra.bluetoothsdk.Device
+import com.mentra.bluetoothsdk.DeviceModel
+import com.mentra.bluetoothsdk.GalleryMode
+import com.mentra.bluetoothsdk.GlassesConnectionState
+import com.mentra.bluetoothsdk.GlassesStatus
+import com.mentra.bluetoothsdk.GlassesStatusUpdate
+import com.mentra.bluetoothsdk.HotspotErrorEvent
+import com.mentra.bluetoothsdk.HotspotStatus
+import com.mentra.bluetoothsdk.HotspotStatusEvent
+import com.mentra.bluetoothsdk.MicConfig
+import com.mentra.bluetoothsdk.PhotoCompression
+import com.mentra.bluetoothsdk.PhotoRequest
+import com.mentra.bluetoothsdk.PhotoResponse
+import com.mentra.bluetoothsdk.PhotoSize
+import com.mentra.bluetoothsdk.RgbLedAction
+import com.mentra.bluetoothsdk.RgbLedColor
+import com.mentra.bluetoothsdk.RgbLedRequest
+import com.mentra.bluetoothsdk.StreamState
+import com.mentra.bluetoothsdk.StreamKeepAliveRequest
+import com.mentra.bluetoothsdk.StreamRequest
+import com.mentra.bluetoothsdk.StreamStatus
+import com.mentra.bluetoothsdk.TouchEvent
+import com.mentra.bluetoothsdk.WifiScanResult
+import com.mentra.bluetoothsdk.WifiStatus
+import com.mentra.bluetoothsdk.WifiStatusEvent
 import com.mentra.examples.android.media.GStreamerWhipReceiver
 import com.mentra.examples.android.media.LocalPhotoUploadServer
 import com.mentra.examples.android.media.PhotoUpload
@@ -351,7 +351,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     fun displayHello() = runAction("Display Hello") {
         requireConnected("display text")
-        mentraBluetoothSdk.displayText(com.mentra.core.DisplayTextRequest("Hello from Mentra Bluetooth SDK"))
+        mentraBluetoothSdk.displayText(com.mentra.bluetoothsdk.DisplayTextRequest("Hello from Mentra Bluetooth SDK"))
     }
 
     fun clearDisplay() = runAction("Clear Display") {
@@ -1178,7 +1178,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("TX", "hotspot error ${event.message ?: summarize(event.values)}")
     }
 
-    override fun onPhotoResponse(event: com.mentra.core.PhotoResponseEvent) {
+    override fun onPhotoResponse(event: com.mentra.bluetoothsdk.PhotoResponseEvent) {
         val response = event.response
         val requestId = response.requestId
         if (activePhotoRequestId != null && requestId != activePhotoRequestId) {
@@ -1197,7 +1197,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("LIVE", "photo response $requestId")
     }
 
-    override fun onStreamStatus(event: com.mentra.core.StreamStatusEvent) {
+    override fun onStreamStatus(event: com.mentra.bluetoothsdk.StreamStatusEvent) {
         applyStreamStatus(event.status)
         val summary = summarize(event.values)
         val streamState = event.state

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.mentra.core.DeviceModel
-import com.mentra.core.GlassesStatus
+import com.mentra.bluetoothsdk.DeviceModel
+import com.mentra.bluetoothsdk.GlassesStatus
 import com.mentra.examples.android.MentraExampleController
 import com.mentra.examples.android.R
 import com.mentra.examples.android.batteryLabel

--- a/examples/react-native/src/sdkFormat.ts
+++ b/examples/react-native/src/sdkFormat.ts
@@ -1,4 +1,4 @@
-import type {CoreStatus, GlassesConnectionStatus, GlassesStatus, HotspotStatus, Device, WifiStatus} from '@mentra/bluetooth-sdk';
+import type {BluetoothStatus, GlassesConnectionStatus, GlassesStatus, HotspotStatus, Device, WifiStatus} from '@mentra/bluetooth-sdk';
 
 export function connectionLabel(status: Partial<GlassesStatus>) {
   const connection = connectionStatus(status);
@@ -216,7 +216,7 @@ function statusNumber(status: Partial<GlassesStatus>, key: string) {
   return typeof value === 'number' ? value : undefined;
 }
 
-export function bluetoothSearchLabel(status: Partial<CoreStatus>) {
+export function bluetoothSearchLabel(status: Partial<BluetoothStatus>) {
   const count = status.searchResults?.length ?? 0;
   return `${status.searching ? 'Scanning' : 'Idle'} · ${count} result${count === 1 ? '' : 's'}`;
 }

--- a/examples/react-native/src/useMentraSdk.ts
+++ b/examples/react-native/src/useMentraSdk.ts
@@ -7,7 +7,7 @@ import BluetoothSdk, {
   type BatteryStatusEvent,
   type ButtonPressEvent,
   type CompatibleGlassesSearchStopEvent,
-  type CoreStatus,
+  type BluetoothStatus,
   createDisconnectedGlassesStatus,
   type GlassesStatus,
   type HotspotStatus,
@@ -110,7 +110,7 @@ export type SdkConsoleEvent = {
 
 export type MentraSdkState = {
   activeAction: string | null;
-  bluetoothStatus: Partial<CoreStatus> & Record<string, unknown>;
+  bluetoothStatus: Partial<BluetoothStatus> & Record<string, unknown>;
   cameraStatus: string;
   defaultDevice: Device | null;
   discoveredDevices: Device[];
@@ -219,7 +219,7 @@ export function useMentraSdk(): MentraSdkModel {
     () => createDisconnectedGlassesStatus(),
   );
   const [bluetoothStatus, setBluetoothStatus] = useState<
-    Partial<CoreStatus> & Record<string, unknown>
+    Partial<BluetoothStatus> & Record<string, unknown>
   >({});
   const [defaultDevice, setDefaultDevice] = useState<Device | null>(
     null,
@@ -311,17 +311,17 @@ export function useMentraSdk(): MentraSdkModel {
   useEffect(() => {
     let cancelled = false;
 
-    void Promise.all([BluetoothSdk.getGlassesStatus(), BluetoothSdk.getCoreStatus()])
-      .then(([initialGlassesStatus, initialCoreStatus]) => {
+    void Promise.all([BluetoothSdk.getGlassesStatus(), BluetoothSdk.getBluetoothStatus()])
+      .then(([initialGlassesStatus, initialBluetoothStatus]) => {
         if (cancelled) {
           return;
         }
-        const coreStatus = initialCoreStatus as Partial<CoreStatus> & Record<string, unknown>;
+        const bluetoothStatus = initialBluetoothStatus as Partial<BluetoothStatus> & Record<string, unknown>;
         setGlassesStatus(initialGlassesStatus);
-        setBluetoothStatus(coreStatus);
+        setBluetoothStatus(bluetoothStatus);
         setHotspotEnabled(enabledHotspotStatus(initialGlassesStatus) !== null);
-        setGalleryModeAuto(galleryModeAutoFrom(coreStatus));
-        setDefaultDevice(defaultDeviceFromStatus(coreStatus));
+        setGalleryModeAuto(galleryModeAutoFrom(bluetoothStatus));
+        setDefaultDevice(defaultDeviceFromStatus(bluetoothStatus));
       })
       .catch((error) => {
         addEvent('TX', `initial SDK status load failed: ${formatError(error)}`);
@@ -406,7 +406,7 @@ export function useMentraSdk(): MentraSdkModel {
       addEvent('STORE', summarizeMap(changed));
     });
 
-    const removeBluetooth = BluetoothSdk.onCoreStatus((changed) => {
+    const removeBluetooth = BluetoothSdk.onBluetoothStatus((changed) => {
       setBluetoothStatus((current) => ({...current, ...changed}));
       if ('gallery_mode' in changed) {
         setGalleryModeAuto(galleryModeAutoFrom(changed));


### PR DESCRIPTION
## Summary

Updates the Partner Kit examples and docs to match the Bluetooth SDK naming cleanup in MentraOS.

The MentraOS SDK rename PR exposes Android symbols from `com.mentra.bluetoothsdk`, while the Maven coordinate remains `com.mentra:bluetooth-sdk`. It also renames the React Native adapter status surface from `CoreStatus` / `getCoreStatus` / `onCoreStatus` to `BluetoothStatus` / `getBluetoothStatus` / `onBluetoothStatus`. This PR updates the customer-facing Partner Kit code and docs to use those names.

Related MentraOS PR: https://github.com/Mentra-Community/MentraOS/pull/2688

## Changes

- Document Android package as `com.mentra.bluetoothsdk` in the API reference.
- Update the Android getting-started snippet to import `com.mentra.bluetoothsdk.*`.
- Update Android example app imports and fully-qualified SDK event/request references.
- Update the React Native example to use `BluetoothStatus`, `getBluetoothStatus`, and `onBluetoothStatus`.
- Remove stale "Core" wording from customer-facing API reference section headings.

## Validation

- Searched the Partner Kit for stale public rename symbols: `com.mentra.core`, `CoreStatus`, `getCoreStatus`, `onCoreStatus`, and `core_status`; no matches remain outside unrelated dependency names like `expo-modules-core`.
- Android package rename was locally verified against the current stacked SDK state with the Android package rename applied. Building against only MentraOS PR #2688 is expected not to compile yet because #2688 predates later SDK API additions used by the current example apps.
