### PR TITLE
Add Starter Kit OTA update prompts

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,14 +68,14 @@ Add the public Swift package in Xcode or `Package.swift`:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.12` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Use version `0.1.13` or newer, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.12"
+  from: "0.1.13"
 )
 ```
 
@@ -173,7 +173,7 @@ cd examples/react-native
 unset MENTRA_BLUETOOTH_SDK_PACKAGE_PATH
 rm -rf node_modules/@mentra/bluetooth-sdk
 
-bun add @mentra/bluetooth-sdk@0.1.12
+bun add @mentra/bluetooth-sdk@0.1.13
 bun install
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.12` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.13` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.12
+mentraSdkVersion=0.1.13
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -32,7 +32,6 @@ import com.mentra.bluetoothsdk.MicLc3Event
 import com.mentra.bluetoothsdk.MicPcmEvent
 import com.mentra.bluetoothsdk.OtaQueryResult
 import com.mentra.bluetoothsdk.OtaStatusEvent
-import com.mentra.bluetoothsdk.OtaUpdateAvailableEvent
 import com.mentra.bluetoothsdk.ButtonPressEvent
 import com.mentra.bluetoothsdk.CameraFov
 import com.mentra.bluetoothsdk.CameraFovResult
@@ -224,7 +223,7 @@ data class MentraExampleState(
     val micRecording: Boolean = false,
     val otaStatus: OtaStatusEvent? = null,
     val otaStatusMessage: String? = null,
-    val otaUpdateAvailable: OtaUpdateAvailableEvent? = null,
+    val otaUpdateAvailable: Boolean = false,
     val pcmBytes: Int = 0,
     val pcmFrames: Int = 0,
     val speaking: Boolean? = null,
@@ -318,6 +317,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var actionSequence = 0L
     private val activeActions = linkedMapOf<Long, String>()
     private var streamConfigurationChangeInProgress = false
+    private var autoOtaCheckedConnectionKey: String? = null
+    private var autoOtaCheckInProgress = false
 
     private val micSampleRate = 16_000
     private val micChannelCount = 1
@@ -1630,6 +1631,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 pushScanButtonPreset(state.scanAeDivisor, state.scanIsoCap)
             }
         }
+        maybeAutoCheckOta()
         addEvent("STORE", summarize(glasses))
     }
 
@@ -1690,6 +1692,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             is WifiStatus.Connected -> status.ssid
             WifiStatus.Disconnected -> "disconnected"
         }
+        maybeAutoCheckOta()
         addEvent("STORE", "Wi-Fi $label")
     }
 
@@ -1895,23 +1898,15 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         applyOtaStatus(event)
     }
 
