### PR TITLE
Update React Native example for photo IMU metadata

### DIFF
--- a/examples/react-native/modules/mentra-barcode-scanner/android/src/main/java/com/mentra/barcodescanner/MentraBarcodeScannerModule.kt
+++ b/examples/react-native/modules/mentra-barcode-scanner/android/src/main/java/com/mentra/barcodescanner/MentraBarcodeScannerModule.kt
@@ -23,6 +23,8 @@ import java.net.HttpURLConnection
 import java.net.URL
 import kotlin.math.atan
 import kotlin.math.sqrt
+import org.json.JSONArray
+import org.json.JSONObject
 
 class MentraBarcodeScannerModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -103,7 +105,78 @@ class MentraBarcodeScannerModule : Module() {
       put("height", height)
       put("focalLength35mm", focalLength35mm)
       put("estimatedFov", estimatedFov(width, height, focalLength35mm))
+      put("imuMetadata", imuMetadata(exif))
     }
+  }
+
+  private fun imuMetadata(exif: ExifInterface?): Map<String, Any?>? {
+    val json = userCommentJson(exif?.getAttribute(ExifInterface.TAG_USER_COMMENT)) ?: return null
+    return runCatching {
+      val payload = JSONObject(json)
+      val samples = payload.optJSONArray("samples")
+      buildMap {
+        put("version", positiveInt(payload.optInt("version", 0)))
+        put("sampleCount", positiveInt(payload.optInt("sampleCount", 0)))
+        put("samplingRateHz", positiveInt(payload.optInt("samplingRateHz", 0)))
+        put("durationMs", nonNegativeDouble(payload.opt("durationMs")))
+        put("clockSource", payload.optString("clockSource").takeIf { it.isNotBlank() })
+        put("startTimeNs", longString(payload, "startTimeNs"))
+        put("recordingStartElapsedRealtimeNs", longString(payload, "recordingStartElapsedRealtimeNs"))
+        put("videoStartElapsedRealtimeNs", longString(payload, "videoStartElapsedRealtimeNs"))
+        put("exifTruncated", payload.opt("exifTruncated") as? Boolean)
+        put("firstSample", sampleSummary(samples?.optJSONArray(0)))
+        put("lastSample", sampleSummary(samples?.optJSONArray((samples.length() - 1).coerceAtLeast(0))))
+      }
+    }.getOrNull()
+  }
+
+  private fun userCommentJson(userComment: String?): String? {
+    val trimmed = userComment?.trim().orEmpty()
+    val start = trimmed.indexOf('{')
+    val end = trimmed.lastIndexOf('}')
+    if (start < 0 || end <= start) {
+      return null
+    }
+    return trimmed.substring(start, end + 1)
+  }
+
+  private fun sampleSummary(sample: JSONArray?): Map<String, Any?>? {
+    if (sample == null || sample.length() < 7) {
+      return null
+    }
+    return mapOf(
+      "relativeTimeMs" to nonNegativeDouble(sample.opt(0)),
+      "accel" to vector(sample, 1),
+      "gyro" to vector(sample, 4),
+    )
+  }
+
+  private fun vector(sample: JSONArray, offset: Int): List<Double>? {
+    if (sample.length() < offset + 3) {
+      return null
+    }
+    return listOf(sample.optDouble(offset), sample.optDouble(offset + 1), sample.optDouble(offset + 2))
+  }
+
+  private fun longString(payload: JSONObject, key: String): String? {
+    if (!payload.has(key)) {
+      return null
+    }
+    val value = payload.opt(key) ?: return null
+    return when (value) {
+      is Number -> value.toLong().toString()
+      is String -> value.takeIf { it.isNotBlank() }
+      else -> null
+    }
+  }
+
+  private fun nonNegativeDouble(value: Any?): Double? {
+    val number = when (value) {
+      is Number -> value.toDouble()
+      is String -> value.toDoubleOrNull()
+      else -> null
+    } ?: return null
+    return number.takeIf { it.isFinite() && it >= 0 }
   }
 
   private fun openImage(imageUri: String) {

--- a/examples/react-native/modules/mentra-barcode-scanner/ios/MentraBarcodeScannerModule.swift
+++ b/examples/react-native/modules/mentra-barcode-scanner/ios/MentraBarcodeScannerModule.swift
@@ -90,7 +90,125 @@ public class MentraBarcodeScannerModule: Module {
       "height": height,
       "focalLength35mm": focalLength35mm,
       "estimatedFov": estimatedFov(width: width, height: height, focalLength35mm: focalLength35mm),
+      "imuMetadata": imuMetadata(from: exif),
     ]
+  }
+
+  private func imuMetadata(from exif: [String: Any]?) -> [String: Any?]? {
+    guard
+      let json = userCommentJson(exif?[kCGImagePropertyExifUserComment as String]),
+      let data = json.data(using: .utf8),
+      let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return nil
+    }
+
+    let samples = payload["samples"] as? [Any]
+    return [
+      "version": positiveIntValue(payload["version"]),
+      "sampleCount": positiveIntValue(payload["sampleCount"]),
+      "samplingRateHz": positiveIntValue(payload["samplingRateHz"]),
+      "durationMs": nonNegativeDouble(payload["durationMs"]),
+      "clockSource": nonEmptyString(payload["clockSource"]),
+      "startTimeNs": stringValue(payload["startTimeNs"]),
+      "recordingStartElapsedRealtimeNs": stringValue(payload["recordingStartElapsedRealtimeNs"]),
+      "videoStartElapsedRealtimeNs": stringValue(payload["videoStartElapsedRealtimeNs"]),
+      "exifTruncated": boolValue(payload["exifTruncated"]),
+      "firstSample": sampleSummary(samples?.first),
+      "lastSample": sampleSummary(samples?.last),
+    ]
+  }
+
+  private func userCommentJson(_ value: Any?) -> String? {
+    let raw: String?
+    if let string = value as? String {
+      raw = string
+    } else if let data = value as? Data {
+      raw = String(data: data, encoding: .utf8)
+    } else if let nsData = value as? NSData {
+      raw = String(data: nsData as Data, encoding: .utf8)
+    } else {
+      raw = nil
+    }
+    guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+          let start = trimmed.firstIndex(of: "{"),
+          let end = trimmed.lastIndex(of: "}"),
+          start < end else {
+      return nil
+    }
+    return String(trimmed[start...end])
+  }
+
+  private func sampleSummary(_ sample: Any?) -> [String: Any?]? {
+    guard let values = sample as? [Any], values.count >= 7 else {
+      return nil
+    }
+    return [
+      "relativeTimeMs": nonNegativeDouble(values[0]),
+      "accel": vector(values, offset: 1),
+      "gyro": vector(values, offset: 4),
+    ]
+  }
+
+  private func vector(_ values: [Any], offset: Int) -> [Double]? {
+    guard values.count >= offset + 3,
+          let x = doubleValue(values[offset]),
+          let y = doubleValue(values[offset + 1]),
+          let z = doubleValue(values[offset + 2]) else {
+      return nil
+    }
+    return [x, y, z]
+  }
+
+  private func positiveIntValue(_ value: Any?) -> Int? {
+    guard let number = doubleValue(value), number > 0 else {
+      return nil
+    }
+    return Int(number)
+  }
+
+  private func nonNegativeDouble(_ value: Any?) -> Double? {
+    guard let number = doubleValue(value), number >= 0 else {
+      return nil
+    }
+    return number
+  }
+
+  private func doubleValue(_ value: Any?) -> Double? {
+    if let number = value as? NSNumber {
+      return number.doubleValue
+    }
+    if let string = value as? String {
+      return Double(string)
+    }
+    return nil
+  }
+
+  private func stringValue(_ value: Any?) -> String? {
+    if let number = value as? NSNumber {
+      return number.stringValue
+    }
+    if let string = value as? String {
+      return string.isEmpty ? nil : string
+    }
+    return nil
+  }
+
+  private func boolValue(_ value: Any?) -> Bool? {
+    if let bool = value as? Bool {
+      return bool
+    }
+    if let number = value as? NSNumber {
+      return number.boolValue
+    }
+    return nil
+  }
+
+  private func nonEmptyString(_ value: Any?) -> String? {
+    guard let string = value as? String, !string.isEmpty else {
+      return nil
+    }
+    return string
   }
 
   private func openImage(imageUri: String) throws {

--- a/examples/react-native/modules/mentra-barcode-scanner/src/MentraBarcodeScanner.types.ts
+++ b/examples/react-native/modules/mentra-barcode-scanner/src/MentraBarcodeScanner.types.ts
@@ -28,10 +28,31 @@ export type ImageFovEstimate = {
   verticalDegrees: number;
 };
 
+export type ImageImuSample = {
+  accel?: [number, number, number] | null;
+  gyro?: [number, number, number] | null;
+  relativeTimeMs?: number | null;
+};
+
+export type ImageImuMetadata = {
+  clockSource?: string | null;
+  durationMs?: number | null;
+  exifTruncated?: boolean | null;
+  firstSample?: ImageImuSample | null;
+  lastSample?: ImageImuSample | null;
+  recordingStartElapsedRealtimeNs?: string | null;
+  sampleCount?: number | null;
+  samplingRateHz?: number | null;
+  startTimeNs?: string | null;
+  version?: number | null;
+  videoStartElapsedRealtimeNs?: string | null;
+};
+
 export type ImageMetadata = {
   estimatedFov?: ImageFovEstimate | null;
   focalLength35mm?: number | null;
   height?: number | null;
+  imuMetadata?: ImageImuMetadata | null;
   width?: number | null;
 };
 

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -1522,6 +1522,7 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
   if (details.width && details.height) rows.push({label: 'Dimensions', value: `${details.width} x ${details.height}`});
   if (details.estimatedFov) rows.push({label: 'Estimated FOV', value: formatFovEstimate(details.estimatedFov)});
   else if (details.focalLength35mm) rows.push({label: 'Focal length', value: `${details.focalLength35mm}mm equiv.`});
+  addImuMetadataRows(rows, details.imuMetadata);
   addActualCaptureRows(rows, details.captureMetadata);
   addRequestedCaptureRows(rows, details.requestedCaptureConfig);
   addMeteredPreviewRows(rows, details.meteredPreview);
@@ -1621,6 +1622,38 @@ function addResolvedConfigRows(rows: DetailRow[], config: PhotoPreviewDetails['r
   if (config.iso != null) rows.push({label: 'Resolved ISO', value: String(config.iso)});
 }
 
+function addImuMetadataRows(rows: DetailRow[], metadata: PhotoPreviewDetails['imuMetadata']) {
+  if (!metadata) {
+    return;
+  }
+  if (metadata.sampleCount != null) rows.push({label: 'IMU samples', value: String(metadata.sampleCount)});
+  if (metadata.samplingRateHz != null) rows.push({label: 'IMU rate', value: `${metadata.samplingRateHz} Hz`});
+  if (metadata.durationMs != null) rows.push({label: 'IMU duration', value: `${Math.round(metadata.durationMs)} ms`});
+  if (metadata.exifTruncated) {
+    rows.push({label: 'IMU EXIF', value: 'truncated preview; full sidecar remains on glasses'});
+  }
+  if (metadata.clockSource) rows.push({label: 'IMU clock', value: metadata.clockSource});
+  if (metadata.recordingStartElapsedRealtimeNs) {
+    rows.push({label: 'IMU recording start', value: `${metadata.recordingStartElapsedRealtimeNs} ns`});
+  }
+  if (metadata.startTimeNs) rows.push({label: 'IMU first sample', value: `${metadata.startTimeNs} ns`});
+  addImuSampleRows(rows, 'First IMU', metadata.firstSample);
+  addImuSampleRows(rows, 'Last IMU', metadata.lastSample);
+}
+
+function addImuSampleRows(
+  rows: DetailRow[],
+  prefix: string,
+  sample: NonNullable<PhotoPreviewDetails['imuMetadata']>['firstSample'],
+) {
+  if (!sample) {
+    return;
+  }
+  if (sample.relativeTimeMs != null) rows.push({label: `${prefix} t`, value: `${Math.round(sample.relativeTimeMs)} ms`});
+  if (sample.accel) rows.push({label: `${prefix} accel`, value: formatVector(sample.accel)});
+  if (sample.gyro) rows.push({label: `${prefix} gyro`, value: formatVector(sample.gyro)});
+}
+
 function addRequestedCaptureRows(rows: DetailRow[], config: PhotoPreviewDetails['requestedCaptureConfig']) {
   if (!config) {
     return;
@@ -1699,6 +1732,10 @@ function formatFovEstimate(fov: NonNullable<PhotoPreviewDetails['estimatedFov']>
     `${Math.round(fov.verticalDegrees)}° V`,
     `${fov.focalLength35mm}mm equiv.`,
   ].join(' · ');
+}
+
+function formatVector(values: readonly number[]) {
+  return values.map((value) => formatDecimal(value)).join(', ');
 }
 
 function boolLabel(value: boolean) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -40,6 +40,7 @@ import {
 import MentraBarcodeScanner, {
   type BarcodeScanResult,
   type ImageFovEstimate,
+  type ImageImuMetadata,
 } from '@mentra/react-native-barcode-scanner';
 import MentraPhotoReceiver, {
   type PhotoReceiverResult,
@@ -168,6 +169,7 @@ export type PhotoPreviewDetails = {
   estimatedFov?: ImageFovEstimate | null;
   focalLength35mm?: number | null;
   height?: number;
+  imuMetadata?: ImageImuMetadata | null;
   previewUrl?: string;
   requestId?: string | null;
   resolvedConfig?: PhotoStatusEvent['resolvedConfig'];
@@ -1969,6 +1971,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
               estimatedFov: metadata.estimatedFov,
               focalLength35mm: metadata.focalLength35mm,
               height: metadata.height ?? current.height,
+              imuMetadata: metadata.imuMetadata ?? current.imuMetadata,
               width: metadata.width ?? current.width,
             }
           : current,


### PR DESCRIPTION
## Summary
- stack this PR on #11 so OTA/SDK-version migration stays separate
- remove the old `includeImu` / `photo_imu` event approach
- read photo IMU JSON from the returned image EXIF `UserComment` in the React Native metadata helper
- surface IMU sample count, rate, duration, clock anchors, truncation, and first/last accel/gyro rows in the camera details panel

## Test plan
- [x] `git diff --check --cached`
- [x] `cd examples/react-native/android && ./gradlew :app:compileDebugKotlin`
- [ ] `bunx tsc --noEmit -p examples/react-native/tsconfig.json` currently fails on inherited request-photo `PhotoSize` API mismatch (`small`/`large`/`full` vs SDK `low`/`high`/`max`), intentionally left for a separate PR
- [ ] `cd examples/react-native/ios && xcodebuild -workspace MentraSDKRN.xcworkspace -scheme MentraSDKRN -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO -quiet build` reaches the SDK pod and fails in published SDK 0.1.13 (`BluetoothSdkAnalyticsConfiguration` not found), unrelated to this example IMU bridge change

## Notes
The latest SDK no longer exposes `includeImu` or a `photo_imu` event. The glasses already embed the IMU capture payload into the photo EXIF, so this example now demonstrates the current path: request a normal photo, load the preview, then inspect the photo artifact metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app and local metadata parsing only; no auth, SDK protocol, or production service changes.
> 
> **Overview**
> The React Native example now surfaces **photo IMU data from the JPEG EXIF `UserComment`** instead of relying on SDK `includeImu` / `photo_imu` events (per the updated glasses flow).
> 
> **`MentraBarcodeScanner.getImageMetadata`** on Android and iOS parses embedded JSON from `UserComment`, normalizes it into **`imuMetadata`** (sample count, rate, duration, clock anchors, truncation flag, first/last accel/gyro summaries), and exposes matching **`ImageImuMetadata`** types in TypeScript.
> 
> After a preview loads, **`updatePhotoPreviewMetadata`** merges that field into **`PhotoPreviewDetails`**, and the camera **Photo details** panel shows IMU rows (including a note when EXIF was truncated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa7acb4b3f40115530417534e322c59bb55f57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->