### PR TITLE
Update React Native examples for VAD query and switch status

### DIFF
--- a/examples/react-native-elevenlabs-audio/README.md
+++ b/examples/react-native-elevenlabs-audio/README.md
@@ -28,7 +28,7 @@ If multiple Android devices are connected, set `ANDROID_SERIAL`.
 ## What It Sends
 
 - Glasses microphone PCM from `BluetoothSdk.addListener('mic_pcm', ...)`
-- `BluetoothSdk.setMicState(true, true)` for continuous Mentra Live glasses PCM
+- `BluetoothSdk.setVoiceActivityDetectionEnabled(false)` then `setMicState(true, true)` for continuous Mentra Live glasses PCM (disables hardware VAD gating on the glasses)
 - Base64 encoded `pcm_s16le`, 16 kHz, 16-bit, mono audio chunks
 - ElevenLabs WebSocket messages shaped as `{ "user_audio_chunk": "..." }`
 

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -110,7 +110,7 @@ The example has five tabs:
 - **Device**: scan for Mentra Live glasses, connect, disconnect, reconnect to the saved/default device, and inspect battery, firmware, Wi-Fi, RSSI, and discovered-device state.
 - **Camera**: request photo upload to the local demo cloud or directly to this phone, then preview the received JPEG. Direct phone photo is implemented in the companion local native module.
 - **Stream**: start RTMP, SRT, or WebRTC streams, send 15-second keep-alives, and preview HLS/WebRTC output. Android and iOS can receive WebRTC directly on the phone through the app-hosted GStreamer WHIP receiver.
-- **System**: scan/connect/forget Wi-Fi, toggle hotspot, change gallery mode, receive microphone PCM, and send RGB LED controls.
+- **System**: scan/connect/forget Wi-Fi, toggle hotspot, change gallery mode, receive microphone PCM, toggle glasses-side VAD (`setVoiceActivityDetectionEnabled`), and send RGB LED controls. Use the Console tab for `log` / `switch_status` feedback.
 - **Console**: watch button, touch, swipe, BLE, TX, STORE, hotspot, stream, photo, microphone, and SDK diagnostic events.
 
 ## Local Photo And Streaming Helper

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -14,8 +14,8 @@ import BluetoothSdk, {
   type MicPcmEvent,
   type PhotoResponseEvent,
   type RgbLedControlResponseEvent,
-  type SpeakingStatusEvent,
   type StreamStatusEvent,
+  type SpeakingStatusEvent,
   type TouchEvent,
   type VoiceActivityDetectionStatusEvent,
 } from '@mentra/bluetooth-sdk';
@@ -247,7 +247,9 @@ export function useBluetoothSdkExample(): BluetoothSdkExampleModel {
   const [pcmFrames, setPcmFrames] = useState(0);
   const [pcmBytes, setPcmBytes] = useState(0);
   const [speaking, setSpeaking] = useState<boolean | null>(null);
+  const voiceActivityDetectionEnabledRef = useRef(true);
   const [voiceActivityDetectionEnabled, setVoiceActivityDetectionEnabledState] = useState(true);
+  voiceActivityDetectionEnabledRef.current = voiceActivityDetectionEnabled;
   const [lastMicBytes, setLastMicBytes] = useState(0);
   const [lastMicDurationSeconds, setLastMicDurationSeconds] = useState<number | null>(null);
   const [micPlaybackHint, setMicPlaybackHint] = useState<string | null>(null);
@@ -333,15 +335,28 @@ export function useBluetoothSdkExample(): BluetoothSdkExampleModel {
           `${gesture.toLowerCase().includes('swipe') ? 'swipe' : 'touch'} ${gesture}`,
         );
       }),
-      BluetoothSdk.addListener('voice_activity_detection_status', (payload: VoiceActivityDetectionStatusEvent) => {
-        setVoiceActivityDetectionEnabledState(payload.voiceActivityDetectionEnabled);
-        if (!payload.voiceActivityDetectionEnabled) {
-          setSpeaking(null);
-        }
-        addEvent('LIVE', `voice activity detection ${payload.voiceActivityDetectionEnabled ? 'enabled' : 'disabled'}`);
-      }),
       BluetoothSdk.addListener('speaking_status', (payload: SpeakingStatusEvent) => {
+        if (!voiceActivityDetectionEnabledRef.current) {
+          return;
+        }
         setSpeaking(payload.speaking);
+        addEvent('LIVE', `speech ${payload.speaking ? 'detected' : 'idle'}`);
+      }),
+      BluetoothSdk.addListener(
+        'voice_activity_detection_status',
+        (payload: VoiceActivityDetectionStatusEvent) => {
+          setVoiceActivityDetectionEnabledState(payload.voiceActivityDetectionEnabled);
+          addEvent(
+            'LIVE',
+            `VAD ${payload.voiceActivityDetectionEnabled ? 'enabled (gated LC3)' : 'disabled (continuous)'}`,
+          );
+        },
+      ),
+      BluetoothSdk.addListener('switch_status', (payload) => {
+        addEvent('LIVE', `switch_status type=${payload.switchType} value=${payload.switchValue}`);
+        if (payload.switchType === 8 && (payload.switchValue === 0 || payload.switchValue === 1)) {
+          setVoiceActivityDetectionEnabledState(payload.switchValue === 1);
+        }
       }),
       BluetoothSdk.addListener('battery_status', (payload) => {
         addEvent('STORE', `battery ${payload.level}%${payload.charging ? ' charging' : ''}`);
@@ -1169,11 +1184,19 @@ export function useBluetoothSdkExample(): BluetoothSdkExampleModel {
   }
 
   async function setVoiceActivityDetectionEnabledAction(enabled: boolean) {
-    await runAction(enabled ? 'Enable voice activity detection' : 'Disable voice activity detection', async () => {
-      requireConnected('change voice activity detection');
-      setVoiceActivityDetectionEnabledState(enabled);
-      await BluetoothSdk.setVoiceActivityDetectionEnabled(enabled);
-    });
+    await runAction(
+      enabled ? 'Enable voice activity detection' : 'Disable voice activity detection',
+      async () => {
+        requireConnected('change voice activity detection');
+        setVoiceActivityDetectionEnabledState(enabled);
+        if (!enabled) {
+          setSpeaking(null);
+        }
+        await BluetoothSdk.setVoiceActivityDetectionEnabled(enabled);
+        addEvent('TX', `cs_swit VAD ${enabled ? 'on' : 'off'}`);
+        await BluetoothSdk.queryVoiceActivityDetectionEnabled();
+      },
+    );
   }
 
   async function openBluetoothSettings() {


### PR DESCRIPTION
## Summary

- Sync the React Native example with `queryVoiceActivityDetectionEnabled` and `switch_status` (VAD switch type 8) after toggling glasses-side VAD.
- Gate `speaking_status` UI updates when VAD is disabled and improve Console/LIVE event messaging.
- Document continuous PCM setup in the ElevenLabs example README via `setVoiceActivityDetectionEnabled(false)` before `setMicState`.

## Test plan

- [ ] Run `examples/react-native` against a Mentra Live device with a local SDK build that includes `queryVoiceActivityDetectionEnabled`
- [ ] Toggle VAD on the System tab and confirm Console shows VAD/switch_status events and speaking indicator behavior
- [ ] Verify ElevenLabs example README steps match expected continuous PCM flow


Made with [Cursor](https://cursor.com)