-    private fun handleOtaQueryResult(result: OtaQueryResult) {
+    private fun handleOtaQueryResult(result: OtaQueryResult): Boolean {
         if (result.type == "ota_update_available") {
-            val event = OtaUpdateAvailableEvent(
-                versionCode = result.values.longValue("version_code"),
-                versionName = result.values.stringValue("version_name"),
-                updates = (result.values["updates"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
-                totalSize = result.values.longValue("total_size"),
-                cacheReady = result.values["cache_ready"] as? Boolean,
-                values = result.values,
-            )
             state = state.copy(
                 otaStatus = null,
                 otaStatusMessage = null,
-                otaUpdateAvailable = event,
+                otaUpdateAvailable = true,
             )
-            addEvent("LIVE", "OTA available ${event.versionName ?: "unknown"} (${event.updates.joinToString().ifBlank { "update" }})")
-            return
+            addEvent("LIVE", "OTA update available")
+            return true
         }
 
         val event = OtaStatusEvent(
@@ -1928,6 +1923,11 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             values = result.values,
         )
         applyOtaStatus(event)
+        if (!isDisplayableOtaStatus(event)) {
+            state = state.copy(otaStatusMessage = "Glasses firmware is up to date")
+            addEvent("LIVE", "OTA up to date")
+        }
+        return false
     }
 
     override fun onMicPcm(event: MicPcmEvent) {
@@ -1978,6 +1978,34 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         requireConnected("check OTA")
         requireGlassesWifi("check for OTA updates")
         handleOtaQueryResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+    }
+
+    private fun maybeAutoCheckOta() {
+        val glasses = state.glassesStatus
+        if (!isGlassesConnected(glasses)) {
+            autoOtaCheckedConnectionKey = null
+            autoOtaCheckInProgress = false
+            return
+        }
+        if (!isGlassesWifiConnected(glasses) || autoOtaCheckInProgress || isOtaInProgress()) {
+            return
+        }
+        val connectionKey = otaConnectionKey(glasses)
+        if (autoOtaCheckedConnectionKey == connectionKey) {
+            return
+        }
+
+        autoOtaCheckedConnectionKey = connectionKey
+        autoOtaCheckInProgress = true
+        runAction("Auto-check OTA") {
+            try {
+                requireConnected("check OTA")
+                requireGlassesWifi("check for OTA updates")
+                handleOtaQueryResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+            } finally {
+                autoOtaCheckInProgress = false
+            }
+        }
     }
 
     fun startOtaUpdate() = runAction("Start OTA") {
@@ -2278,6 +2306,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     private fun isGlassesConnected(): Boolean = isGlassesConnected(state.glassesStatus)
 
+    private fun isOtaInProgress(): Boolean =
+        state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
+
     private fun requireGlassesWifi(feature: String) {
         if (isGlassesWifiConnected(state.glassesStatus)) {
             return
@@ -2388,7 +2419,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             hotspotEnabled = false,
             otaStatus = null,
             otaStatusMessage = null,
-            otaUpdateAvailable = null,
+            otaUpdateAvailable = false,
             micRecording = false,
             phoneAudioRoute = currentAudioOutputRouteLabel(),
             phonePhotoServerRunning = false,
@@ -2427,9 +2458,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         state = state.copy(
             otaStatus = event,
             otaStatusMessage = null,
-            otaUpdateAvailable = state.otaUpdateAvailable.takeUnless {
-                event.status == "complete" || event.status == "failed"
-            },
+            otaUpdateAvailable = if (event.status == "complete" || event.status == "failed") false else state.otaUpdateAvailable,
         )
         addEvent("LIVE", "OTA ${event.status.ifBlank { "status" }} ${event.overallPercent}%")
     }
@@ -3302,6 +3331,13 @@ val GlassesRuntimeState.wifi: WifiStatus?
 
 fun connectedGlassesInfo(status: GlassesRuntimeState?) =
     (status as? GlassesRuntimeState.Connected)?.device
+
+fun otaConnectionKey(status: GlassesRuntimeState?): String =
+    listOfNotNull(
+        connectedGlassesInfo(status)?.bluetoothName,
+        connectedGlassesInfo(status)?.serialNumber,
+        connectedGlassesInfo(status)?.deviceModel?.deviceType,
+    ).joinToString("|").ifBlank { "connected" }
 
 fun deviceLabel(status: GlassesRuntimeState?): String =
     connectedGlassesInfo(status)?.bluetoothName

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -65,6 +65,7 @@ import com.mentra.bluetoothsdk.TouchEvent
 import com.mentra.bluetoothsdk.MediaUploadEvent
 import com.mentra.bluetoothsdk.VideoRecordingRequest
 import com.mentra.bluetoothsdk.VideoRecordingStatusEvent
+import com.mentra.bluetoothsdk.VersionInfoResult
 import com.mentra.bluetoothsdk.VoiceActivityDetectionStatusEvent
 import com.mentra.bluetoothsdk.WifiScanResult
 import com.mentra.bluetoothsdk.WifiStatus
@@ -318,6 +319,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var streamConfigurationChangeInProgress = false
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
+    private var latestOtaVersionInfoSignature: String? = null
 
     private val micSampleRate = 16_000
     private val micChannelCount = 1
@@ -1897,6 +1899,11 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         applyOtaStatus(event)
     }
 
+    override fun onVersionInfo(event: VersionInfoResult) {
+        latestOtaVersionInfoSignature = event.otaVersionInfoSignature()
+        maybeAutoCheckOta()
+    }
+
     private fun handleOtaCheckResult(updateAvailable: Boolean): Boolean {
         if (updateAvailable) {
             state = state.copy(
@@ -1972,17 +1979,18 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected(glasses)) {
             autoOtaCheckedConnectionKey = null
             autoOtaCheckInProgress = false
+            latestOtaVersionInfoSignature = null
             return
         }
         if (!isGlassesWifiConnected(glasses) || autoOtaCheckInProgress || isOtaInProgress()) {
             return
         }
-        val connectionKey = otaConnectionKey(glasses)
-        if (autoOtaCheckedConnectionKey == connectionKey) {
+        val autoCheckKey = otaAutoCheckKey(glasses, latestOtaVersionInfoSignature)
+        if (autoOtaCheckedConnectionKey == autoCheckKey) {
             return
         }
 
-        autoOtaCheckedConnectionKey = connectionKey
+        autoOtaCheckedConnectionKey = autoCheckKey
         autoOtaCheckInProgress = true
         runAction("Auto-check OTA") {
             try {
@@ -3325,6 +3333,35 @@ fun otaConnectionKey(status: GlassesRuntimeState?): String =
         connectedGlassesInfo(status)?.serialNumber,
         connectedGlassesInfo(status)?.deviceModel?.deviceType,
     ).joinToString("|").ifBlank { "connected" }
+
+fun otaAutoCheckKey(status: GlassesRuntimeState?, versionInfoSignature: String? = null): String =
+    listOf(
+        otaConnectionKey(status),
+        versionInfoSignature ?: status.otaVersionSignature(),
+    ).joinToString("|")
+
+fun GlassesRuntimeState?.otaVersionSignature(): String =
+    if (!isGlassesConnected(this)) {
+        "disconnected"
+    } else {
+        listOfNotNull(
+            connectedGlassesInfo(this)?.buildNumber,
+            this?.firmware?.buildNumber,
+            connectedGlassesInfo(this)?.appVersion,
+            this?.firmware?.appVersion,
+            this?.firmware?.source?.name,
+            this?.firmware?.version,
+        ).joinToString("|").ifBlank { "version-unknown" }
+    }
+
+fun VersionInfoResult.otaVersionInfoSignature(): String =
+    listOf(
+        buildNumber,
+        appVersion,
+        mtkFirmwareVersion,
+        besFirmwareVersion,
+        firmwareVersion,
+    ).filter { it.isNotBlank() }.joinToString("|").ifBlank { "version-unknown" }
 
 fun deviceLabel(status: GlassesRuntimeState?): String =
     connectedGlassesInfo(status)?.bluetoothName

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -30,7 +30,6 @@ import com.mentra.bluetoothsdk.MentraBluetoothSdk
 import com.mentra.bluetoothsdk.MentraBluetoothSdkCallback
 import com.mentra.bluetoothsdk.MicLc3Event
 import com.mentra.bluetoothsdk.MicPcmEvent
-import com.mentra.bluetoothsdk.OtaQueryResult
 import com.mentra.bluetoothsdk.OtaStatusEvent
 import com.mentra.bluetoothsdk.ButtonPressEvent
 import com.mentra.bluetoothsdk.CameraFov
@@ -1898,8 +1897,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         applyOtaStatus(event)
     }
 
-    private fun handleOtaQueryResult(result: OtaQueryResult): Boolean {
-        if (result.type == "ota_update_available") {
+    private fun handleOtaCheckResult(updateAvailable: Boolean): Boolean {
+        if (updateAvailable) {
             state = state.copy(
                 otaStatus = null,
                 otaStatusMessage = null,
@@ -1909,24 +1908,12 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             return true
         }
 
-        val event = OtaStatusEvent(
-            sessionId = result.values.stringValue("session_id").orEmpty(),
-            totalSteps = result.values.intValue("total_steps") ?: 0,
-            currentStep = result.values.intValue("current_step") ?: 0,
-            stepType = result.values.stringValue("step_type").orEmpty(),
-            phase = result.values.stringValue("phase").orEmpty(),
-            stepPercent = result.values.intValue("step_percent") ?: 0,
-            overallPercent = result.values.intValue("overall_percent") ?: 0,
-            status = result.values.stringValue("status").orEmpty(),
-            errorMessage = result.values.stringValue("error_message"),
-            glassesTimeMs = result.values.longValue("glasses_time_ms"),
-            values = result.values,
+        state = state.copy(
+            otaStatus = null,
+            otaStatusMessage = "Glasses firmware is up to date",
+            otaUpdateAvailable = false,
         )
-        applyOtaStatus(event)
-        if (!isDisplayableOtaStatus(event)) {
-            state = state.copy(otaStatusMessage = "Glasses firmware is up to date")
-            addEvent("LIVE", "OTA up to date")
-        }
+        addEvent("LIVE", "OTA up to date")
         return false
     }
 
@@ -1977,7 +1964,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     fun checkForOtaUpdate() = runAction("Check OTA") {
         requireConnected("check OTA")
         requireGlassesWifi("check for OTA updates")
-        handleOtaQueryResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+        handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
     }
 
     private fun maybeAutoCheckOta() {
@@ -2001,7 +1988,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             try {
                 requireConnected("check OTA")
                 requireGlassesWifi("check for OTA updates")
-                handleOtaQueryResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+                handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
             } finally {
                 autoOtaCheckInProgress = false
             }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -526,9 +526,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
         runAction(if (enabled) "Apply scan preset on glasses" else "Restore photo preset on glasses") {
             requireConnected("sync photo capture settings")
-            // SDK 0.1.12 `ButtonPhotoSettings` only carries `size`. The granular scan tuning
-            // (mfnr/zsl/aeExposureDivisor/isoCap/edge/NR/ISP gains/resetCaptureTuning) ships in
-            // 0.1.13; bump the Maven pin and restore the full preset once published.
+            // Keep hardware-button captures at max detail while scan mode is enabled.
             val settings =
                 if (enabled) {
                     ButtonPhotoSettings(size = ButtonPhotoSize.MAX)
@@ -559,9 +557,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected()) {
             return
         }
-        // SDK 0.1.12 `ButtonPhotoSettings` cannot carry aeExposureDivisor/isoCap; the divisor and
-        // ISO-cap chips only drive on-device UI state until the 0.1.13 preset ships. Re-assert the
-        // max-size scan button preset so the hardware button stays in sync.
+        // Re-assert the max-size scan button preset so the hardware button stays in sync.
         runAction("Apply scan preset on glasses") {
             requireConnected("sync photo capture settings")
             withContext(Dispatchers.IO) {
@@ -716,13 +712,12 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     private fun buildPhotoRequest(requestId: String, appId: String, webhookUrl: String): PhotoRequest {
         if (state.scanMode) {
-            // SDK 0.1.12 `PhotoRequest` cannot carry per-capture scan fields (aeExposureDivisor/
-            // isoCap/mfnr/...); those ship in 0.1.13. The scan preset still reaches the glasses via
-            // the `ButtonPhotoSettings` sync above (Maven 0.1.12 supports it). Capture at max detail.
+            // Hardware-button scan settings are synced separately.
+            // App-triggered captures use max detail to match the scan preset's output tier.
             return PhotoRequest(
                 requestId = requestId,
                 appId = appId,
-                size = PhotoSize.FULL,
+                size = PhotoSize.MAX,
                 webhookUrl = webhookUrl,
                 compress = PhotoCompression.NONE,
                 sound = false,
@@ -1905,6 +1900,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     private fun handleOtaCheckResult(updateAvailable: Boolean): Boolean {
+        if (isOtaInProgress()) {
+            addEvent("LIVE", "OTA check result ignored while update is in progress")
+            return updateAvailable
+        }
         if (updateAvailable) {
             state = state.copy(
                 otaStatus = null,
@@ -1971,6 +1970,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     fun checkForOtaUpdate() = runAction("Check OTA") {
         requireConnected("check OTA")
         requireGlassesWifi("check for OTA updates")
+        if (isOtaInProgress()) {
+            addEvent("TX", "OTA check skipped while update is in progress")
+            return@runAction
+        }
         handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
     }
 
@@ -1990,15 +1993,28 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             return
         }
 
-        autoOtaCheckedConnectionKey = autoCheckKey
         autoOtaCheckInProgress = true
         runAction("Auto-check OTA") {
+            var checkSucceeded = false
             try {
                 requireConnected("check OTA")
                 requireGlassesWifi("check for OTA updates")
                 handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+                checkSucceeded = true
             } finally {
                 autoOtaCheckInProgress = false
+                if (checkSucceeded) {
+                    autoOtaCheckedConnectionKey = autoCheckKey
+                    val currentKey = otaAutoCheckKey(state.glassesStatus, latestOtaVersionInfoSignature)
+                    if (
+                        autoOtaCheckedConnectionKey != currentKey &&
+                        isGlassesConnected(state.glassesStatus) &&
+                        isGlassesWifiConnected(state.glassesStatus) &&
+                        !isOtaInProgress()
+                    ) {
+                        maybeAutoCheckOta()
+                    }
+                }
             }
         }
     }
@@ -2913,18 +2929,16 @@ fun rgbLedColorFor(color: String): RgbLedColor =
 fun disconnectedGlassesStatus(status: GlassesRuntimeState?): GlassesRuntimeState? =
     status?.let { GlassesRuntimeState.Disconnected() }
 
-// UI tier names match the 0.1.13 SDK (LOW/MEDIUM/HIGH/MAX).
-// This helper maps them to 0.1.12 Maven enum values (SMALL/MEDIUM/LARGE/FULL).
 fun photoSizeToSdk(size: String): PhotoSize = when (size) {
-    "low" -> PhotoSize.SMALL
-    "high" -> PhotoSize.LARGE
-    "max", "full" -> PhotoSize.FULL
+    "low" -> PhotoSize.LOW
+    "high" -> PhotoSize.HIGH
+    "max", "full" -> PhotoSize.MAX
     else -> PhotoSize.MEDIUM
 }
 
 fun buttonPhotoSizeToSdk(size: String): ButtonPhotoSize = when (size) {
-    "low" -> ButtonPhotoSize.SMALL
-    "high" -> ButtonPhotoSize.LARGE
+    "low" -> ButtonPhotoSize.LOW
+    "high" -> ButtonPhotoSize.HIGH
     "max", "full" -> ButtonPhotoSize.MAX
     else -> ButtonPhotoSize.MEDIUM
 }
@@ -2998,7 +3012,7 @@ val photo = mentraBluetoothSdk.requestPhoto(
     PhotoRequest(
       requestId = requestId,
       appId = "com.mentra.bluetoothsdk.example.android",
-      size = PhotoSize.${when(size) { "low" -> "SMALL"; "high" -> "LARGE"; "max" -> "FULL"; else -> "MEDIUM" }},
+      size = PhotoSize.${when(size) { "low" -> "LOW"; "high" -> "HIGH"; "max" -> "MAX"; else -> "MEDIUM" }},
       webhookUrl = uploadUrl,
       compress = PhotoCompression.${compression.uppercase(Locale.US)},
       sound = true,

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -62,7 +62,6 @@ import com.mentra.examples.android.ui.GlassCard
 import com.mentra.examples.android.ui.OfflineNotice
 import com.mentra.examples.android.ui.PageHeader
 import com.mentra.examples.android.ui.scrollBottomPadding
-import java.util.Locale
 
 @Composable
 fun DeviceScreen(controller: MentraExampleController) {
@@ -130,7 +129,7 @@ fun DeviceScreen(controller: MentraExampleController) {
                 StatTile("WI-FI", wifiLabel(glasses), currentWifi?.localIp ?: "unknown", AppColor.muted, Modifier.weight(1f), bold = true)
                 StatTile("RSSI", rssiLabel(glasses), rssiUpdatedLabel(glasses), AppColor.greenAccent, Modifier.weight(1f), bold = true)
             }
-            if (state.otaStatus != null || state.otaUpdateAvailable != null) {
+            if (state.otaStatus != null || state.otaUpdateAvailable) {
                 OtaCard(controller, modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp))
             }
             if (otaWifiRequired) {
@@ -289,14 +288,14 @@ private fun glassesImageRes(values: GlassesRuntimeState?): Int {
 }
 
 private fun canStartOta(state: com.mentra.examples.android.MentraExampleState): Boolean =
-    isGlassesConnected(state.glassesStatus) && isGlassesWifiConnected(state.glassesStatus) && state.otaUpdateAvailable != null && !isOtaInProgress(state)
+    isGlassesConnected(state.glassesStatus) && isGlassesWifiConnected(state.glassesStatus) && state.otaUpdateAvailable && !isOtaInProgress(state)
 
 private fun isOtaInProgress(state: com.mentra.examples.android.MentraExampleState): Boolean =
     state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
 
 private fun otaStatusLine(state: com.mentra.examples.android.MentraExampleState): String =
     state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${it.overallPercent}%" }
-        ?: state.otaUpdateAvailable?.let { "Update ${it.versionName ?: "available"}" }
+        ?: if (state.otaUpdateAvailable) "Update required" else null
         ?: state.otaStatusMessage
         ?: if (isGlassesConnected(state.glassesStatus)) "Check not run" else "Connect glasses"
 
@@ -304,7 +303,7 @@ private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState):
     when {
         state.otaStatus?.status == "failed" -> "Update failed"
         state.otaStatus != null && isOtaInProgress(state) -> "Updating ${state.otaStatus.stepType.ifBlank { "firmware" }}"
-        state.otaUpdateAvailable != null -> "Update ${state.otaUpdateAvailable.versionName ?: "available"}"
+        state.otaUpdateAvailable -> "Update required"
         else -> "OTA status"
     }
 
@@ -313,25 +312,16 @@ private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState)
     state.otaStatus?.let {
         return "${it.phase.ifBlank { "status" }} · step ${it.currentStep}/${it.totalSteps}"
     }
-    state.otaUpdateAvailable?.let {
-        val updates = it.updates.joinToString().ifBlank { "firmware" }
-        val size = it.totalSize?.let { totalSize -> " · ${formatBytes(totalSize)}" } ?: ""
-        return updates + size
+    if (state.otaUpdateAvailable) {
+        return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
     }
     return "Tap Check OTA to ask the glasses for availability and progress."
 }
 
-private fun formatBytes(bytes: Long): String =
-    when {
-        bytes <= 0 -> "unknown size"
-        bytes < 1024 * 1024 -> if (bytes < 1024) "$bytes B" else "${bytes / 1024} KB"
-        else -> String.format(Locale.US, "%.1f MB", bytes / (1024.0 * 1024.0))
-    }
-
 @Composable
 private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Modifier) {
     val state = controller.state
-    if (state.otaStatus == null && state.otaUpdateAvailable == null) return
+    if (state.otaStatus == null && !state.otaUpdateAvailable) return
     val percent = state.otaStatus?.overallPercent ?: 0
     Column(
         modifier = modifier

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -315,7 +316,7 @@ private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState)
     if (state.otaUpdateAvailable) {
         return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
     }
-    return "Tap Check OTA to ask the glasses for availability and progress."
+    return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
 }
 
 @Composable
@@ -323,19 +324,46 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
     val state = controller.state
     if (state.otaStatus == null && !state.otaUpdateAvailable) return
     val percent = state.otaStatus?.overallPercent ?: 0
+    val updateRequired = state.otaUpdateAvailable && state.otaStatus == null
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .then(if (updateRequired) Modifier.shadow(8.dp, RoundedCornerShape(16.dp)) else Modifier)
             .clip(RoundedCornerShape(16.dp))
-            .background(Color.White)
-            .border(1.dp, Color.White.copy(alpha = 0.7f), RoundedCornerShape(16.dp))
+            .background(
+                if (updateRequired) {
+                    Brush.verticalGradient(listOf(Color(0xFFFFF5DF), Color(0xFFFFE6E1)))
+                } else {
+                    Brush.verticalGradient(listOf(Color.White, Color.White))
+                }
+            )
+            .border(
+                1.dp,
+                if (updateRequired) AppColor.red.copy(alpha = 0.34f) else Color.White.copy(alpha = 0.7f),
+                RoundedCornerShape(16.dp)
+            )
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(9.dp),
     ) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.Top) {
-            Column(modifier = Modifier.weight(1f)) {
-                Eyebrow("OTA")
-                Text(otaCardTitle(state), color = AppColor.ink, fontSize = 15.sp, fontWeight = FontWeight.Bold)
+            Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (updateRequired) {
+                    Box(
+                        modifier = Modifier.size(34.dp).clip(CircleShape).background(AppColor.red),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(Icons.Outlined.Warning, null, tint = Color.White, modifier = Modifier.size(18.dp))
+                    }
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Eyebrow(if (updateRequired) "ACTION NEEDED" else "OTA", color = if (updateRequired) AppColor.red else AppColor.muted)
+                    Text(
+                        otaCardTitle(state),
+                        color = AppColor.inkAlt,
+                        fontSize = if (updateRequired) 19.sp else 15.sp,
+                        fontWeight = if (updateRequired) FontWeight.ExtraBold else FontWeight.Bold,
+                    )
+                }
             }
             if (state.otaStatus != null) {
                 Text("$percent%", color = AppColor.greenInk, fontSize = 20.sp, fontWeight = FontWeight.ExtraBold)
@@ -352,7 +380,23 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
                 )
             }
         }
-        Text(otaCardDetail(state), color = AppColor.muted, fontSize = 12.sp, lineHeight = 16.sp, fontWeight = FontWeight.Medium)
+        Text(
+            otaCardDetail(state),
+            color = if (updateRequired) Color(0xFF5F201B) else AppColor.muted,
+            fontSize = if (updateRequired) 13.sp else 12.sp,
+            lineHeight = if (updateRequired) 18.sp else 16.sp,
+            fontWeight = if (updateRequired) FontWeight.Bold else FontWeight.Medium,
+        )
+        if (updateRequired) {
+            DarkBtn(
+                if (canStartOta(state)) "Start OTA" else "Connect Wi-Fi first",
+                Icons.Outlined.FileDownload,
+                AppColor.red,
+                Modifier.fillMaxWidth(),
+                enabled = canStartOta(state),
+                onClick = controller::startOtaUpdate,
+            )
+        }
     }
 }
 

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -74,6 +74,8 @@ fun DeviceScreen(controller: MentraExampleController) {
     val displaySupported = connected && supportsDisplay(glasses)
     val glassesWifiConnected = isGlassesWifiConnected(glasses)
     val otaWifiRequired = connected && !glassesWifiConnected
+    val otaInProgress = isOtaInProgress(state)
+    val canCheckOta = connected && glassesWifiConnected && !otaInProgress
     val currentDeviceName = if (connected) connectionTargetLabel(state, glasses) else deviceLabel(glasses)
     val level = batteryLevel(glasses)
     val latestEvent = state.events.firstOrNull()
@@ -162,7 +164,7 @@ fun DeviceScreen(controller: MentraExampleController) {
                     LightBtn("Clear Display", Icons.Outlined.Tv, Modifier.weight(1f), enabled = displaySupported, onClick = controller::clearDisplay)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    LightBtn(if (connected && !glassesWifiConnected) "Connect Wi-Fi" else "Check OTA", Icons.Outlined.Refresh, Modifier.weight(1f), enabled = connected && glassesWifiConnected, onClick = controller::checkForOtaUpdate)
+                    LightBtn(if (connected && !glassesWifiConnected) "Connect Wi-Fi" else "Check OTA", Icons.Outlined.Refresh, Modifier.weight(1f), enabled = canCheckOta, onClick = controller::checkForOtaUpdate)
                     LightBtn("Start OTA", Icons.Outlined.FileDownload, Modifier.weight(1f), enabled = canStartOta(state), onClick = controller::startOtaUpdate)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.12
+mentraSdkVersion=0.1.13

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.12;
+				version = 0.1.13;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -334,7 +334,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var micPlaybackHint: String?
     @Published private(set) var otaStatus: OtaStatusEvent?
     @Published private(set) var otaStatusMessage: String?
-    @Published private(set) var otaUpdateAvailable: OtaUpdateAvailableEvent?
+    @Published private(set) var otaUpdateAvailable = false
     @Published private(set) var ledColor = "green"
     @Published private(set) var ledMode = "Off"
     @Published var rawJsonExpanded = false
@@ -355,6 +355,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var directStreamStopTask: Task<Void, Never>?
     private var directStreamFirstFrameSeen = false
     private var lastDirectStreamFrameStatusRefresh = Date.distantPast
+    private var autoOtaCheckedConnectionKey: String?
+    private var autoOtaCheckInProgress = false
     private var scanSession: ScanSession?
     private var micStartedAt: Date?
     private var micElapsedTask: Task<Void, Never>?
@@ -561,7 +563,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         runAsyncAction("Check OTA") { [self] in
             try requireConnected("check OTA")
             try requireGlassesWifi("check for OTA updates")
-            handleOtaQueryResult(try await mentraBluetoothSdk.checkForOtaUpdate())
+            _ = try await checkForOtaUpdateResult()
         }
     }
 
@@ -1595,6 +1597,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             }
         }
         refreshGalleryServerStatusForCurrentHotspot(defaultStatus: hotspotEnabled ? galleryServerStatus : "Gallery server: hotspot off")
+        maybeAutoCheckOta()
         append(tag: "STORE", text: summarize(glasses))
     }
 
@@ -1655,18 +1658,26 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func handleOtaQueryResult(_ result: OtaQueryResult) {
+    private func checkForOtaUpdateResult() async throws -> Bool {
+        handleOtaQueryResult(try await mentraBluetoothSdk.checkForOtaUpdate())
+    }
+
+    private func handleOtaQueryResult(_ result: OtaQueryResult) -> Bool {
         if result.type == "ota_update_available" {
-            let event = OtaUpdateAvailableEvent(values: result.values)
             otaStatus = nil
             otaStatusMessage = nil
-            otaUpdateAvailable = event
-            append(tag: "LIVE", text: "OTA available \(event.versionName ?? "unknown") (\(event.updates.joined(separator: ", ")))")
-            return
+            otaUpdateAvailable = true
+            append(tag: "LIVE", text: "OTA update available")
+            return true
         }
 
         let event = OtaStatusEvent(values: result.values)
         applyOtaStatus(event)
+        if !isDisplayableOtaStatus(event) {
+            otaStatusMessage = "Glasses firmware is up to date"
+            append(tag: "LIVE", text: "OTA up to date")
+        }
+        return false
     }
 
     private func applyOtaStatus(_ event: OtaStatusEvent) {
@@ -1680,7 +1691,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         otaStatus = event
         otaStatusMessage = nil
         if event.status == "complete" || event.status == "failed" {
-            otaUpdateAvailable = nil
+            otaUpdateAvailable = false
         }
         append(tag: "LIVE", text: "OTA \(event.status.isEmpty ? "status" : event.status) \(event.overallPercent)%")
     }
@@ -1694,7 +1705,28 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         case .disconnected:
             label = "disconnected"
         }
+        maybeAutoCheckOta()
         append(tag: "STORE", text: "Wi-Fi \(label)")
+    }
+
+    private func maybeAutoCheckOta() {
+        guard glassesConnected else {
+            autoOtaCheckedConnectionKey = nil
+            autoOtaCheckInProgress = false
+            return
+        }
+        guard glassesWifiConnected, !autoOtaCheckInProgress, !isOtaInProgress() else { return }
+        let connectionKey = otaConnectionKey(glassesValues)
+        guard autoOtaCheckedConnectionKey != connectionKey else { return }
+
+        autoOtaCheckedConnectionKey = connectionKey
+        autoOtaCheckInProgress = true
+        runAsyncAction("Auto-check OTA") { [self] in
+            defer { autoOtaCheckInProgress = false }
+            try requireConnected("check OTA")
+            try requireGlassesWifi("check for OTA updates")
+            _ = try await checkForOtaUpdateResult()
+        }
     }
 
     func mentraBluetoothSDK(_: MentraBluetoothSDK, didReceiveMicPcm event: MicPcmEvent) {
@@ -1779,6 +1811,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         runAction("Auto-connect default") {
             try mentraBluetoothSdk.connectDefault()
         }
+    }
+
+    private func isOtaInProgress() -> Bool {
+        otaStatus?.status == "in_progress" || otaStatus?.status == "step_complete"
     }
 
     private func requireConnected(_ feature: String) throws {
@@ -2006,7 +2042,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         galleryServerStatus = "Gallery server: connect glasses first"
         otaStatus = nil
         otaStatusMessage = nil
-        otaUpdateAvailable = nil
+        otaUpdateAvailable = false
         if activePhotoRequestId != nil {
             activePhotoRequestId = nil
             pollGeneration += 1
@@ -2531,6 +2567,17 @@ func isGlassesConnected(_ status: GlassesRuntimeState?) -> Bool {
 
 func connectedGlassesInfo(_ status: GlassesRuntimeState?) -> ConnectedGlassesInfo? {
     status?.device
+}
+
+func otaConnectionKey(_ status: GlassesRuntimeState?) -> String {
+    let key = [
+        connectedGlassesInfo(status)?.bluetoothName,
+        connectedGlassesInfo(status)?.serialNumber,
+        connectedGlassesInfo(status)?.deviceModel?.deviceType,
+    ]
+    .compactMap { $0 }
+    .joined(separator: "|")
+    return key.isEmpty ? "connected" : key
 }
 
 func modelLabel(_ status: GlassesRuntimeState?) -> String {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -357,6 +357,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var lastDirectStreamFrameStatusRefresh = Date.distantPast
     private var autoOtaCheckedConnectionKey: String?
     private var autoOtaCheckInProgress = false
+    private var latestOtaVersionInfoSignature: String?
     private var scanSession: ScanSession?
     private var micStartedAt: Date?
     private var micElapsedTask: Task<Void, Never>?
@@ -1651,6 +1652,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             break
         case let .otaStatus(event):
             applyOtaStatus(event)
+        case let .versionInfo(event):
+            latestOtaVersionInfoSignature = otaVersionInfoSignature(event)
+            maybeAutoCheckOta()
         case let .raw(name, values):
             handleRawEvent(name: name, values: values)
         default:
@@ -1711,13 +1715,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         guard glassesConnected else {
             autoOtaCheckedConnectionKey = nil
             autoOtaCheckInProgress = false
+            latestOtaVersionInfoSignature = nil
             return
         }
         guard glassesWifiConnected, !autoOtaCheckInProgress, !isOtaInProgress() else { return }
-        let connectionKey = otaConnectionKey(glassesValues)
-        guard autoOtaCheckedConnectionKey != connectionKey else { return }
+        let autoCheckKey = otaAutoCheckKey(glassesValues, versionInfoSignature: latestOtaVersionInfoSignature)
+        guard autoOtaCheckedConnectionKey != autoCheckKey else { return }
 
-        autoOtaCheckedConnectionKey = connectionKey
+        autoOtaCheckedConnectionKey = autoCheckKey
         autoOtaCheckInProgress = true
         runAsyncAction("Auto-check OTA") { [self] in
             defer { autoOtaCheckInProgress = false }
@@ -2576,6 +2581,40 @@ func otaConnectionKey(_ status: GlassesRuntimeState?) -> String {
     .compactMap { $0 }
     .joined(separator: "|")
     return key.isEmpty ? "connected" : key
+}
+
+func otaAutoCheckKey(_ status: GlassesRuntimeState?, versionInfoSignature: String? = nil) -> String {
+    "\(otaConnectionKey(status))|\(versionInfoSignature ?? otaVersionSignature(status))"
+}
+
+func otaVersionSignature(_ status: GlassesRuntimeState?) -> String {
+    guard isGlassesConnected(status) else {
+        return "disconnected"
+    }
+    let key = [
+        connectedGlassesInfo(status)?.buildNumber,
+        status?.firmware?.buildNumber,
+        connectedGlassesInfo(status)?.appVersion,
+        status?.firmware?.appVersion,
+        status?.firmware?.source.rawValue,
+        status?.firmware?.version,
+    ]
+    .compactMap { $0 }
+    .joined(separator: "|")
+    return key.isEmpty ? "version-unknown" : key
+}
+
+func otaVersionInfoSignature(_ event: VersionInfoResult) -> String {
+    let key = [
+        event.buildNumber,
+        event.appVersion,
+        event.mtkFirmwareVersion,
+        event.besFirmwareVersion,
+        event.firmwareVersion,
+    ]
+    .filter { !$0.isEmpty }
+    .joined(separator: "|")
+    return key.isEmpty ? "version-unknown" : key
 }
 
 func modelLabel(_ status: GlassesRuntimeState?) -> String {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -1659,11 +1659,11 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     private func checkForOtaUpdateResult() async throws -> Bool {
-        handleOtaQueryResult(try await mentraBluetoothSdk.checkForOtaUpdate())
+        handleOtaCheckResult(try await mentraBluetoothSdk.checkForOtaUpdate())
     }
 
-    private func handleOtaQueryResult(_ result: OtaQueryResult) -> Bool {
-        if result.type == "ota_update_available" {
+    private func handleOtaCheckResult(_ updateAvailable: Bool) -> Bool {
+        if updateAvailable {
             otaStatus = nil
             otaStatusMessage = nil
             otaUpdateAvailable = true
@@ -1671,12 +1671,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             return true
         }
 
-        let event = OtaStatusEvent(values: result.values)
-        applyOtaStatus(event)
-        if !isDisplayableOtaStatus(event) {
-            otaStatusMessage = "Glasses firmware is up to date"
-            append(tag: "LIVE", text: "OTA up to date")
-        }
+        otaStatus = nil
+        otaStatusMessage = "Glasses firmware is up to date"
+        otaUpdateAvailable = false
+        append(tag: "LIVE", text: "OTA up to date")
         return false
     }
 

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -282,7 +282,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var videoPreviewUrl: URL?
     @Published private(set) var videoRecording = false
     @Published private(set) var photoDestination: PhotoDestination = .thisPhone
-    @Published private(set) var photoSize: PhotoSize = .full
+    @Published private(set) var photoSize: PhotoSize = .max
     @Published private(set) var scanMode = false
     @Published private(set) var scanAeDivisor = 3
     @Published private(set) var scanIsoCap = 800
@@ -564,6 +564,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         runAsyncAction("Check OTA") { [self] in
             try requireConnected("check OTA")
             try requireGlassesWifi("check for OTA updates")
+            if isOtaInProgress() {
+                append(tag: "TX", text: "OTA check skipped while update is in progress")
+                return
+            }
             _ = try await checkForOtaUpdateResult()
         }
     }
@@ -619,9 +623,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         Task {
             do {
                 if enabled {
-                    // SDK 0.1.12 `ButtonPhotoSettings` only carries `size`. The granular scan
-                    // tuning (mfnr/zsl/aeExposureDivisor/isoCap/edge/NR/ISP gains) ships in
-                    // 0.1.13; bump the SwiftPM pin and restore the full preset once published.
+                    // Keep hardware-button captures at max detail while scan mode is enabled.
                     _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
                         ButtonPhotoSettings(size: .max)
                     )
@@ -655,9 +657,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func pushScanButtonPreset(aeDivisor: Int, isoCap: Int) {
         guard glassesConnected else { return }
-        // SDK 0.1.12 `ButtonPhotoSettings` cannot carry aeExposureDivisor/isoCap; the divisor
-        // and ISO-cap chips only affect on-device UI state until the 0.1.13 preset ships. We
-        // still re-assert the max-size scan button preset so the hardware button stays in sync.
+        // Re-assert the max-size scan button preset so the hardware button stays in sync.
         Task {
             do {
                 _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
@@ -797,15 +797,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func buildPhotoRequest(requestId: String, appId: String, webhookUrl: String) -> PhotoRequest {
         if scanMode {
-            // SDK 0.1.12 `PhotoRequest` cannot carry per-capture scan fields (aeExposureDivisor/
-            // isoCap/mfnr/...); those arrive in 0.1.13. Capture at max resolution with no
-            // compression so the scan still favors detail; the rest applies once the pin is bumped.
+            // Hardware-button scan settings are synced separately.
+            // App-triggered captures use max detail to match the scan preset's output tier.
             return PhotoRequest(
                 requestId: requestId,
                 appId: appId,
-                size: .full,
+                size: .max,
                 webhookUrl: webhookUrl,
-                compress: .none,
+                compress: PhotoCompression.none,
                 sound: false
             )
         }
@@ -1667,6 +1666,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     private func handleOtaCheckResult(_ updateAvailable: Bool) -> Bool {
+        if isOtaInProgress() {
+            append(tag: "LIVE", text: "OTA check result ignored while update is in progress")
+            return updateAvailable
+        }
         if updateAvailable {
             otaStatus = nil
             otaStatusMessage = nil
@@ -1722,13 +1725,26 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         let autoCheckKey = otaAutoCheckKey(glassesValues, versionInfoSignature: latestOtaVersionInfoSignature)
         guard autoOtaCheckedConnectionKey != autoCheckKey else { return }
 
-        autoOtaCheckedConnectionKey = autoCheckKey
         autoOtaCheckInProgress = true
         runAsyncAction("Auto-check OTA") { [self] in
-            defer { autoOtaCheckInProgress = false }
+            var checkSucceeded = false
+            defer {
+                autoOtaCheckInProgress = false
+                if checkSucceeded {
+                    autoOtaCheckedConnectionKey = autoCheckKey
+                    let currentKey = otaAutoCheckKey(glassesValues, versionInfoSignature: latestOtaVersionInfoSignature)
+                    if autoOtaCheckedConnectionKey != currentKey,
+                       glassesConnected,
+                       glassesWifiConnected,
+                       !isOtaInProgress() {
+                        maybeAutoCheckOta()
+                    }
+                }
+            }
             try requireConnected("check OTA")
             try requireGlassesWifi("check for OTA updates")
             _ = try await checkForOtaUpdateResult()
+            checkSucceeded = true
         }
     }
 

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -4,10 +4,8 @@ import MentraBluetoothSDK
 import SwiftUI
 import UIKit
 
-// Map new-tier display names (low|medium|high|max) to SDK 0.1.12 enum values
-// (small/medium/large/full). Remove this mapping when the SwiftPM pin moves to 0.1.13.
 private let photoSizeOptions: [(display: String, size: PhotoSize)] = [
-    ("low", .small), ("medium", .medium), ("high", .large), ("max", .full),
+    ("low", .low), ("medium", .medium), ("high", .high), ("max", .max),
 ]
 private let photoCompressionOptions: [PhotoCompression] = [.none, .medium, .heavy]
 
@@ -31,15 +29,15 @@ private func cameraSdkCall(
 ) -> String {
     if scanMode {
         return """
-    // Scan tuning (aeExposureDivisor \(scanAeDivisor), isoCap \(scanIsoCap), mfnr/edge off)
-    // ships in SDK 0.1.13's PhotoRequest. On 0.1.12 we capture at max detail:
+    // Scan tuning is synced through button photo settings.
+    // App-triggered captures use max detail:
     let photo = try await mentraBluetoothSdk.requestPhoto(
         PhotoRequest(
           requestId: requestId,
           appId: "com.mentra.bluetoothsdk.example.ios",
-          size: .full,
+          size: .max,
           webhookUrl: uploadUrl,
-          compress: .none,
+          compress: PhotoCompression.none,
           sound: false
         )
     )

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -118,6 +118,8 @@ struct DeviceScreen: View {
         let hasDefaultTarget = hasSavedConnectionTarget(model.bluetoothValues)
         let displaySupported = connected && supportsDisplay(model.glassesValues)
         let otaWifiRequired = connected && !model.glassesWifiConnected
+        let otaInProgress = isOtaInProgress(model: model)
+        let canCheckOta = connected && model.glassesWifiConnected && !otaInProgress
         return GlassCard {
             HStack {
                 Text(connected ? "Quick actions" : "Connect glasses")
@@ -147,7 +149,7 @@ struct DeviceScreen: View {
                     LightActionButton(icon: "display.slash", title: "Clear Display", enabled: displaySupported, action: model.clearDisplay)
                 }
                 HStack(spacing: 8) {
-                    LightActionButton(icon: "arrow.triangle.2.circlepath", title: otaWifiRequired ? "Connect Wi-Fi" : "Check OTA", enabled: connected && model.glassesWifiConnected, action: model.checkForOtaUpdate)
+                    LightActionButton(icon: "arrow.triangle.2.circlepath", title: otaWifiRequired ? "Connect Wi-Fi" : "Check OTA", enabled: canCheckOta, action: model.checkForOtaUpdate)
                     LightActionButton(icon: "arrow.down.to.line", title: "Start OTA", enabled: canStartOta(model: model), action: model.startOtaUpdate)
                 }
                 HStack(spacing: 8) {

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -19,7 +19,7 @@ struct DeviceScreen: View {
                         .padding(.horizontal, 16)
                         .padding(.top, 12)
 
-                    if model.otaStatus != nil || model.otaUpdateAvailable != nil {
+                    if model.otaStatus != nil || model.otaUpdateAvailable {
                         otaCard
                             .padding(.horizontal, 16)
                             .padding(.top, 10)
@@ -401,7 +401,7 @@ private func targetDeviceDetail(_ device: Device) -> String {
 
 @MainActor
 private func canStartOta(model: BluetoothViewModel) -> Bool {
-    model.glassesConnected && model.glassesWifiConnected && model.otaUpdateAvailable != nil && !isOtaInProgress(model: model)
+    model.glassesConnected && model.glassesWifiConnected && model.otaUpdateAvailable && !isOtaInProgress(model: model)
 }
 
 @MainActor
@@ -414,8 +414,8 @@ private func otaStatusLine(model: BluetoothViewModel) -> String {
     if let status = model.otaStatus {
         return "\(status.status.replacingOccurrences(of: "_", with: " ")) · \(status.overallPercent)%"
     }
-    if let update = model.otaUpdateAvailable {
-        return "Update \(update.versionName ?? "available")"
+    if model.otaUpdateAvailable {
+        return "Update required"
     }
     if let message = model.otaStatusMessage {
         return message
@@ -431,8 +431,8 @@ private func otaCardTitle(model: BluetoothViewModel) -> String {
     if let status = model.otaStatus, isOtaInProgress(model: model) {
         return "Updating \(status.stepType.isEmpty ? "firmware" : status.stepType)"
     }
-    if let update = model.otaUpdateAvailable {
-        return "Update \(update.versionName ?? "available")"
+    if model.otaUpdateAvailable {
+        return "Update required"
     }
     return "OTA status"
 }
@@ -445,22 +445,10 @@ private func otaCardDetail(model: BluetoothViewModel) -> String {
     if let status = model.otaStatus {
         return "\(status.phase.isEmpty ? "status" : status.phase) · step \(status.currentStep)/\(status.totalSteps)"
     }
-    if let update = model.otaUpdateAvailable {
-        let updates = update.updates.isEmpty ? "firmware" : update.updates.joined(separator: ", ")
-        let size = update.totalSize.map { " · \(formatBytes($0))" } ?? ""
-        return updates + size
+    if model.otaUpdateAvailable {
+        return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
     }
     return "Tap Check OTA to ask the glasses for availability and progress."
-}
-
-private func formatBytes(_ bytes: Int) -> String {
-    if bytes <= 0 {
-        return "unknown size"
-    }
-    if bytes < 1024 * 1024 {
-        return "\(bytes / 1024) KB"
-    }
-    return String(format: "%.1f MB", Double(bytes) / (1024.0 * 1024.0))
 }
 
 @MainActor

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -322,16 +322,28 @@ struct DeviceScreen: View {
     }
 
     private var otaCard: some View {
+        let updateRequired = model.otaUpdateAvailable && model.otaStatus == nil
         return VStack(alignment: .leading, spacing: 9) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("OTA")
-                        .font(.system(size: 10, weight: .semibold).monospaced())
-                        .tracking(1.1)
-                        .foregroundColor(AppColor.muted)
-                    Text(otaCardTitle(model: model))
-                        .font(.system(size: 15, weight: .bold))
-                        .foregroundColor(AppColor.ink)
+                HStack(alignment: .center, spacing: 10) {
+                    if updateRequired {
+                        ZStack {
+                            Circle().fill(AppColor.red)
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.system(size: 15, weight: .bold))
+                                .foregroundColor(.white)
+                        }
+                        .frame(width: 34, height: 34)
+                    }
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(updateRequired ? "ACTION NEEDED" : "OTA")
+                            .font(.system(size: 10, weight: updateRequired ? .heavy : .semibold).monospaced())
+                            .tracking(1.1)
+                            .foregroundColor(updateRequired ? AppColor.red : AppColor.muted)
+                        Text(otaCardTitle(model: model))
+                            .font(.system(size: updateRequired ? 19 : 15, weight: updateRequired ? .heavy : .bold))
+                            .foregroundColor(AppColor.inkAlt)
+                    }
                 }
                 Spacer()
                 if let status = model.otaStatus {
@@ -352,15 +364,39 @@ struct DeviceScreen: View {
                 .frame(height: 6)
             }
             Text(otaCardDetail(model: model))
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(AppColor.muted)
+                .font(.system(size: updateRequired ? 13 : 12, weight: updateRequired ? .bold : .medium))
+                .foregroundColor(updateRequired ? Color(hex: 0x5F201B) : AppColor.muted)
+                .lineSpacing(updateRequired ? 2 : 0)
                 .fixedSize(horizontal: false, vertical: true)
+            if updateRequired {
+                Button(action: model.startOtaUpdate) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.down.to.line")
+                            .font(.system(size: 15, weight: .bold))
+                        Text(canStartOta(model: model) ? "Start OTA" : "Connect Wi-Fi first")
+                            .font(.system(size: 14, weight: .heavy))
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 48)
+                    .background(canStartOta(model: model) ? AppColor.red : Color(hex: 0x5F201B).opacity(0.36))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canStartOta(model: model))
+            }
         }
         .padding(14)
-        .background(Color.white)
-        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.7), lineWidth: 1))
+        .background(
+            LinearGradient(
+                colors: updateRequired ? [Color(hex: 0xFFF5DF), Color(hex: 0xFFE6E1)] : [.white, .white],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(updateRequired ? AppColor.red.opacity(0.34) : Color.white.opacity(0.7), lineWidth: 1))
         .clipShape(RoundedRectangle(cornerRadius: 16))
-        .shadow(color: Color(hex: 0x0F2A1D).opacity(0.06), radius: 18, x: 0, y: 6)
+        .shadow(color: (updateRequired ? AppColor.red : Color(hex: 0x0F2A1D)).opacity(updateRequired ? 0.18 : 0.06), radius: updateRequired ? 22 : 18, x: 0, y: updateRequired ? 8 : 6)
     }
 }
 
@@ -448,7 +484,7 @@ private func otaCardDetail(model: BluetoothViewModel) -> String {
     if model.otaUpdateAvailable {
         return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
     }
-    return "Tap Check OTA to ask the glasses for availability and progress."
+    return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
 }
 
 @MainActor

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.12`:
+The Xcode project pins the public Swift package to `0.1.13`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.12
+    exactVersion: 0.1.13
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.12",
+    "@mentra/bluetooth-sdk": "0.1.13",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.12"
+"@mentra/bluetooth-sdk": "0.1.13"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.12",
+        "@mentra/bluetooth-sdk": "0.1.13",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.12", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-3q1aBtX2HXqj9D42z3FSuhTPWc0hXgtXV4HUb/4DHVTWdl8+n8eNfV9SIc9qF8Rhog76gjsF85QW3G6IVHROdw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.13", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-5GYfm5GxB8lPLhYsGPTPdZDq+NLBTZ9OxwcG9zF2qoaE4+X0c0DrL4MWtBelFM8DWZGAT9zySdTqiiCjdlECHA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.12",
+    "@mentra/bluetooth-sdk": "0.1.13",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/bluetoothSdkCompat.ts
+++ b/examples/react-native/src/bluetoothSdkCompat.ts
@@ -1,10 +1,11 @@
 import { requireNativeModule } from 'expo';
 import BluetoothSdk, {
+  type ButtonPhotoSettings,
+  type PhotoCompression,
+  type PhotoSize,
   type PhotoSuccessResponseEvent,
   type SettingsAckSuccessEvent,
 } from '@mentra/bluetooth-sdk';
-
-type PhotoSize = 'low' | 'medium' | 'high' | 'max';
 
 export type ScanButtonPhotoSettings = {
   size?: PhotoSize;
@@ -16,7 +17,7 @@ export type ScanButtonPhotoSettings = {
   ispAnalogGain?: string;
   aeExposureDivisor?: number;
   isoCap?: number;
-  compress?: string;
+  compress?: PhotoCompression;
   sound?: boolean;
   resetCaptureTuning?: boolean;
 };
@@ -27,7 +28,7 @@ export type ScanPhotoRequestParams = {
   webhookUrl: string;
   authToken: string | null;
   size: PhotoSize;
-  compress: string;
+  compress: PhotoCompression;
   sound: boolean;
   save?: boolean;
   exposureTimeNs?: number | null;
@@ -70,10 +71,6 @@ function normalizePhotoSizeTier(size: string | undefined): PhotoSize {
   }
 }
 
-/**
- * Published SDK 0.1.12 omits scan-mode fields from requestPhoto payloads.
- * Build the full native map here so toggling Scan Mode affects app captures.
- */
 export function photoRequestParamsForNativeCompat(
   params: ScanPhotoRequestParams,
 ): Record<string, string | number | boolean> {
@@ -127,22 +124,25 @@ export function photoRequestParamsForNativeCompat(
   return payload;
 }
 
-/** Route granular presets to the native capture-settings API (SDK 0.1.12 public JS only accepts size strings). */
+function buttonPhotoSettingsForSdk(settings: PhotoSize | ScanButtonPhotoSettings): ButtonPhotoSettings {
+  if (typeof settings === 'string') {
+    return {size: normalizePhotoSizeTier(settings)};
+  }
+  return {
+    ...settings,
+    size: normalizePhotoSizeTier(settings.size),
+  };
+}
+
 export async function setButtonPhotoSettingsCompat(
   sizeOrSettings: PhotoSize | ScanButtonPhotoSettings,
 ): Promise<SettingsAckSuccessEvent> {
   if (typeof sizeOrSettings === 'string') {
-    return BluetoothSdk.setButtonPhotoSettings(
-      sizeOrSettings as Parameters<typeof BluetoothSdk.setButtonPhotoSettings>[0],
-    );
+    return BluetoothSdk.setButtonPhotoSettings(buttonPhotoSettingsForSdk(sizeOrSettings));
   }
   const native = NativeBluetoothSdkModule.setButtonPhotoCaptureSettings;
   if (typeof native !== 'function') {
-    // Granular scan-preset API is not available in the currently-installed native build
-    // (SDK < 0.1.13). Fall back to the size-only path so the glasses at least get max
-    // resolution; scan-mode tuning fields (AE÷, ISO cap, etc.) will not be applied.
-    const size: PhotoSize = (sizeOrSettings.size as PhotoSize | undefined) ?? ('max' as PhotoSize);
-    return BluetoothSdk.setButtonPhotoSettings(size as any);
+    return BluetoothSdk.setButtonPhotoSettings(buttonPhotoSettingsForSdk(sizeOrSettings));
   }
   return native(sizeOrSettings);
 }

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -46,6 +46,8 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const displaySupported = connected && supportsDisplay(sdk.glasses);
   const glassesWifiConnected = isGlassesWifiConnected(sdk.glasses);
   const otaWifiRequired = connected && !glassesWifiConnected;
+  const otaInProgress = isOtaInProgress(sdk);
+  const canCheckOta = connected && glassesWifiConnected && !otaInProgress;
   const connection = connectionLabel(sdk.glasses);
   const latestEvent = sdk.events[0];
 
@@ -141,7 +143,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             </Pressable>
           </View>
           <View style={styles.btnRow}>
-            <Pressable disabled={!connected || !glassesWifiConnected} style={({ pressed }) => [styles.btnLight, pressed && styles.btnPressed, (!connected || !glassesWifiConnected) && styles.disabled]} onPress={sdk.checkForOtaUpdate}>
+            <Pressable disabled={!canCheckOta} style={({ pressed }) => [styles.btnLight, pressed && styles.btnPressed, !canCheckOta && styles.disabled]} onPress={sdk.checkForOtaUpdate}>
               <Svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke={colors.inkAlt} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
                 <Path d="M21 12a9 9 0 0 1-15.5 6.2" /><Path d="M3 12a9 9 0 0 1 15.5-6.2" /><Path d="M18 2v4h-4" /><Path d="M6 22v-4h4" />
               </Svg>

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -270,7 +270,7 @@ function canStartOta(sdk: BluetoothSdkExampleModel) {
   if (!isGlassesConnected(sdk.glasses) || !isGlassesWifiConnected(sdk.glasses)) {
     return false;
   }
-  return !isOtaInProgress(sdk);
+  return sdk.otaUpdateAvailable && !isOtaInProgress(sdk);
 }
 
 function isOtaInProgress(sdk: BluetoothSdkExampleModel) {
@@ -282,7 +282,7 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
     return `${sdk.otaStatus.status.replace(/_/g, ' ')} · ${sdk.otaStatus.overall_percent ?? 0}%`;
   }
   if (sdk.otaUpdateAvailable) {
-    return `Update ${sdk.otaUpdateAvailable.version_name ?? 'available'}`;
+    return 'Update required';
   }
   if (sdk.otaStatusMessage) {
     return sdk.otaStatusMessage;
@@ -298,7 +298,7 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
     return `Updating ${sdk.otaStatus.step_type || 'firmware'}`;
   }
   if (sdk.otaUpdateAvailable) {
-    return `Update ${sdk.otaUpdateAvailable.version_name ?? 'available'}`;
+    return 'Update required';
   }
   return 'OTA status';
 }
@@ -311,23 +311,9 @@ function otaCardDetail(sdk: BluetoothSdkExampleModel) {
     return `${sdk.otaStatus.phase || 'status'} · step ${sdk.otaStatus.current_step}/${sdk.otaStatus.total_steps}`;
   }
   if (sdk.otaUpdateAvailable) {
-    const updates = (sdk.otaUpdateAvailable.updates ?? []).join(', ') || 'firmware';
-    const size = typeof sdk.otaUpdateAvailable.total_size === 'number'
-      ? ` · ${formatBytes(sdk.otaUpdateAvailable.total_size)}`
-      : '';
-    return `${updates}${size}`;
+    return 'Update your glasses before continuing. This example app may not work properly until the glasses firmware is current.';
   }
   return 'Tap Check OTA to ask the glasses for availability and progress.';
-}
-
-function formatBytes(bytes: number) {
-  if (!Number.isFinite(bytes) || bytes <= 0) {
-    return 'unknown size';
-  }
-  if (bytes < 1024 * 1024) {
-    return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -313,7 +313,7 @@ function otaCardDetail(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaUpdateAvailable) {
     return 'Update your glasses before continuing. This example app may not work properly until the glasses firmware is current.';
   }
-  return 'Tap Check OTA to ask the glasses for availability and progress.';
+  return 'Tap Check OTA to compare the current glasses version with the SDK OTA manifest.';
 }
 
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
@@ -321,12 +321,28 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
     return null;
   }
   const percent = sdk.otaStatus?.overall_percent ?? 0;
+  const updateRequired = sdk.otaUpdateAvailable && !sdk.otaStatus;
   return (
-    <View style={styles.otaCard}>
+    <LinearGradient
+      colors={updateRequired ? ['#FFF5DF', '#FFE6E1'] : ['#fff', '#fff']}
+      style={[styles.otaCard, updateRequired && styles.otaCardRequired]}>
       <View style={styles.otaHead}>
-        <View style={{ flex: 1 }}>
-          <Text style={styles.otaEyebrow}>OTA</Text>
-          <Text style={styles.otaTitle}>{otaCardTitle(sdk)}</Text>
+        <View style={styles.otaTitleRow}>
+          {updateRequired ? (
+            <View style={styles.otaWarningIcon}>
+              <Svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round">
+                <Path d="m21.7 18.6-8.3-14a1.6 1.6 0 0 0-2.8 0l-8.3 14A1.6 1.6 0 0 0 3.7 21h16.6a1.6 1.6 0 0 0 1.4-2.4Z" />
+                <Path d="M12 8v5" />
+                <Path d="M12 17h.01" />
+              </Svg>
+            </View>
+          ) : null}
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.otaEyebrow, updateRequired && styles.otaEyebrowRequired]}>
+              {updateRequired ? 'ACTION NEEDED' : 'OTA'}
+            </Text>
+            <Text style={[styles.otaTitle, updateRequired && styles.otaTitleRequired]}>{otaCardTitle(sdk)}</Text>
+          </View>
         </View>
         {sdk.otaStatus ? <Text style={styles.otaPercent}>{percent}%</Text> : null}
       </View>
@@ -335,8 +351,25 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           <View style={[styles.otaFill, { width: `${Math.max(0, Math.min(percent, 100))}%` }]} />
         </View>
       ) : null}
-      <Text style={styles.otaDetail}>{otaCardDetail(sdk)}</Text>
-    </View>
+      <Text style={[styles.otaDetail, updateRequired && styles.otaDetailRequired]}>{otaCardDetail(sdk)}</Text>
+      {updateRequired ? (
+        <Pressable
+          disabled={!canStartOta(sdk)}
+          onPress={sdk.startOtaUpdate}
+          style={({ pressed }) => [
+            styles.otaStartButton,
+            pressed && styles.btnPressed,
+            !canStartOta(sdk) && styles.otaStartButtonDisabled,
+          ]}>
+          <Svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round">
+            <Path d="M12 3v12" />
+            <Path d="m7 10 5 5 5-5" />
+            <Path d="M5 21h14" />
+          </Svg>
+          <Text style={styles.otaStartButtonText}>{canStartOta(sdk) ? 'Start OTA' : 'Connect Wi-Fi first'}</Text>
+        </Pressable>
+      ) : null}
+    </LinearGradient>
   );
 }
 
@@ -557,14 +590,23 @@ const styles = StyleSheet.create({
   signalBars: { flexDirection: 'row', alignItems: 'flex-end', gap: 4, paddingBottom: 6 },
   bar: { width: 6, borderRadius: 3 },
   statRow: { flexDirection: 'row', gap: 10, marginHorizontal: 16, marginTop: 12 },
-  otaCard: { marginHorizontal: 16, marginTop: 10, padding: 14, borderRadius: 16, backgroundColor: '#fff', borderWidth: 1, borderColor: 'rgba(255,255,255,0.7)', shadowColor: '#0F2A1D', shadowOpacity: 0.06, shadowRadius: 18, shadowOffset: { width: 0, height: 6 } },
+  otaCard: { marginHorizontal: 16, marginTop: 10, padding: 14, borderRadius: 16, backgroundColor: '#fff', borderWidth: 1, borderColor: 'rgba(255,255,255,0.7)', shadowColor: '#0F2A1D', shadowOpacity: 0.06, shadowRadius: 18, shadowOffset: { width: 0, height: 6 }, gap: 0 },
+  otaCardRequired: { borderColor: 'rgba(255,59,48,0.34)', shadowColor: '#FF3B30', shadowOpacity: 0.18, shadowRadius: 22, shadowOffset: { width: 0, height: 8 }, elevation: 5 },
   otaHead: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 },
+  otaTitleRow: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 10 },
+  otaWarningIcon: { width: 34, height: 34, borderRadius: 999, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.red },
   otaEyebrow: { color: colors.muted, fontSize: 10, fontWeight: '600', letterSpacing: 1.1, fontFamily: 'Courier' },
+  otaEyebrowRequired: { color: colors.red, fontWeight: '800' },
   otaTitle: { color: colors.ink, fontSize: 15, fontWeight: '700', marginTop: 3 },
+  otaTitleRequired: { color: colors.inkAlt, fontSize: 19, fontWeight: '900' },
   otaPercent: { color: colors.greenInk, fontSize: 20, fontWeight: '800' },
   otaTrack: { height: 6, borderRadius: 999, overflow: 'hidden', backgroundColor: 'rgba(14,44,26,0.08)', marginTop: 12 },
   otaFill: { height: 6, borderRadius: 999, backgroundColor: colors.greenPrimary },
   otaDetail: { color: colors.muted, fontSize: 12, fontWeight: '500', lineHeight: 16, marginTop: 9 },
+  otaDetailRequired: { color: '#5F201B', fontSize: 13, fontWeight: '700', lineHeight: 18, marginTop: 11 },
+  otaStartButton: { marginTop: 13, minHeight: 48, borderRadius: 14, backgroundColor: colors.red, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 },
+  otaStartButtonDisabled: { backgroundColor: 'rgba(95,32,27,0.36)' },
+  otaStartButtonText: { color: '#fff', fontSize: 14, fontWeight: '800' },
   statCard: {
     flex: 1,
     backgroundColor: '#fff',

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -22,6 +22,7 @@ import BluetoothSdk, {
   type SpeakingStatusEvent,
   type StreamStatusEvent,
   type TouchEvent,
+  type VersionInfoEvent,
   type VideoRecordingStatusEvent,
   type VoiceActivityDetectionStatusEvent,
 } from '@mentra/bluetooth-sdk';
@@ -77,6 +78,30 @@ type MediaUploadErrorEvent = BluetoothSdkEventMap['media_error'];
 
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
+}
+
+function otaVersionSignature(glasses: GlassesRuntimeState) {
+  if (!glasses.connected) {
+    return 'disconnected';
+  }
+  return [
+    glasses.device.buildNumber,
+    glasses.firmware.buildNumber,
+    glasses.device.appVersion,
+    glasses.firmware.appVersion,
+    glasses.firmware.source,
+    glasses.firmware.version,
+  ].filter(Boolean).join('|') || 'version-unknown';
+}
+
+function otaVersionInfoSignature(event: VersionInfoEvent) {
+  return [
+    event.buildNumber,
+    event.appVersion,
+    event.mtkFirmwareVersion,
+    event.besFirmwareVersion,
+    event.firmwareVersion,
+  ].filter(Boolean).join('|') || 'version-unknown';
 }
 
 export type StreamResolvedConfig = {
@@ -560,6 +585,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const wasConnectedRef = useRef(false);
   const autoOtaCheckedConnectionRef = useRef<string | null>(null);
   const autoOtaCheckInProgressRef = useRef(false);
+  const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
 
   const bluetooth = useMentraBluetooth({
     defaultDeviceStorage,
@@ -581,6 +607,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         glasses.device.serialNumber,
         glasses.device.deviceModel,
       ].filter(Boolean).join('|') || 'connected'
+    : null;
+  const autoOtaCheckKey = connectedDeviceKey
+    ? `${connectedDeviceKey}|${latestVersionInfoSignature ?? otaVersionSignature(glasses)}`
     : null;
   const phone = bluetooth.sdk;
   const scanActive = bluetooth.scan.active;
@@ -638,18 +667,19 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (!glassesConnected) {
       autoOtaCheckedConnectionRef.current = null;
       autoOtaCheckInProgressRef.current = false;
+      setLatestVersionInfoSignature(null);
       return;
     }
     if (
-      !connectedDeviceKey ||
+      !autoOtaCheckKey ||
       !glassesWifiConnected ||
-      autoOtaCheckedConnectionRef.current === connectedDeviceKey ||
+      autoOtaCheckedConnectionRef.current === autoOtaCheckKey ||
       autoOtaCheckInProgressRef.current
     ) {
       return;
     }
 
-    autoOtaCheckedConnectionRef.current = connectedDeviceKey;
+    autoOtaCheckedConnectionRef.current = autoOtaCheckKey;
     autoOtaCheckInProgressRef.current = true;
     void runAction('Auto-check OTA', async () => {
       try {
@@ -658,7 +688,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         autoOtaCheckInProgressRef.current = false;
       }
     });
-  }, [connectedDeviceKey, glassesConnected, glassesWifiConnected]);
+  }, [autoOtaCheckKey, glassesConnected, glassesWifiConnected]);
 
   useEffect(() => {
     const subscriptions = [
@@ -709,6 +739,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           setStreamStatus(JSON.stringify(payload));
         }
         addEvent('LIVE', `stream status ${summarizeMap(payload)}`);
+      }),
+      BluetoothSdk.addListener('version_info', (payload: VersionInfoEvent) => {
+        setLatestVersionInfoSignature(otaVersionInfoSignature(payload));
       }),
       BluetoothSdk.addListener('ota_status', applyOtaStatus),
       BluetoothSdk.addListener('mic_pcm', (payload: MicPcmEvent) => {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -15,9 +15,7 @@ import BluetoothSdk, {
   type DeviceModel,
   type MicLc3Event,
   type MicPcmEvent,
-  type OtaQueryResult,
   type OtaStatusEvent,
-  type OtaUpdateAvailableEvent,
   type PhotoSuccessResponseEvent,
   type PhotoStatusEvent,
   type SettingsAckEvent,
@@ -306,7 +304,7 @@ export type BluetoothSdkExampleState = {
   micRecording: boolean;
   otaStatus: OtaStatusEvent | null;
   otaStatusMessage: string | null;
-  otaUpdateAvailable: OtaUpdateAvailableEvent | null;
+  otaUpdateAvailable: boolean;
   pcmBytes: number;
   pcmFrames: number;
   speaking: boolean | null;
@@ -513,8 +511,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [micPlaybackHint, setMicPlaybackHint] = useState<string | null>(null);
   const [otaStatus, setOtaStatus] = useState<OtaStatusEvent | null>(null);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
-  const [otaUpdateAvailable, setOtaUpdateAvailable] =
-    useState<OtaUpdateAvailableEvent | null>(null);
+  const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
   const [micAudioRouteStatus, setMicAudioRouteStatus] = useState(
     Platform.OS === 'ios'
       ? IOS_AUDIO_ROUTE_HINT
@@ -561,6 +558,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const micStartedAtRef = useRef<number | null>(null);
   const didAutoConnectDefaultRef = useRef(false);
   const wasConnectedRef = useRef(false);
+  const autoOtaCheckedConnectionRef = useRef<string | null>(null);
+  const autoOtaCheckInProgressRef = useRef(false);
 
   const bluetooth = useMentraBluetooth({
     defaultDeviceStorage,
@@ -575,6 +574,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const discoveredDevices = bluetooth.scan.devices;
   const glasses = bluetooth.glasses;
   const glassesConnected = glasses.connected;
+  const glassesWifiConnected = isGlassesWifiConnected(glasses);
+  const connectedDeviceKey = glassesConnected
+    ? [
+        glasses.device.bluetoothName,
+        glasses.device.serialNumber,
+        glasses.device.deviceModel,
+      ].filter(Boolean).join('|') || 'connected'
+    : null;
   const phone = bluetooth.sdk;
   const scanActive = bluetooth.scan.active;
   const galleryModeEnabled = phone.galleryMode.enabled;
@@ -626,6 +633,32 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       await bluetooth.connectDefault();
     });
   }, [defaultDevice, glassesConnected]);
+
+  useEffect(() => {
+    if (!glassesConnected) {
+      autoOtaCheckedConnectionRef.current = null;
+      autoOtaCheckInProgressRef.current = false;
+      return;
+    }
+    if (
+      !connectedDeviceKey ||
+      !glassesWifiConnected ||
+      autoOtaCheckedConnectionRef.current === connectedDeviceKey ||
+      autoOtaCheckInProgressRef.current
+    ) {
+      return;
+    }
+
+    autoOtaCheckedConnectionRef.current = connectedDeviceKey;
+    autoOtaCheckInProgressRef.current = true;
+    void runAction('Auto-check OTA', async () => {
+      try {
+        await checkForOtaUpdateResult();
+      } finally {
+        autoOtaCheckInProgressRef.current = false;
+      }
+    });
+  }, [connectedDeviceKey, glassesConnected, glassesWifiConnected]);
 
   useEffect(() => {
     const subscriptions = [
@@ -911,17 +944,20 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     });
   }
 
-  async function checkForOtaUpdateResult(): Promise<OtaQueryResult> {
-    const result = await BluetoothSdk.checkForOtaUpdate();
-    if (result.type === 'ota_update_available') {
+  async function checkForOtaUpdateResult(): Promise<boolean> {
+    const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
+    if (updateAvailable) {
       setOtaStatus(null);
       setOtaStatusMessage(null);
-      setOtaUpdateAvailable(result);
-      addEvent('LIVE', `OTA available ${result.version_name ?? 'unknown'} (${(result.updates ?? []).join(', ') || 'update'})`);
-      return result;
+      setOtaUpdateAvailable(true);
+      addEvent('LIVE', 'OTA update available');
+      return true;
     }
-    applyOtaStatus(result);
-    return result;
+    setOtaStatus(null);
+    setOtaStatusMessage('Glasses firmware is up to date');
+    setOtaUpdateAvailable(false);
+    addEvent('LIVE', 'OTA up to date');
+    return false;
   }
 
   async function startOtaUpdate() {
@@ -2769,7 +2805,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setGalleryServerStatus('Gallery server: connect glasses first');
     setOtaStatus(null);
     setOtaStatusMessage(null);
-    setOtaUpdateAvailable(null);
+    setOtaUpdateAvailable(false);
     setMicRecording(false);
     micRecordingRef.current = false;
     stopMicElapsedTimer();
@@ -2780,7 +2816,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (!isDisplayableOtaStatus(payload)) {
       setOtaStatus(null);
       setOtaStatusMessage('No active OTA');
-      setOtaUpdateAvailable(null);
+      setOtaUpdateAvailable(false);
       addEvent('LIVE', 'OTA idle');
       return;
     }
@@ -2788,7 +2824,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setOtaStatus(payload);
     setOtaStatusMessage(null);
     if (payload.status === 'complete' || payload.status === 'failed') {
-      setOtaUpdateAvailable(null);
+      setOtaUpdateAvailable(false);
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);
   }

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -80,6 +80,10 @@ function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
 
+function isOtaEventInProgress(payload: OtaStatusEvent | null) {
+  return payload?.status === 'in_progress' || payload?.status === 'step_complete';
+}
+
 function otaVersionSignature(glasses: GlassesRuntimeState) {
   if (!glasses.connected) {
     return 'disconnected';
@@ -585,6 +589,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const wasConnectedRef = useRef(false);
   const autoOtaCheckedConnectionRef = useRef<string | null>(null);
   const autoOtaCheckInProgressRef = useRef(false);
+  const latestAutoOtaCheckKeyRef = useRef<string | null>(null);
+  const otaStatusRef = useRef<OtaStatusEvent | null>(null);
+  const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
 
   const bluetooth = useMentraBluetooth({
@@ -611,6 +618,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const autoOtaCheckKey = connectedDeviceKey
     ? `${connectedDeviceKey}|${latestVersionInfoSignature ?? otaVersionSignature(glasses)}`
     : null;
+  const otaInProgress = isOtaEventInProgress(otaStatus);
   const phone = bluetooth.sdk;
   const scanActive = bluetooth.scan.active;
   const galleryModeEnabled = phone.galleryMode.enabled;
@@ -619,6 +627,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const selectedScanModel = scanModelFromDeviceModel(bluetooth.scan.model);
   activeTabRef.current = activeTab;
   galleryModeEnabledRef.current = galleryModeEnabled;
+  latestAutoOtaCheckKeyRef.current = autoOtaCheckKey;
+  otaStatusRef.current = otaStatus;
 
   useEffect(() => {
     let cancelled = false;
@@ -667,6 +677,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (!glassesConnected) {
       autoOtaCheckedConnectionRef.current = null;
       autoOtaCheckInProgressRef.current = false;
+      latestAutoOtaCheckKeyRef.current = null;
       setLatestVersionInfoSignature(null);
       return;
     }
@@ -674,21 +685,35 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       !autoOtaCheckKey ||
       !glassesWifiConnected ||
       autoOtaCheckedConnectionRef.current === autoOtaCheckKey ||
-      autoOtaCheckInProgressRef.current
+      autoOtaCheckInProgressRef.current ||
+      otaInProgress
     ) {
       return;
     }
 
-    autoOtaCheckedConnectionRef.current = autoOtaCheckKey;
+    const checkedKey = autoOtaCheckKey;
     autoOtaCheckInProgressRef.current = true;
     void runAction('Auto-check OTA', async () => {
+      let checkSucceeded = false;
       try {
         await checkForOtaUpdateResult();
+        checkSucceeded = true;
       } finally {
         autoOtaCheckInProgressRef.current = false;
+        if (!checkSucceeded) {
+          return;
+        }
+        autoOtaCheckedConnectionRef.current = checkedKey;
+        if (
+          latestAutoOtaCheckKeyRef.current &&
+          latestAutoOtaCheckKeyRef.current !== checkedKey &&
+          !isOtaEventInProgress(otaStatusRef.current)
+        ) {
+          setAutoOtaCheckRetryTick((tick) => tick + 1);
+        }
       }
     });
-  }, [autoOtaCheckKey, glassesConnected, glassesWifiConnected]);
+  }, [autoOtaCheckKey, autoOtaCheckRetryTick, glassesConnected, glassesWifiConnected, otaInProgress]);
 
   useEffect(() => {
     const subscriptions = [
@@ -973,12 +998,20 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Connect glasses first.');
       }
       requireGlassesWifi('check for OTA updates');
+      if (isOtaEventInProgress(otaStatusRef.current)) {
+        addEvent('TX', 'OTA check skipped while update is in progress');
+        return;
+      }
       await checkForOtaUpdateResult();
     });
   }
 
   async function checkForOtaUpdateResult(): Promise<boolean> {
     const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
+    if (isOtaEventInProgress(otaStatusRef.current)) {
+      addEvent('LIVE', 'OTA check result ignored while update is in progress');
+      return updateAvailable;
+    }
     if (updateAvailable) {
       setOtaStatus(null);
       setOtaStatusMessage(null);


### PR DESCRIPTION
## Summary

- Auto-check OTA availability in the React Native, Android, and iOS example apps after glasses connect and report Wi-Fi.
- Preserve active OTA progress when a manual or automatic check races with install status updates.
- Retry auto-checks when version metadata changes during an in-flight check, and only mark a connection/version key checked after a successful check.
- Disable manual Check OTA while an update is already in progress; Start OTA remains gated on a positive availability result plus glasses Wi-Fi.
- Bump example SDK pins and lockfiles to Bluetooth SDK `0.1.13`, including Maven, SwiftPM, and npm consumers.

## Why

B2B customers using the Starter Kit can see broken or confusing behavior if their glasses firmware is stale. The examples should surface that immediately after connection without wiping active OTA progress or missing a follow-up check when version metadata arrives mid-flight.

## Validation

- `git diff --check`
- `cd examples/react-native && bunx tsc --noEmit -p tsconfig.json`
- `cd examples/android && ./gradlew --refresh-dependencies :app:compileDebugKotlin`
- `cd examples/android && ./gradlew :app:compileDebugKotlin`
- `cd examples/ios && xcodebuild -project MentraExample.xcodeproj -scheme MentraExample -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO -quiet build`

Note: the iOS build was run with code signing disabled because the local project has no development team configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to example apps, docs, and dependency pins; OTA and photo API updates follow the published 0.1.13 SDK contract with no auth or production app code touched.
> 
> **Overview**
> Bumps **all starter-kit examples and docs** from Bluetooth SDK **0.1.12 → 0.1.13** (Maven, SwiftPM, npm, lockfiles).
> 
> **OTA flow** is aligned with the new SDK: `checkForOtaUpdate()` returns a **boolean** instead of rich query payloads; **`version_info`** drives when to re-run checks. Android, iOS, and React Native examples **auto-check OTA** once glasses are connected, on Wi‑Fi, and when version metadata changes (deduped per connection/version signature). Manual check is **disabled while an update is in progress**.
> 
> The Device tab shows a stronger **“update required”** card (warning styling, inline **Start OTA**) when a check finds an update; **Start OTA** stays gated on a positive availability result plus glasses Wi‑Fi.
> 
> **Camera/scan** code drops 0.1.12 shims: photo tiers use **`LOW` / `HIGH` / `MAX`** (and scan-mode captures use **`PhotoSize.MAX`**). React Native **`bluetoothSdkCompat`** is simplified now that typed **`ButtonPhotoSettings`** and scan fields ship in 0.1.13.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9ed125b02186ac1eb3fd300c11e82ac4553826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->