### PR TITLE
Keep OTA completion state current in examples

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -2520,7 +2520,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         val sessionKey = event.otaSessionKey()
         if (postOtaCheckInProgress || postOtaCheckedSessionKey == sessionKey) return
 
-        postOtaCheckedSessionKey = sessionKey
         postOtaCheckInProgress = true
         autoOtaCheckInProgress = true
         runAction("Verify OTA") {
@@ -2536,6 +2535,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 postOtaCheckInProgress = false
                 autoOtaCheckInProgress = false
                 if (checkSucceeded) {
+                    postOtaCheckedSessionKey = sessionKey
                     autoOtaCheckedConnectionKey = otaAutoCheckKey(state.glassesStatus, latestOtaVersionInfoSignature)
                 }
             }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -221,6 +221,7 @@ data class MentraExampleState(
     val micPlaybackHint: String? = null,
     val micPlaying: Boolean = false,
     val micRecording: Boolean = false,
+    val otaDisplayPercent: Int? = null,
     val otaStatus: OtaStatusEvent? = null,
     val otaStatusMessage: String? = null,
     val otaUpdateAvailable: Boolean = false,
@@ -320,6 +321,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
     private var latestOtaVersionInfoSignature: String? = null
+    private var otaDisplayProgressSessionKey: String? = null
+    private var otaDisplayOverallPercent: Int? = null
+    private var postOtaCheckInProgress = false
+    private var postOtaCheckedSessionKey: String? = null
 
     private val micSampleRate = 16_000
     private val micChannelCount = 1
@@ -1905,8 +1910,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             return updateAvailable
         }
         if (updateAvailable) {
+            resetOtaDisplayProgress()
             state = state.copy(
                 otaStatus = null,
+                otaDisplayPercent = null,
                 otaStatusMessage = null,
                 otaUpdateAvailable = true,
             )
@@ -1914,8 +1921,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             return true
         }
 
+        resetOtaDisplayProgress()
         state = state.copy(
             otaStatus = null,
+            otaDisplayPercent = null,
             otaStatusMessage = "Glasses firmware is up to date",
             otaUpdateAvailable = false,
         )
@@ -1983,6 +1992,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             autoOtaCheckedConnectionKey = null
             autoOtaCheckInProgress = false
             latestOtaVersionInfoSignature = null
+            postOtaCheckInProgress = false
+            postOtaCheckedSessionKey = null
             return
         }
         if (!isGlassesWifiConnected(glasses) || autoOtaCheckInProgress || isOtaInProgress()) {
@@ -2022,6 +2033,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     fun startOtaUpdate() = runAction("Start OTA") {
         requireConnected("start OTA")
         requireGlassesWifi("start OTA updates")
+        postOtaCheckedSessionKey = null
+        resetOtaDisplayProgress()
+        state = state.copy(otaDisplayPercent = null)
         withContext(Dispatchers.IO) { mentraBluetoothSdk.startOtaUpdate() }
         addEvent("LIVE", "OTA start acknowledged")
     }
@@ -2411,6 +2425,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         directPhotoTimeoutJob?.cancel()
         directPhotoTimeoutJob = null
         photoUploadServer.stop()
+        resetOtaDisplayProgress()
         if (hadPhotoRequest) {
             pollGeneration += 1
         }
@@ -2429,6 +2444,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             streamStatus = status,
             hotspotEnabled = false,
             otaStatus = null,
+            otaDisplayPercent = null,
             otaStatusMessage = null,
             otaUpdateAvailable = false,
             micRecording = false,
@@ -2458,20 +2474,72 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     private fun applyOtaStatus(event: OtaStatusEvent) {
         if (!isDisplayableOtaStatus(event)) {
+            resetOtaDisplayProgress()
             state = state.copy(
                 otaStatus = null,
+                otaDisplayPercent = null,
                 otaStatusMessage = "No active OTA",
             )
             addEvent("LIVE", "OTA idle")
             return
         }
 
+        val displayPercent = updateOtaDisplayPercent(event)
         state = state.copy(
             otaStatus = event,
+            otaDisplayPercent = displayPercent,
             otaStatusMessage = null,
             otaUpdateAvailable = if (event.status == "complete" || event.status == "failed") false else state.otaUpdateAvailable,
         )
         addEvent("LIVE", "OTA ${event.status.ifBlank { "status" }} ${event.overallPercent}%")
+        schedulePostOtaCheck(event)
+    }
+
+    private fun updateOtaDisplayPercent(event: OtaStatusEvent): Int {
+        val sessionKey = event.otaSessionKey()
+        val incomingPercent = event.overallPercent.coerceIn(0, 100)
+        val previousPercent =
+            if (otaDisplayProgressSessionKey == sessionKey) otaDisplayOverallPercent else null
+        val displayPercent = when (event.status) {
+            "complete" -> 100
+            "in_progress", "step_complete" -> maxOf(previousPercent ?: incomingPercent, incomingPercent)
+            else -> incomingPercent
+        }.coerceIn(0, 100)
+        otaDisplayProgressSessionKey = sessionKey
+        otaDisplayOverallPercent = displayPercent
+        return displayPercent
+    }
+
+    private fun resetOtaDisplayProgress() {
+        otaDisplayProgressSessionKey = null
+        otaDisplayOverallPercent = null
+    }
+
+    private fun schedulePostOtaCheck(event: OtaStatusEvent) {
+        if (event.status != "complete") return
+        val sessionKey = event.otaSessionKey()
+        if (postOtaCheckInProgress || postOtaCheckedSessionKey == sessionKey) return
+
+        postOtaCheckedSessionKey = sessionKey
+        postOtaCheckInProgress = true
+        autoOtaCheckInProgress = true
+        runAction("Verify OTA") {
+            var checkSucceeded = false
+            try {
+                if (!isGlassesConnected(state.glassesStatus) || !isGlassesWifiConnected(state.glassesStatus)) {
+                    addEvent("LIVE", "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
+                    return@runAction
+                }
+                handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+                checkSucceeded = true
+            } finally {
+                postOtaCheckInProgress = false
+                autoOtaCheckInProgress = false
+                if (checkSucceeded) {
+                    autoOtaCheckedConnectionKey = otaAutoCheckKey(state.glassesStatus, latestOtaVersionInfoSignature)
+                }
+            }
+        }
     }
 
     private fun applyStreamStatus(status: StreamStatus) {
@@ -3443,6 +3511,9 @@ fun isGlassesWifiConnected(status: GlassesRuntimeState?): Boolean =
 
 fun isDisplayableOtaStatus(status: OtaStatusEvent): Boolean =
     status.status != "idle" || !status.errorMessage.isNullOrBlank()
+
+fun OtaStatusEvent.otaSessionKey(): String =
+    sessionId.ifBlank { "$currentStep:$totalSteps:$stepType" }
 
 fun connectedWifiStatus(status: GlassesRuntimeState?): WifiStatus.Connected? =
     status?.wifi as? WifiStatus.Connected

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -3513,7 +3513,7 @@ fun isDisplayableOtaStatus(status: OtaStatusEvent): Boolean =
     status.status != "idle" || !status.errorMessage.isNullOrBlank()
 
 fun OtaStatusEvent.otaSessionKey(): String =
-    sessionId.ifBlank { "$currentStep:$totalSteps:$stepType" }
+    sessionId.ifBlank { "current-ota" }
 
 fun connectedWifiStatus(status: GlassesRuntimeState?): WifiStatus.Connected? =
     status?.wifi as? WifiStatus.Connected

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -297,10 +297,13 @@ private fun isOtaInProgress(state: com.mentra.examples.android.MentraExampleStat
     state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
 
 private fun otaStatusLine(state: com.mentra.examples.android.MentraExampleState): String =
-    state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${it.overallPercent}%" }
+    state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${otaDisplayPercent(state)}%" }
         ?: if (state.otaUpdateAvailable) "Update required" else null
         ?: state.otaStatusMessage
         ?: if (isGlassesConnected(state.glassesStatus)) "Check not run" else "Connect glasses"
+
+private fun otaDisplayPercent(state: com.mentra.examples.android.MentraExampleState): Int =
+    state.otaDisplayPercent ?: state.otaStatus?.overallPercent ?: 0
 
 private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState): String =
     when {
@@ -325,7 +328,7 @@ private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState)
 private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Modifier) {
     val state = controller.state
     if (state.otaStatus == null && !state.otaUpdateAvailable) return
-    val percent = state.otaStatus?.overallPercent ?: 0
+    val percent = otaDisplayPercent(state)
     val updateRequired = state.otaUpdateAvailable && state.otaStatus == null
     Column(
         modifier = modifier

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -332,6 +332,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var lastMicDurationSeconds: Int?
     @Published private(set) var lastMicBytes = 0
     @Published private(set) var micPlaybackHint: String?
+    @Published private(set) var otaDisplayPercent: Int?
     @Published private(set) var otaStatus: OtaStatusEvent?
     @Published private(set) var otaStatusMessage: String?
     @Published private(set) var otaUpdateAvailable = false
@@ -358,6 +359,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var autoOtaCheckedConnectionKey: String?
     private var autoOtaCheckInProgress = false
     private var latestOtaVersionInfoSignature: String?
+    private var otaDisplayProgressSessionKey: String?
+    private var otaDisplayOverallPercent: Int?
+    private var postOtaCheckInProgress = false
+    private var postOtaCheckedSessionKey: String?
     private var scanSession: ScanSession?
     private var micStartedAt: Date?
     private var micElapsedTask: Task<Void, Never>?
@@ -576,6 +581,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         runAsyncAction("Start OTA") { [self] in
             try requireConnected("start OTA")
             try requireGlassesWifi("start OTA updates")
+            postOtaCheckedSessionKey = nil
+            resetOtaDisplayProgress()
+            otaDisplayPercent = nil
             _ = try await mentraBluetoothSdk.startOtaUpdate()
             append(tag: "LIVE", text: "OTA start acknowledged")
         }
@@ -1670,8 +1678,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             append(tag: "LIVE", text: "OTA check result ignored while update is in progress")
             return updateAvailable
         }
+        resetOtaDisplayProgress()
         if updateAvailable {
             otaStatus = nil
+            otaDisplayPercent = nil
             otaStatusMessage = nil
             otaUpdateAvailable = true
             append(tag: "LIVE", text: "OTA update available")
@@ -1679,6 +1689,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
 
         otaStatus = nil
+        otaDisplayPercent = nil
         otaStatusMessage = "Glasses firmware is up to date"
         otaUpdateAvailable = false
         append(tag: "LIVE", text: "OTA up to date")
@@ -1687,18 +1698,71 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func applyOtaStatus(_ event: OtaStatusEvent) {
         guard isDisplayableOtaStatus(event) else {
+            resetOtaDisplayProgress()
             otaStatus = nil
+            otaDisplayPercent = nil
             otaStatusMessage = "No active OTA"
             append(tag: "LIVE", text: "OTA idle")
             return
         }
 
+        otaDisplayPercent = updateOtaDisplayPercent(event)
         otaStatus = event
         otaStatusMessage = nil
         if event.status == "complete" || event.status == "failed" {
             otaUpdateAvailable = false
         }
         append(tag: "LIVE", text: "OTA \(event.status.isEmpty ? "status" : event.status) \(event.overallPercent)%")
+        schedulePostOtaCheck(event)
+    }
+
+    private func updateOtaDisplayPercent(_ event: OtaStatusEvent) -> Int {
+        let sessionKey = otaSessionKey(event)
+        let incomingPercent = min(max(event.overallPercent, 0), 100)
+        let previousPercent = otaDisplayProgressSessionKey == sessionKey ? otaDisplayOverallPercent : nil
+        let displayPercent: Int
+        switch event.status {
+        case "complete":
+            displayPercent = 100
+        case "in_progress", "step_complete":
+            displayPercent = max(previousPercent ?? incomingPercent, incomingPercent)
+        default:
+            displayPercent = incomingPercent
+        }
+        otaDisplayProgressSessionKey = sessionKey
+        otaDisplayOverallPercent = min(max(displayPercent, 0), 100)
+        return otaDisplayOverallPercent ?? incomingPercent
+    }
+
+    private func resetOtaDisplayProgress() {
+        otaDisplayProgressSessionKey = nil
+        otaDisplayOverallPercent = nil
+    }
+
+    private func schedulePostOtaCheck(_ event: OtaStatusEvent) {
+        guard event.status == "complete" else { return }
+        let sessionKey = otaSessionKey(event)
+        guard !postOtaCheckInProgress, postOtaCheckedSessionKey != sessionKey else { return }
+
+        postOtaCheckedSessionKey = sessionKey
+        postOtaCheckInProgress = true
+        autoOtaCheckInProgress = true
+        runAsyncAction("Verify OTA") { [self] in
+            var checkSucceeded = false
+            defer {
+                postOtaCheckInProgress = false
+                autoOtaCheckInProgress = false
+                if checkSucceeded {
+                    autoOtaCheckedConnectionKey = otaAutoCheckKey(glassesValues, versionInfoSignature: latestOtaVersionInfoSignature)
+                }
+            }
+            guard glassesConnected, glassesWifiConnected else {
+                append(tag: "LIVE", text: "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
+                return
+            }
+            _ = try await checkForOtaUpdateResult()
+            checkSucceeded = true
+        }
     }
 
     private func applyWifiStatus(_ event: WifiStatusEvent) {
@@ -1719,6 +1783,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             autoOtaCheckedConnectionKey = nil
             autoOtaCheckInProgress = false
             latestOtaVersionInfoSignature = nil
+            postOtaCheckInProgress = false
+            postOtaCheckedSessionKey = nil
             return
         }
         guard glassesWifiConnected, !autoOtaCheckInProgress, !isOtaInProgress() else { return }
@@ -2059,7 +2125,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         hotspotEnabled = false
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
+        resetOtaDisplayProgress()
         otaStatus = nil
+        otaDisplayPercent = nil
         otaStatusMessage = nil
         otaUpdateAvailable = false
         if activePhotoRequestId != nil {
@@ -2631,6 +2699,10 @@ func otaVersionInfoSignature(_ event: VersionInfoResult) -> String {
     .filter { !$0.isEmpty }
     .joined(separator: "|")
     return key.isEmpty ? "version-unknown" : key
+}
+
+func otaSessionKey(_ status: OtaStatusEvent) -> String {
+    status.sessionId.isEmpty ? "\(status.currentStep):\(status.totalSteps):\(status.stepType)" : status.sessionId
 }
 
 func modelLabel(_ status: GlassesRuntimeState?) -> String {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -1744,7 +1744,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         let sessionKey = otaSessionKey(event)
         guard !postOtaCheckInProgress, postOtaCheckedSessionKey != sessionKey else { return }
 
-        postOtaCheckedSessionKey = sessionKey
         postOtaCheckInProgress = true
         autoOtaCheckInProgress = true
         runAsyncAction("Verify OTA") { [self] in
@@ -1753,6 +1752,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 postOtaCheckInProgress = false
                 autoOtaCheckInProgress = false
                 if checkSucceeded {
+                    postOtaCheckedSessionKey = sessionKey
                     autoOtaCheckedConnectionKey = otaAutoCheckKey(glassesValues, versionInfoSignature: latestOtaVersionInfoSignature)
                 }
             }

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -2702,7 +2702,7 @@ func otaVersionInfoSignature(_ event: VersionInfoResult) -> String {
 }
 
 func otaSessionKey(_ status: OtaStatusEvent) -> String {
-    status.sessionId.isEmpty ? "\(status.currentStep):\(status.totalSteps):\(status.stepType)" : status.sessionId
+    status.sessionId.isEmpty ? "current-ota" : status.sessionId
 }
 
 func modelLabel(_ status: GlassesRuntimeState?) -> String {

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -349,7 +349,7 @@ struct DeviceScreen: View {
                 }
                 Spacer()
                 if let status = model.otaStatus {
-                    Text("\(status.overallPercent)%")
+                    Text("\(otaDisplayPercent(model: model, status: status))%")
                         .font(.system(size: 20, weight: .heavy))
                         .foregroundColor(AppColor.greenInk)
                 }
@@ -360,7 +360,7 @@ struct DeviceScreen: View {
                         Capsule().fill(AppColor.greenInk.opacity(0.08))
                         Capsule()
                             .fill(AppColor.greenPrimary)
-                            .frame(width: geometry.size.width * CGFloat(min(max(status.overallPercent, 0), 100)) / 100.0)
+                            .frame(width: geometry.size.width * CGFloat(min(max(otaDisplayPercent(model: model, status: status), 0), 100)) / 100.0)
                     }
                 }
                 .frame(height: 6)
@@ -450,7 +450,7 @@ private func isOtaInProgress(model: BluetoothViewModel) -> Bool {
 @MainActor
 private func otaStatusLine(model: BluetoothViewModel) -> String {
     if let status = model.otaStatus {
-        return "\(status.status.replacingOccurrences(of: "_", with: " ")) · \(status.overallPercent)%"
+        return "\(status.status.replacingOccurrences(of: "_", with: " ")) · \(otaDisplayPercent(model: model, status: status))%"
     }
     if model.otaUpdateAvailable {
         return "Update required"
@@ -459,6 +459,11 @@ private func otaStatusLine(model: BluetoothViewModel) -> String {
         return message
     }
     return model.glassesConnected ? "Check not run" : "Connect glasses"
+}
+
+@MainActor
+private func otaDisplayPercent(model: BluetoothViewModel, status: OtaStatusEvent) -> Int {
+    model.otaDisplayPercent ?? status.overallPercent
 }
 
 @MainActor

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -281,7 +281,7 @@ function isOtaInProgress(sdk: BluetoothSdkExampleModel) {
 
 function otaStatusLine(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaStatus) {
-    return `${sdk.otaStatus.status.replace(/_/g, ' ')} · ${sdk.otaStatus.overall_percent ?? 0}%`;
+    return `${sdk.otaStatus.status.replace(/_/g, ' ')} · ${otaDisplayPercent(sdk)}%`;
   }
   if (sdk.otaUpdateAvailable) {
     return 'Update required';
@@ -318,11 +318,15 @@ function otaCardDetail(sdk: BluetoothSdkExampleModel) {
   return 'Tap Check OTA to compare the current glasses version with the SDK OTA manifest.';
 }
 
+function otaDisplayPercent(sdk: BluetoothSdkExampleModel) {
+  return sdk.otaDisplayPercent ?? sdk.otaStatus?.overall_percent ?? 0;
+}
+
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   if (!sdk.otaStatus && !sdk.otaUpdateAvailable) {
     return null;
   }
-  const percent = sdk.otaStatus?.overall_percent ?? 0;
+  const percent = otaDisplayPercent(sdk);
   const updateRequired = sdk.otaUpdateAvailable && !sdk.otaStatus;
   return (
     <LinearGradient

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1069,7 +1069,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       return;
     }
 
-    postOtaCheckedSessionRef.current = sessionId;
     postOtaCheckInProgressRef.current = true;
     autoOtaCheckInProgressRef.current = true;
     void runAction('Verify OTA', async () => {
@@ -1084,8 +1083,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       } finally {
         postOtaCheckInProgressRef.current = false;
         autoOtaCheckInProgressRef.current = false;
-        if (checkSucceeded && latestAutoOtaCheckKeyRef.current) {
-          autoOtaCheckedConnectionRef.current = latestAutoOtaCheckKeyRef.current;
+        if (checkSucceeded) {
+          postOtaCheckedSessionRef.current = sessionId;
+          if (latestAutoOtaCheckKeyRef.current) {
+            autoOtaCheckedConnectionRef.current = latestAutoOtaCheckKeyRef.current;
+          }
         }
       }
     });

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -328,6 +328,7 @@ export type BluetoothSdkExampleState = {
   micPlaybackHint: string | null;
   micPlaying: boolean;
   micRecording: boolean;
+  otaDisplayPercent: number | null;
   otaStatus: OtaStatusEvent | null;
   otaStatusMessage: string | null;
   otaUpdateAvailable: boolean;
@@ -536,6 +537,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [lastMicDurationSeconds, setLastMicDurationSeconds] = useState<number | null>(null);
   const [micPlaybackHint, setMicPlaybackHint] = useState<string | null>(null);
   const [otaStatus, setOtaStatus] = useState<OtaStatusEvent | null>(null);
+  const [otaDisplayPercent, setOtaDisplayPercent] = useState<number | null>(null);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
   const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
   const [micAudioRouteStatus, setMicAudioRouteStatus] = useState(
@@ -588,6 +590,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const autoOtaCheckInProgressRef = useRef(false);
   const latestAutoOtaCheckKeyRef = useRef<string | null>(null);
   const otaStatusRef = useRef<OtaStatusEvent | null>(null);
+  const glassesConnectedRef = useRef(false);
+  const glassesWifiConnectedRef = useRef(false);
+  const otaDisplayProgressRef = useRef<{sessionId: string; percent: number} | null>(null);
+  const postOtaCheckInProgressRef = useRef(false);
+  const postOtaCheckedSessionRef = useRef<string | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
 
@@ -626,6 +633,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   galleryModeEnabledRef.current = galleryModeEnabled;
   latestAutoOtaCheckKeyRef.current = autoOtaCheckKey;
   otaStatusRef.current = otaStatus;
+  glassesConnectedRef.current = glassesConnected;
+  glassesWifiConnectedRef.current = glassesWifiConnected;
 
   useEffect(() => {
     let cancelled = false;
@@ -675,6 +684,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       autoOtaCheckedConnectionRef.current = null;
       autoOtaCheckInProgressRef.current = false;
       latestAutoOtaCheckKeyRef.current = null;
+      postOtaCheckInProgressRef.current = false;
+      postOtaCheckedSessionRef.current = null;
       setLatestVersionInfoSignature(null);
       return;
     }
@@ -1009,18 +1020,75 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('LIVE', 'OTA check result ignored while update is in progress');
       return updateAvailable;
     }
+    clearOtaDisplayProgress();
     if (updateAvailable) {
+      otaStatusRef.current = null;
       setOtaStatus(null);
       setOtaStatusMessage(null);
       setOtaUpdateAvailable(true);
       addEvent('LIVE', 'OTA update available');
       return true;
     }
+    otaStatusRef.current = null;
     setOtaStatus(null);
     setOtaStatusMessage('Glasses firmware is up to date');
     setOtaUpdateAvailable(false);
     addEvent('LIVE', 'OTA up to date');
     return false;
+  }
+
+  function clearOtaDisplayProgress() {
+    otaDisplayProgressRef.current = null;
+    setOtaDisplayPercent(null);
+  }
+
+  function updateOtaDisplayPercent(payload: OtaStatusEvent) {
+    const incomingPercent = Math.max(0, Math.min(payload.overall_percent ?? 0, 100));
+    const sessionId = payload.session_id || `${payload.current_step}:${payload.total_steps}:${payload.step_type}`;
+    const previous =
+      otaDisplayProgressRef.current?.sessionId === sessionId
+        ? otaDisplayProgressRef.current.percent
+        : null;
+    const displayPercent =
+      payload.status === 'complete'
+        ? 100
+        : payload.status === 'in_progress' || payload.status === 'step_complete'
+          ? Math.max(previous ?? incomingPercent, incomingPercent)
+          : incomingPercent;
+
+    otaDisplayProgressRef.current = {sessionId, percent: displayPercent};
+    return displayPercent;
+  }
+
+  function schedulePostOtaCheck(payload: OtaStatusEvent) {
+    if (payload.status !== 'complete') {
+      return;
+    }
+    const sessionId = payload.session_id || `${payload.current_step}:${payload.total_steps}:${payload.step_type}`;
+    if (postOtaCheckInProgressRef.current || postOtaCheckedSessionRef.current === sessionId) {
+      return;
+    }
+
+    postOtaCheckedSessionRef.current = sessionId;
+    postOtaCheckInProgressRef.current = true;
+    autoOtaCheckInProgressRef.current = true;
+    void runAction('Verify OTA', async () => {
+      let checkSucceeded = false;
+      try {
+        if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
+          addEvent('LIVE', 'OTA complete; skipped verification because glasses Wi-Fi is unavailable');
+          return;
+        }
+        await checkForOtaUpdateResult();
+        checkSucceeded = true;
+      } finally {
+        postOtaCheckInProgressRef.current = false;
+        autoOtaCheckInProgressRef.current = false;
+        if (checkSucceeded && latestAutoOtaCheckKeyRef.current) {
+          autoOtaCheckedConnectionRef.current = latestAutoOtaCheckKeyRef.current;
+        }
+      }
+    });
   }
 
   async function startOtaUpdate() {
@@ -1029,6 +1097,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Connect glasses first.');
       }
       requireGlassesWifi('start OTA updates');
+      postOtaCheckedSessionRef.current = null;
+      clearOtaDisplayProgress();
       await BluetoothSdk.startOtaUpdate();
       addEvent('LIVE', 'OTA start acknowledged');
     });
@@ -2866,7 +2936,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setStreamStatus(status);
     setGalleryServerReachable(null);
     setGalleryServerStatus('Gallery server: connect glasses first');
+    otaStatusRef.current = null;
     setOtaStatus(null);
+    clearOtaDisplayProgress();
     setOtaStatusMessage(null);
     setOtaUpdateAvailable(false);
     setMicRecording(false);
@@ -2877,19 +2949,25 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function applyOtaStatus(payload: OtaStatusEvent) {
     if (!isDisplayableOtaStatus(payload)) {
+      otaStatusRef.current = null;
       setOtaStatus(null);
+      clearOtaDisplayProgress();
       setOtaStatusMessage('No active OTA');
       setOtaUpdateAvailable(false);
       addEvent('LIVE', 'OTA idle');
       return;
     }
 
+    const displayPercent = updateOtaDisplayPercent(payload);
+    otaStatusRef.current = payload;
     setOtaStatus(payload);
+    setOtaDisplayPercent(displayPercent);
     setOtaStatusMessage(null);
     if (payload.status === 'complete' || payload.status === 'failed') {
       setOtaUpdateAvailable(false);
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);
+    schedulePostOtaCheck(payload);
   }
 
   function applyStreamStatus(payload: StreamStatusEvent) {
@@ -2991,6 +3069,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     micPlaying,
     micRecording,
     otaStatus,
+    otaDisplayPercent,
     otaStatusMessage,
     otaUpdateAvailable,
     openBluetoothSettings,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1044,7 +1044,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function updateOtaDisplayPercent(payload: OtaStatusEvent) {
     const incomingPercent = Math.max(0, Math.min(payload.overall_percent ?? 0, 100));
-    const sessionId = payload.session_id || `${payload.current_step}:${payload.total_steps}:${payload.step_type}`;
+    const sessionId = otaStatusSessionKey(payload);
     const previous =
       otaDisplayProgressRef.current?.sessionId === sessionId
         ? otaDisplayProgressRef.current.percent
@@ -1064,7 +1064,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (payload.status !== 'complete') {
       return;
     }
-    const sessionId = payload.session_id || `${payload.current_step}:${payload.total_steps}:${payload.step_type}`;
+    const sessionId = otaStatusSessionKey(payload);
     if (postOtaCheckInProgressRef.current || postOtaCheckedSessionRef.current === sessionId) {
       return;
     }
@@ -3975,6 +3975,10 @@ function clampRounded(value: number, min: number, max: number) {
 
 function roiPositionLabel(roiPosition: CameraRoiPosition) {
   return CAMERA_ROI_POSITIONS.find((option) => option.value === roiPosition)?.label ?? 'Center';
+}
+
+function otaStatusSessionKey(status: OtaStatusEvent) {
+  return status.session_id || 'current-ota';
 }
 
 function formatError(error: unknown) {


### PR DESCRIPTION
## Summary
- Trigger one session-guarded OTA re-check after OTA `complete` events in the React Native, Android, and iOS examples.
- Clear terminal OTA progress through the existing check-result path so the examples show the fresh up-to-date/update-required state after completion.
- Keep the displayed OTA percentage monotonic within a session so an install-phase `0%` event does not visually regress after download reaches `100%`.

## Validation
- `bunx tsc --noEmit` from `examples/react-native`
- `./gradlew :app:compileDebugKotlin` from `examples/android`
- `./gradlew :app:assembleDebug` from `examples/android`
- `xcodebuild -project examples/ios/MentraExample.xcodeproj -scheme MentraExample -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO`

Note: the iOS validation uses a generic device build because the local GStreamer framework is device-only and the simulator link step rejects it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to example app OTA UI/state; no production SDK or firmware logic is modified.
> 
> **Overview**
> Aligns **Android, iOS, and React Native** example apps so OTA UI stays accurate through download, install, and completion.
> 
> Each platform now keeps a session-scoped **`otaDisplayPercent`** that only moves forward (e.g. install-phase `0%` no longer drops the bar after download reached `100%`). Progress bars and status lines read this value instead of raw `overall_percent`.
> 
> When an OTA reports **`complete`**, the examples run a **one-time, session-guarded** `checkForOtaUpdate` (skipped if Wi‑Fi is unavailable) so the card can settle on “up to date” or “update required” via the existing check-result path. Display progress and post-check flags reset on disconnect, manual check, and new update starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb1be34c5472873b9f141c1d562439a4e3ed247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->