### PR TITLE
Add photo request tuning controls

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -632,6 +632,25 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         state = state.copy(photoIspAnalogGain = gain?.takeIf { it in photoIspAnalogGainOptions })
     }
 
+    fun applyBarcodeScanPhotoPreset() {
+        val preset = scanButtonPreset(3, 800)
+        state = state.copy(
+            photoSize = "max",
+            photoCompression = "none",
+            photoExposureManual = true,
+            photoExposureTimeNs = PHOTO_EXPOSURE_DEFAULT_NS,
+            photoIso = PHOTO_ISO_DEFAULT,
+            photoAeExposureDivisor = preset.aeExposureDivisor,
+            photoIsoCap = preset.isoCap,
+            photoNoiseReduction = preset.noiseReduction,
+            photoEdgeEnhancement = preset.edgeEnhancement,
+            photoMfnr = preset.mfnr,
+            photoZsl = preset.zsl,
+            photoIspDigitalGain = preset.ispDigitalGain,
+            photoIspAnalogGain = preset.ispAnalogGain,
+        )
+    }
+
     fun setPhotoExposureManual(enabled: Boolean) {
         state = state.copy(photoExposureManual = enabled)
     }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -525,14 +525,19 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     fun setPhotoSize(size: String) {
         state = state.copy(photoSize = size)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoCompression(compression: String) {
         state = state.copy(photoCompression = compression)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setScanMode(enabled: Boolean) {
         state = state.copy(scanMode = enabled)
+        if (enabled) {
+            applyBarcodeScanPhotoPreset()
+        }
         if (!isGlassesConnected()) {
             return
         }
@@ -541,7 +546,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             // Keep hardware-button captures at max detail while scan mode is enabled.
             val settings =
                 if (enabled) {
-                    scanButtonPreset(state.scanAeDivisor, state.scanIsoCap)
+                    scanButtonPreset()
                 } else {
                     ButtonPhotoSettings(
                         size = buttonPhotoSizeToSdk(state.photoSize),
@@ -556,36 +561,36 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     fun setScanAeDivisor(divisor: Int) {
         val nextDivisor = if (divisor > 3) 5 else 3
-        state = state.copy(scanAeDivisor = nextDivisor)
+        state = state.copy(scanAeDivisor = nextDivisor, photoAeExposureDivisor = nextDivisor)
         if (state.scanMode) {
-            pushScanButtonPreset(nextDivisor, state.scanIsoCap)
+            pushScanButtonPreset()
         }
     }
 
     fun setScanIsoCap(isoCap: Int) {
         val nextIsoCap = if (isoCap <= 400) 400 else 800
-        state = state.copy(scanIsoCap = nextIsoCap)
+        state = state.copy(scanIsoCap = nextIsoCap, photoIsoCap = nextIsoCap)
         if (state.scanMode) {
-            pushScanButtonPreset(state.scanAeDivisor, nextIsoCap)
+            pushScanButtonPreset()
         }
     }
 
-    private fun scanButtonPreset(aeDivisor: Int, isoCap: Int) =
+    private fun scanButtonPreset() =
         ButtonPhotoSettings(
-            size = ButtonPhotoSize.MAX,
-            mfnr = false,
-            zsl = false,
-            noiseReduction = false,
-            edgeEnhancement = false,
-            ispDigitalGain = 0,
-            ispAnalogGain = "low",
-            aeExposureDivisor = aeDivisor,
-            isoCap = isoCap,
-            compress = "none",
+            size = buttonPhotoSizeToSdk(state.photoSize),
+            mfnr = state.photoMfnr,
+            zsl = state.photoZsl,
+            noiseReduction = state.photoNoiseReduction,
+            edgeEnhancement = state.photoEdgeEnhancement,
+            ispDigitalGain = state.photoIspDigitalGain,
+            ispAnalogGain = state.photoIspAnalogGain,
+            aeExposureDivisor = state.photoAeExposureDivisor,
+            isoCap = state.photoIsoCap,
+            compress = state.photoCompression,
             sound = false,
         )
 
-    private fun pushScanButtonPreset(aeDivisor: Int, isoCap: Int) {
+    private fun pushScanButtonPreset() {
         if (!isGlassesConnected()) {
             return
         }
@@ -593,61 +598,80 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         runAction("Apply scan preset on glasses") {
             requireConnected("sync photo capture settings")
             withContext(Dispatchers.IO) {
-                mentraBluetoothSdk.setButtonPhotoSettings(
-                    scanButtonPreset(aeDivisor, isoCap),
-                )
+                mentraBluetoothSdk.setButtonPhotoSettings(scanButtonPreset())
             }
+        }
+    }
+
+    private fun syncScanButtonPresetIfEnabled() {
+        if (state.scanMode) {
+            pushScanButtonPreset()
         }
     }
 
     fun setPhotoAeExposureDivisor(divisor: Int?) {
         state = state.copy(photoAeExposureDivisor = divisor?.takeIf { it in photoAeExposureDivisorOptions })
+        if (state.photoAeExposureDivisor == 3 || state.photoAeExposureDivisor == 5) {
+            state = state.copy(scanAeDivisor = state.photoAeExposureDivisor!!)
+        }
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoIsoCap(isoCap: Int?) {
         state = state.copy(photoIsoCap = isoCap?.takeIf { it in photoIsoCapOptions })
+        if (state.photoIsoCap == 400 || state.photoIsoCap == 800) {
+            state = state.copy(scanIsoCap = state.photoIsoCap!!)
+        }
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoNoiseReduction(value: Boolean?) {
         state = state.copy(photoNoiseReduction = value)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoEdgeEnhancement(value: Boolean?) {
         state = state.copy(photoEdgeEnhancement = value)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoMfnr(value: Boolean?) {
         state = state.copy(photoMfnr = value)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoZsl(value: Boolean?) {
         state = state.copy(photoZsl = value)
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoIspDigitalGain(gain: Int?) {
         state = state.copy(photoIspDigitalGain = gain?.takeIf { it in photoIspDigitalGainOptions })
+        syncScanButtonPresetIfEnabled()
     }
 
     fun setPhotoIspAnalogGain(gain: String?) {
         state = state.copy(photoIspAnalogGain = gain?.takeIf { it in photoIspAnalogGainOptions })
+        syncScanButtonPresetIfEnabled()
     }
 
     fun applyBarcodeScanPhotoPreset() {
-        val preset = scanButtonPreset(3, 800)
         state = state.copy(
             photoSize = "max",
             photoCompression = "none",
             photoExposureManual = true,
             photoExposureTimeNs = PHOTO_EXPOSURE_DEFAULT_NS,
             photoIso = PHOTO_ISO_DEFAULT,
-            photoAeExposureDivisor = preset.aeExposureDivisor,
-            photoIsoCap = preset.isoCap,
-            photoNoiseReduction = preset.noiseReduction,
-            photoEdgeEnhancement = preset.edgeEnhancement,
-            photoMfnr = preset.mfnr,
-            photoZsl = preset.zsl,
-            photoIspDigitalGain = preset.ispDigitalGain,
-            photoIspAnalogGain = preset.ispAnalogGain,
+            scanAeDivisor = 3,
+            scanIsoCap = 800,
+            photoAeExposureDivisor = 3,
+            photoIsoCap = 800,
+            photoNoiseReduction = false,
+            photoEdgeEnhancement = false,
+            photoMfnr = false,
+            photoZsl = false,
+            photoIspDigitalGain = 0,
+            photoIspAnalogGain = "low",
         )
     }
 
@@ -705,7 +729,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
     }
 
-    fun captureAndUpload() = runAction("Capture & upload") {
+    fun captureAndUpload() = runAction(if (state.scanMode) "Capture scan photo" else "Capture & upload") {
         requireConnected("capture photos")
         requireGlassesWifi("capture photos")
         if (state.photoDestination == PhotoDestination.THIS_PHONE) {
@@ -794,33 +818,13 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     private fun buildPhotoRequest(requestId: String, appId: String, webhookUrl: String): PhotoRequest {
-        if (state.scanMode) {
-            // Hardware-button scan settings are synced separately.
-            // App-triggered captures use max detail to match the scan preset's output tier.
-            return PhotoRequest(
-                requestId = requestId,
-                appId = appId,
-                size = PhotoSize.MAX,
-                webhookUrl = webhookUrl,
-                compress = PhotoCompression.NONE,
-                sound = false,
-                aeExposureDivisor = state.scanAeDivisor,
-                isoCap = state.scanIsoCap,
-                noiseReduction = false,
-                edgeEnhancement = false,
-                mfnr = false,
-                zsl = false,
-                ispDigitalGain = 0,
-                ispAnalogGain = "low",
-            )
-        }
         return PhotoRequest(
             requestId = requestId,
             appId = appId,
             size = photoSizeToSdk(state.photoSize),
             webhookUrl = webhookUrl,
             compress = PhotoCompression.fromValue(state.photoCompression),
-            sound = true,
+            sound = !state.scanMode,
             exposureTimeNs = if (state.photoExposureManual) state.photoExposureTimeNs.toDouble() else null,
             iso = if (state.photoExposureManual) state.photoIso else null,
             aeExposureDivisor = state.photoAeExposureDivisor,
@@ -1723,7 +1727,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             refreshGlassesMediaVolume()
             // Re-apply scan preset after reconnect so button captures stay in sync.
             if (state.scanMode) {
-                pushScanButtonPreset(state.scanAeDivisor, state.scanIsoCap)
+                pushScanButtonPreset()
             }
         }
         maybeAutoCheckOta()
@@ -3066,8 +3070,6 @@ fun cameraSdkCall(
     cameraFov: Int,
     cameraRoiPosition: Int,
     scanMode: Boolean,
-    scanAeDivisor: Int,
-    scanIsoCap: Int,
 ): String {
     val prefix = """
 val cameraFovResult = mentraBluetoothSdk.setCameraFov(
@@ -3092,30 +3094,6 @@ val stopped = mentraBluetoothSdk.stopVideoRecording(videoRequestId, uploadUrl)
 println("Video stopped: ${'$'}{stopped.status}")
 """.trimIndent()
     }
-    if (scanMode) {
-        return """
-$prefix
-val photo = mentraBluetoothSdk.requestPhoto(
-    PhotoRequest(
-      requestId = requestId,
-      appId = "com.mentra.bluetoothsdk.example.android",
-      size = PhotoSize.MAX,
-      webhookUrl = uploadUrl,
-      compress = PhotoCompression.NONE,
-      sound = false,
-      aeExposureDivisor = $scanAeDivisor,
-      isoCap = $scanIsoCap,
-      noiseReduction = false,
-      edgeEnhancement = false,
-      mfnr = false,
-      zsl = false,
-      ispDigitalGain = 0,
-      ispAnalogGain = "low",
-    )
-)
-println("Scan photo delivered: ${'$'}{photo.response.requestId}")
-""".trimIndent()
-    }
     val tuningLines = listOfNotNull(
         aeExposureDivisor?.let { "      aeExposureDivisor = $it," },
         isoCap?.let { "      isoCap = $it," },
@@ -3136,7 +3114,7 @@ val photo = mentraBluetoothSdk.requestPhoto(
       size = PhotoSize.${when(size) { "low" -> "LOW"; "high" -> "HIGH"; "max" -> "MAX"; else -> "MEDIUM" }},
       webhookUrl = uploadUrl,
       compress = PhotoCompression.${compression.uppercase(Locale.US)},
-      sound = true,
+      sound = ${if (scanMode) "false" else "true"},
       exposureTimeNs = ${if (exposureManual) exposureTimeNs else "null"},
       iso = ${if (exposureManual) iso else "null"},
 $optionalTuningLines

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -80,6 +80,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
@@ -332,6 +334,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
     private var latestOtaVersionInfoSignature: String? = null
+    private val buttonPhotoSettingsSyncMutex = Mutex()
+    private var buttonPhotoSettingsSyncGeneration = 0
 
     private val micSampleRate = 16_000
     private val micChannelCount = 1
@@ -541,22 +545,21 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected()) {
             return
         }
-        runAction(if (enabled) "Apply scan preset on glasses" else "Restore photo preset on glasses") {
-            requireConnected("sync photo capture settings")
-            // Keep hardware-button captures at max detail while scan mode is enabled.
-            val settings =
-                if (enabled) {
-                    scanButtonPreset()
-                } else {
-                    ButtonPhotoSettings(
-                        size = buttonPhotoSizeToSdk(state.photoSize),
-                        mfnr = true,
-                        zsl = true,
-                        resetCaptureTuning = true,
-                    )
-                }
-            withContext(Dispatchers.IO) { mentraBluetoothSdk.setButtonPhotoSettings(settings) }
-        }
+        val settings =
+            if (enabled) {
+                scanButtonPreset()
+            } else {
+                ButtonPhotoSettings(
+                    size = buttonPhotoSizeToSdk(state.photoSize),
+                    mfnr = true,
+                    zsl = true,
+                    resetCaptureTuning = true,
+                )
+            }
+        syncButtonPhotoSettings(
+            if (enabled) "Apply scan preset on glasses" else "Restore photo preset on glasses",
+            settings,
+        )
     }
 
     fun setScanAeDivisor(divisor: Int) {
@@ -594,11 +597,20 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected()) {
             return
         }
-        // Re-assert the max-size scan button preset so the hardware button stays in sync.
-        runAction("Apply scan preset on glasses") {
+        syncButtonPhotoSettings("Apply scan preset on glasses", scanButtonPreset())
+    }
+
+    private fun syncButtonPhotoSettings(label: String, settings: ButtonPhotoSettings) {
+        val generation = ++buttonPhotoSettingsSyncGeneration
+        runAction(label) {
             requireConnected("sync photo capture settings")
-            withContext(Dispatchers.IO) {
-                mentraBluetoothSdk.setButtonPhotoSettings(scanButtonPreset())
+            buttonPhotoSettingsSyncMutex.withLock {
+                if (generation != buttonPhotoSettingsSyncGeneration) {
+                    return@withLock
+                }
+                withContext(Dispatchers.IO) {
+                    mentraBluetoothSdk.setButtonPhotoSettings(settings)
+                }
             }
         }
     }
@@ -656,6 +668,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     fun applyBarcodeScanPhotoPreset() {
+        // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
         state = state.copy(
             photoSize = "max",
             photoCompression = "none",

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -673,13 +673,11 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     fun applyBarcodeScanPhotoPreset() {
-        // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
+        // Barcode scan tuning relies on ASG auto metering plus AE divisor / ISO cap.
         state = state.copy(
             photoSize = "max",
             photoCompression = "none",
-            photoExposureManual = true,
-            photoExposureTimeNs = PHOTO_EXPOSURE_DEFAULT_NS,
-            photoIso = PHOTO_ISO_DEFAULT,
+            photoExposureManual = false,
             scanAeDivisor = 3,
             scanIsoCap = 800,
             photoAeExposureDivisor = 3,
@@ -845,8 +843,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             sound = !state.scanMode,
             exposureTimeNs = if (state.photoExposureManual) state.photoExposureTimeNs.toDouble() else null,
             iso = if (state.photoExposureManual) state.photoIso else null,
-            aeExposureDivisor = state.photoAeExposureDivisor,
-            isoCap = state.photoIsoCap,
+            aeExposureDivisor = if (state.photoExposureManual) null else state.photoAeExposureDivisor,
+            isoCap = if (state.photoExposureManual) null else state.photoIsoCap,
             noiseReduction = state.photoNoiseReduction,
             edgeEnhancement = state.photoEdgeEnhancement,
             mfnr = state.photoMfnr,
@@ -3175,9 +3173,11 @@ val stopped = mentraBluetoothSdk.stopVideoRecording(videoRequestId, uploadUrl)
 println("Video stopped: ${'$'}{stopped.status}")
 """.trimIndent()
     }
+    val effectiveAeExposureDivisor = if (exposureManual) null else aeExposureDivisor
+    val effectiveIsoCap = if (exposureManual) null else isoCap
     val tuningLines = listOfNotNull(
-        aeExposureDivisor?.let { "      aeExposureDivisor = $it," },
-        isoCap?.let { "      isoCap = $it," },
+        effectiveAeExposureDivisor?.let { "      aeExposureDivisor = $it," },
+        effectiveIsoCap?.let { "      isoCap = $it," },
         noiseReduction?.let { "      noiseReduction = $it," },
         edgeEnhancement?.let { "      edgeEnhancement = $it," },
         mfnr?.let { "      mfnr = $it," },

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -596,7 +596,18 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             isoCap = state.photoIsoCap,
             compress = state.photoCompression,
             sound = false,
+            resetCaptureTuning = shouldResetCaptureTuning(),
         )
+
+    private fun shouldResetCaptureTuning() =
+        state.photoAeExposureDivisor == null ||
+            state.photoIsoCap == null ||
+            state.photoNoiseReduction == null ||
+            state.photoEdgeEnhancement == null ||
+            state.photoMfnr == null ||
+            state.photoZsl == null ||
+            state.photoIspDigitalGain == null ||
+            state.photoIspAnalogGain == null
 
     private fun pushScanButtonPreset() {
         if (!isGlassesConnected()) {

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -195,6 +195,10 @@ const val PHOTO_ISO_DEFAULT = 200
 const val CAMERA_FOV_MIN = 62
 const val CAMERA_FOV_MAX = 118
 const val CAMERA_FOV_DEFAULT = 102
+val photoAeExposureDivisorOptions = listOf(2, 3, 5)
+val photoIsoCapOptions = listOf(400, 800, 1600)
+val photoIspDigitalGainOptions = listOf(0, 1, 2, 4)
+val photoIspAnalogGainOptions = listOf("low")
 val cameraRoiPositions = listOf("Center" to 0, "Bottom" to 1, "Top" to 2)
 
 data class MentraExampleState(
@@ -239,6 +243,14 @@ data class MentraExampleState(
     val scanMode: Boolean = false,
     val scanAeDivisor: Int = 3,
     val scanIsoCap: Int = 800,
+    val photoAeExposureDivisor: Int? = null,
+    val photoIsoCap: Int? = null,
+    val photoNoiseReduction: Boolean? = null,
+    val photoEdgeEnhancement: Boolean? = null,
+    val photoMfnr: Boolean? = null,
+    val photoZsl: Boolean? = null,
+    val photoIspDigitalGain: Int? = null,
+    val photoIspAnalogGain: String? = null,
     val photoExposureManual: Boolean = false,
     val photoExposureTimeNs: Int = PHOTO_EXPOSURE_DEFAULT_NS,
     val photoIso: Int = PHOTO_ISO_DEFAULT,
@@ -529,9 +541,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             // Keep hardware-button captures at max detail while scan mode is enabled.
             val settings =
                 if (enabled) {
-                    ButtonPhotoSettings(size = ButtonPhotoSize.MAX)
+                    scanButtonPreset(state.scanAeDivisor, state.scanIsoCap)
                 } else {
-                    ButtonPhotoSettings(size = buttonPhotoSizeToSdk(state.photoSize))
+                    ButtonPhotoSettings(
+                        size = buttonPhotoSizeToSdk(state.photoSize),
+                        mfnr = true,
+                        zsl = true,
+                        resetCaptureTuning = true,
+                    )
                 }
             withContext(Dispatchers.IO) { mentraBluetoothSdk.setButtonPhotoSettings(settings) }
         }
@@ -553,6 +570,21 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
     }
 
+    private fun scanButtonPreset(aeDivisor: Int, isoCap: Int) =
+        ButtonPhotoSettings(
+            size = ButtonPhotoSize.MAX,
+            mfnr = false,
+            zsl = false,
+            noiseReduction = false,
+            edgeEnhancement = false,
+            ispDigitalGain = 0,
+            ispAnalogGain = "low",
+            aeExposureDivisor = aeDivisor,
+            isoCap = isoCap,
+            compress = "none",
+            sound = false,
+        )
+
     private fun pushScanButtonPreset(aeDivisor: Int, isoCap: Int) {
         if (!isGlassesConnected()) {
             return
@@ -562,10 +594,42 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             requireConnected("sync photo capture settings")
             withContext(Dispatchers.IO) {
                 mentraBluetoothSdk.setButtonPhotoSettings(
-                    ButtonPhotoSettings(size = ButtonPhotoSize.MAX),
+                    scanButtonPreset(aeDivisor, isoCap),
                 )
             }
         }
+    }
+
+    fun setPhotoAeExposureDivisor(divisor: Int?) {
+        state = state.copy(photoAeExposureDivisor = divisor?.takeIf { it in photoAeExposureDivisorOptions })
+    }
+
+    fun setPhotoIsoCap(isoCap: Int?) {
+        state = state.copy(photoIsoCap = isoCap?.takeIf { it in photoIsoCapOptions })
+    }
+
+    fun setPhotoNoiseReduction(value: Boolean?) {
+        state = state.copy(photoNoiseReduction = value)
+    }
+
+    fun setPhotoEdgeEnhancement(value: Boolean?) {
+        state = state.copy(photoEdgeEnhancement = value)
+    }
+
+    fun setPhotoMfnr(value: Boolean?) {
+        state = state.copy(photoMfnr = value)
+    }
+
+    fun setPhotoZsl(value: Boolean?) {
+        state = state.copy(photoZsl = value)
+    }
+
+    fun setPhotoIspDigitalGain(gain: Int?) {
+        state = state.copy(photoIspDigitalGain = gain?.takeIf { it in photoIspDigitalGainOptions })
+    }
+
+    fun setPhotoIspAnalogGain(gain: String?) {
+        state = state.copy(photoIspAnalogGain = gain?.takeIf { it in photoIspAnalogGainOptions })
     }
 
     fun setPhotoExposureManual(enabled: Boolean) {
@@ -721,6 +785,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 webhookUrl = webhookUrl,
                 compress = PhotoCompression.NONE,
                 sound = false,
+                aeExposureDivisor = state.scanAeDivisor,
+                isoCap = state.scanIsoCap,
+                noiseReduction = false,
+                edgeEnhancement = false,
+                mfnr = false,
+                zsl = false,
+                ispDigitalGain = 0,
+                ispAnalogGain = "low",
             )
         }
         return PhotoRequest(
@@ -732,6 +804,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             sound = true,
             exposureTimeNs = if (state.photoExposureManual) state.photoExposureTimeNs.toDouble() else null,
             iso = if (state.photoExposureManual) state.photoIso else null,
+            aeExposureDivisor = state.photoAeExposureDivisor,
+            isoCap = state.photoIsoCap,
+            noiseReduction = state.photoNoiseReduction,
+            edgeEnhancement = state.photoEdgeEnhancement,
+            mfnr = state.photoMfnr,
+            zsl = state.photoZsl,
+            ispDigitalGain = state.photoIspDigitalGain,
+            ispAnalogGain = state.photoIspAnalogGain,
         )
     }
 
@@ -2953,6 +3033,14 @@ fun cameraSdkCall(
     mode: String,
     size: String,
     compression: String,
+    aeExposureDivisor: Int?,
+    isoCap: Int?,
+    noiseReduction: Boolean?,
+    edgeEnhancement: Boolean?,
+    mfnr: Boolean?,
+    zsl: Boolean?,
+    ispDigitalGain: Int?,
+    ispAnalogGain: String?,
     exposureManual: Boolean,
     exposureTimeNs: Int,
     iso: Int,
@@ -3001,11 +3089,25 @@ val photo = mentraBluetoothSdk.requestPhoto(
       noiseReduction = false,
       edgeEnhancement = false,
       mfnr = false,
+      zsl = false,
+      ispDigitalGain = 0,
+      ispAnalogGain = "low",
     )
 )
 println("Scan photo delivered: ${'$'}{photo.response.requestId}")
 """.trimIndent()
     }
+    val tuningLines = listOfNotNull(
+        aeExposureDivisor?.let { "      aeExposureDivisor = $it," },
+        isoCap?.let { "      isoCap = $it," },
+        noiseReduction?.let { "      noiseReduction = $it," },
+        edgeEnhancement?.let { "      edgeEnhancement = $it," },
+        mfnr?.let { "      mfnr = $it," },
+        zsl?.let { "      zsl = $it," },
+        ispDigitalGain?.let { "      ispDigitalGain = $it," },
+        ispAnalogGain?.let { "      ispAnalogGain = \"$it\"," },
+    ).joinToString("\n")
+    val optionalTuningLines = if (tuningLines.isBlank()) "" else "\n$tuningLines"
     return """
 $prefix
 val photo = mentraBluetoothSdk.requestPhoto(
@@ -3018,6 +3120,7 @@ val photo = mentraBluetoothSdk.requestPhoto(
       sound = true,
       exposureTimeNs = ${if (exposureManual) exposureTimeNs else "null"},
       iso = ${if (exposureManual) iso else "null"},
+$optionalTuningLines
     )
 )
 println("Photo delivered: ${'$'}{photo.response.requestId}")

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -122,8 +122,6 @@ fun CameraScreen(controller: MentraExampleController) {
         state.cameraFov,
         state.cameraRoiPosition,
         state.scanMode,
-        state.scanAeDivisor,
-        state.scanIsoCap,
     )
     val clipboardManager = LocalClipboardManager.current
     var photoDetailsExpanded by remember { mutableStateOf(false) }
@@ -557,8 +555,7 @@ fun CameraScreen(controller: MentraExampleController) {
                         photoSizeOptions.forEach { size ->
                             OptionChip(
                                 size,
-                                !state.scanMode && state.photoSize == size,
-                                enabled = !state.scanMode,
+                                state.photoSize == size,
                             ) { controller.setPhotoSize(size) }
                         }
                     }
@@ -569,10 +566,8 @@ fun CameraScreen(controller: MentraExampleController) {
                             }
                         }
                     }
-                    if (!state.scanMode) {
-                        ExposureSettingsCard(controller)
-                        PhotoRequestTuningSettingsCard(controller)
-                    }
+                    ExposureSettingsCard(controller)
+                    PhotoRequestTuningSettingsCard(controller)
                 }
                 CameraFovSettingsCard(controller)
             }
@@ -597,7 +592,7 @@ private fun ScanModeSettingsCard(controller: MentraExampleController) {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text("SCAN MODE", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
                 Text(
-                    if (state.scanMode) "Document / barcode capture preset" else "Standard photo capture",
+                    if (state.scanMode) "Barcode capture preset" else "Standard photo capture",
                     color = AppColor.greenAccent,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
@@ -607,19 +602,11 @@ private fun ScanModeSettingsCard(controller: MentraExampleController) {
         }
         if (state.scanMode) {
             Text(
-                "Syncs max-size preset to the glasses hardware button. Tap Capture to take a max-res, no-compression scan photo via the app.",
+                "Applies the barcode capture preset and keeps the glasses button preset in sync. Tune the live request fields below.",
                 color = AppColor.muted,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
             )
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OptionChip("AE ÷3", state.scanAeDivisor == 3) { controller.setScanAeDivisor(3) }
-                OptionChip("AE ÷5", state.scanAeDivisor == 5) { controller.setScanAeDivisor(5) }
-            }
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OptionChip("ISO 800", state.scanIsoCap == 800) { controller.setScanIsoCap(800) }
-                OptionChip("ISO 400", state.scanIsoCap == 400) { controller.setScanIsoCap(400) }
-            }
         }
     }
 }
@@ -725,23 +712,9 @@ private fun PhotoRequestTuningSettingsCard(controller: MentraExampleController) 
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
-                Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
-            }
-            Text(
-                "Barcode preset",
-                color = AppColor.greenAccent,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier
-                    .clip(RoundedCornerShape(999.dp))
-                    .background(AppColor.greenAccent.copy(alpha = 0.16f))
-                    .border(1.dp, AppColor.greenAccent.copy(alpha = 0.28f), RoundedCornerShape(999.dp))
-                    .clickable { controller.applyBarcodeScanPhotoPreset() }
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
-            )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
+            Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
         }
         CameraOptionGroup("ae divisor") {
             OptionChip("Unset", state.photoAeExposureDivisor == null) { controller.setPhotoAeExposureDivisor(null) }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -131,7 +131,8 @@ fun CameraScreen(controller: MentraExampleController) {
             state.videoRecording ||
                 state.activeAction == "Start video recording" ||
                 state.activeAction == "Stop & upload video" -> captureMode = CameraCaptureMode.VIDEO
-            state.activeAction == "Capture & upload" -> captureMode = CameraCaptureMode.PHOTO
+            state.activeAction == "Capture & upload" ||
+                state.activeAction == "Capture scan photo" -> captureMode = CameraCaptureMode.PHOTO
         }
     }
     Column(modifier = Modifier.fillMaxSize().background(AppColor.bg).verticalScroll(rememberScrollState())) {

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -725,9 +725,23 @@ private fun PhotoRequestTuningSettingsCard(controller: MentraExampleController) 
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
-            Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
+                Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+            }
+            Text(
+                "Barcode preset",
+                color = AppColor.greenAccent,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(AppColor.greenAccent.copy(alpha = 0.16f))
+                    .border(1.dp, AppColor.greenAccent.copy(alpha = 0.28f), RoundedCornerShape(999.dp))
+                    .clickable { controller.applyBarcodeScanPhotoPreset() }
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            )
         }
         CameraOptionGroup("ae divisor") {
             OptionChip("Unset", state.photoAeExposureDivisor == null) { controller.setPhotoAeExposureDivisor(null) }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -603,7 +603,7 @@ private fun ScanModeSettingsCard(controller: MentraExampleController) {
         }
         if (state.scanMode) {
             Text(
-                "Applies the barcode capture preset and keeps the glasses button preset in sync. Tune the live request fields below.",
+                "Applies the AE-divisor / ISO-cap barcode preset and keeps the glasses button preset in sync.",
                 color = AppColor.muted,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
@@ -625,9 +625,9 @@ private fun ExposureSettingsCard(controller: MentraExampleController) {
     ) {
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("EXPOSURE", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
+                Text("MANUAL EXPOSURE", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
                 Text(
-                    if (state.photoExposureManual) exposureLabel(state.photoExposureTimeNs) else "Auto exposure",
+                    if (state.photoExposureManual) exposureLabel(state.photoExposureTimeNs) else "Auto metered by glasses",
                     color = AppColor.greenAccent,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
@@ -666,7 +666,7 @@ private fun ExposureSettingsCard(controller: MentraExampleController) {
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text("ISO", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
             Text(
-                if (state.photoExposureManual) "ISO ${state.photoIso}" else "Auto ISO",
+                if (state.photoExposureManual) "ISO ${state.photoIso}" else "Auto / derived ISO",
                 color = AppColor.greenAccent,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Bold,
@@ -705,6 +705,7 @@ private fun ExposureSettingsCard(controller: MentraExampleController) {
 @Composable
 private fun PhotoRequestTuningSettingsCard(controller: MentraExampleController) {
     val state = controller.state
+    val scanExposureEnabled = !state.photoExposureManual
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -715,20 +716,25 @@ private fun PhotoRequestTuningSettingsCard(controller: MentraExampleController) 
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
-            Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+            Text(
+                if (state.photoExposureManual) "AE divisor / ISO cap disabled in manual mode" else "Optional request parameters",
+                color = AppColor.greenAccent,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold
+            )
         }
         CameraOptionGroup("ae divisor") {
-            OptionChip("Unset", state.photoAeExposureDivisor == null) { controller.setPhotoAeExposureDivisor(null) }
+            OptionChip("Unset", state.photoAeExposureDivisor == null, enabled = scanExposureEnabled) { controller.setPhotoAeExposureDivisor(null) }
             photoAeExposureDivisorOptions.forEach { divisor ->
-                OptionChip("÷$divisor", state.photoAeExposureDivisor == divisor) {
+                OptionChip("÷$divisor", state.photoAeExposureDivisor == divisor, enabled = scanExposureEnabled) {
                     controller.setPhotoAeExposureDivisor(divisor)
                 }
             }
         }
         CameraOptionGroup("iso cap") {
-            OptionChip("Unset", state.photoIsoCap == null) { controller.setPhotoIsoCap(null) }
+            OptionChip("Unset", state.photoIsoCap == null, enabled = scanExposureEnabled) { controller.setPhotoIsoCap(null) }
             photoIsoCapOptions.forEach { isoCap ->
-                OptionChip("$isoCap", state.photoIsoCap == isoCap) { controller.setPhotoIsoCap(isoCap) }
+                OptionChip("$isoCap", state.photoIsoCap == isoCap, enabled = scanExposureEnabled) { controller.setPhotoIsoCap(isoCap) }
             }
         }
         TuningFlagOptionGroup("noise reduction", state.photoNoiseReduction, controller::setPhotoNoiseReduction)
@@ -1263,13 +1269,28 @@ private fun CameraOptionGroup(label: String, content: @Composable RowScope.() ->
 
 @Composable
 private fun OptionChip(value: String, active: Boolean, enabled: Boolean = true, onClick: () -> Unit) {
+    val backgroundColor = when {
+        !enabled -> Color.White.copy(alpha = 0.32f)
+        active -> AppColor.greenAccent.copy(alpha = 0.16f)
+        else -> Color.White.copy(alpha = 0.6f)
+    }
+    val borderColor = when {
+        !enabled -> AppColor.ink.copy(alpha = 0.04f)
+        active -> AppColor.greenAccent.copy(alpha = 0.32f)
+        else -> AppColor.ink.copy(alpha = 0.06f)
+    }
+    val textColor = when {
+        !enabled -> AppColor.muted.copy(alpha = 0.7f)
+        active -> AppColor.greenAccent
+        else -> AppColor.ink
+    }
     Row(
         modifier = Modifier
             .clip(RoundedCornerShape(999.dp))
-            .background(if (active) AppColor.greenAccent.copy(alpha = 0.16f) else Color.White.copy(alpha = 0.6f))
+            .background(backgroundColor)
             .border(
                 1.dp,
-                if (active) AppColor.greenAccent.copy(alpha = 0.32f) else AppColor.ink.copy(alpha = 0.06f),
+                borderColor,
                 RoundedCornerShape(999.dp)
             )
             .clickable(enabled = enabled) { onClick() }
@@ -1278,6 +1299,6 @@ private fun OptionChip(value: String, active: Boolean, enabled: Boolean = true, 
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        Text(value, color = if (active) AppColor.greenAccent else AppColor.ink, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+        Text(value, color = textColor, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1)
     }
 }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -65,7 +65,11 @@ import com.mentra.examples.android.cameraRoiPositions
 import com.mentra.examples.android.cameraSdkCall
 import com.mentra.examples.android.isGlassesConnected
 import com.mentra.examples.android.isGlassesWifiConnected
+import com.mentra.examples.android.photoAeExposureDivisorOptions
 import com.mentra.examples.android.photoCompressionOptions
+import com.mentra.examples.android.photoIspAnalogGainOptions
+import com.mentra.examples.android.photoIspDigitalGainOptions
+import com.mentra.examples.android.photoIsoCapOptions
 import com.mentra.examples.android.photoSizeOptions
 import com.mentra.examples.android.roiPositionLabel
 import com.mentra.examples.android.ui.AppColor
@@ -104,6 +108,14 @@ fun CameraScreen(controller: MentraExampleController) {
         if (videoMode) "video" else "photo",
         state.photoSize,
         state.photoCompression,
+        state.photoAeExposureDivisor,
+        state.photoIsoCap,
+        state.photoNoiseReduction,
+        state.photoEdgeEnhancement,
+        state.photoMfnr,
+        state.photoZsl,
+        state.photoIspDigitalGain,
+        state.photoIspAnalogGain,
         state.photoExposureManual,
         state.photoExposureTimeNs,
         state.photoIso,
@@ -557,7 +569,10 @@ fun CameraScreen(controller: MentraExampleController) {
                             }
                         }
                     }
-                    ExposureSettingsCard(controller)
+                    if (!state.scanMode) {
+                        ExposureSettingsCard(controller)
+                        PhotoRequestTuningSettingsCard(controller)
+                    }
                 }
                 CameraFovSettingsCard(controller)
             }
@@ -597,19 +612,13 @@ private fun ScanModeSettingsCard(controller: MentraExampleController) {
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
             )
-            Text(
-                "AE÷ and ISO cap will ship on app captures in SDK 0.1.13+. Until then these chips only update the hardware button preset.",
-                color = AppColor.muted,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.Normal,
-            )
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OptionChip("AE ÷3", state.scanAeDivisor == 3, enabled = false) { controller.setScanAeDivisor(3) }
-                OptionChip("AE ÷5", state.scanAeDivisor == 5, enabled = false) { controller.setScanAeDivisor(5) }
+                OptionChip("AE ÷3", state.scanAeDivisor == 3) { controller.setScanAeDivisor(3) }
+                OptionChip("AE ÷5", state.scanAeDivisor == 5) { controller.setScanAeDivisor(5) }
             }
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OptionChip("ISO 800", state.scanIsoCap == 800, enabled = false) { controller.setScanIsoCap(800) }
-                OptionChip("ISO 400", state.scanIsoCap == 400, enabled = false) { controller.setScanIsoCap(400) }
+                OptionChip("ISO 800", state.scanIsoCap == 800) { controller.setScanIsoCap(800) }
+                OptionChip("ISO 400", state.scanIsoCap == 400) { controller.setScanIsoCap(400) }
             }
         }
     }
@@ -638,31 +647,32 @@ private fun ExposureSettingsCard(controller: MentraExampleController) {
             }
             Switch(checked = state.photoExposureManual, onCheckedChange = controller::setPhotoExposureManual)
         }
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            SliderNudgeButton("-", enabled = state.photoExposureManual && state.photoExposureTimeNs > PHOTO_EXPOSURE_MIN_NS) {
-                controller.setPhotoExposureTimeNs(state.photoExposureTimeNs - 500_000)
+        if (state.photoExposureManual) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                SliderNudgeButton("-", enabled = state.photoExposureTimeNs > PHOTO_EXPOSURE_MIN_NS) {
+                    controller.setPhotoExposureTimeNs(state.photoExposureTimeNs - 500_000)
+                }
+                Slider(
+                    value = state.photoExposureTimeNs.toFloat(),
+                    onValueChange = { controller.setPhotoExposureTimeNs((it / 500_000f).roundToInt() * 500_000) },
+                    valueRange = PHOTO_EXPOSURE_MIN_NS.toFloat()..PHOTO_EXPOSURE_MAX_NS.toFloat(),
+                    modifier = Modifier.weight(1f),
+                )
+                SliderNudgeButton("+", enabled = state.photoExposureTimeNs < PHOTO_EXPOSURE_MAX_NS) {
+                    controller.setPhotoExposureTimeNs(state.photoExposureTimeNs + 500_000)
+                }
             }
-            Slider(
-                enabled = state.photoExposureManual,
-                value = state.photoExposureTimeNs.toFloat(),
-                onValueChange = { controller.setPhotoExposureTimeNs((it / 500_000f).roundToInt() * 500_000) },
-                valueRange = PHOTO_EXPOSURE_MIN_NS.toFloat()..PHOTO_EXPOSURE_MAX_NS.toFloat(),
-                modifier = Modifier.weight(1f),
-            )
-            SliderNudgeButton("+", enabled = state.photoExposureManual && state.photoExposureTimeNs < PHOTO_EXPOSURE_MAX_NS) {
-                controller.setPhotoExposureTimeNs(state.photoExposureTimeNs + 500_000)
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("1/1000s", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "Preset 1/120s",
+                    color = AppColor.greenAccent,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.clickable { controller.setPhotoExposureTimeNs(PHOTO_EXPOSURE_DEFAULT_NS) }
+                )
+                Text("1/30s", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
             }
-        }
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Text("1/1000s", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
-            Text(
-                "Default 1/120s",
-                color = AppColor.greenAccent,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.clickable { controller.setPhotoExposureTimeNs(PHOTO_EXPOSURE_DEFAULT_NS) }
-            )
-            Text("1/30s", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
         }
         Spacer(Modifier.height(4.dp))
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -674,32 +684,90 @@ private fun ExposureSettingsCard(controller: MentraExampleController) {
                 fontWeight = FontWeight.Bold,
             )
         }
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            SliderNudgeButton("-", enabled = state.photoExposureManual && state.photoIso > PHOTO_ISO_MIN) {
-                controller.setPhotoIso(state.photoIso - 50)
+        if (state.photoExposureManual) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                SliderNudgeButton("-", enabled = state.photoIso > PHOTO_ISO_MIN) {
+                    controller.setPhotoIso(state.photoIso - 50)
+                }
+                Slider(
+                    value = state.photoIso.toFloat(),
+                    onValueChange = { controller.setPhotoIso((it / 50f).roundToInt() * 50) },
+                    valueRange = PHOTO_ISO_MIN.toFloat()..PHOTO_ISO_MAX.toFloat(),
+                    modifier = Modifier.weight(1f),
+                )
+                SliderNudgeButton("+", enabled = state.photoIso < PHOTO_ISO_MAX) {
+                    controller.setPhotoIso(state.photoIso + 50)
+                }
             }
-            Slider(
-                enabled = state.photoExposureManual,
-                value = state.photoIso.toFloat(),
-                onValueChange = { controller.setPhotoIso((it / 50f).roundToInt() * 50) },
-                valueRange = PHOTO_ISO_MIN.toFloat()..PHOTO_ISO_MAX.toFloat(),
-                modifier = Modifier.weight(1f),
-            )
-            SliderNudgeButton("+", enabled = state.photoExposureManual && state.photoIso < PHOTO_ISO_MAX) {
-                controller.setPhotoIso(state.photoIso + 50)
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("ISO $PHOTO_ISO_MIN", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "Preset ISO $PHOTO_ISO_DEFAULT",
+                    color = AppColor.greenAccent,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.clickable { controller.setPhotoIso(PHOTO_ISO_DEFAULT) }
+                )
+                Text("ISO $PHOTO_ISO_MAX", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
             }
         }
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Text("ISO $PHOTO_ISO_MIN", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
-            Text(
-                "Default ISO $PHOTO_ISO_DEFAULT",
-                color = AppColor.greenAccent,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.clickable { controller.setPhotoIso(PHOTO_ISO_DEFAULT) }
-            )
-            Text("ISO $PHOTO_ISO_MAX", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun PhotoRequestTuningSettingsCard(controller: MentraExampleController) {
+    val state = controller.state
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(AppColor.ink.copy(alpha = 0.04f))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text("PHOTO REQUEST TUNING", color = AppColor.muted, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.1.sp)
+            Text("Optional request parameters", color = AppColor.greenAccent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
         }
+        CameraOptionGroup("ae divisor") {
+            OptionChip("Unset", state.photoAeExposureDivisor == null) { controller.setPhotoAeExposureDivisor(null) }
+            photoAeExposureDivisorOptions.forEach { divisor ->
+                OptionChip("÷$divisor", state.photoAeExposureDivisor == divisor) {
+                    controller.setPhotoAeExposureDivisor(divisor)
+                }
+            }
+        }
+        CameraOptionGroup("iso cap") {
+            OptionChip("Unset", state.photoIsoCap == null) { controller.setPhotoIsoCap(null) }
+            photoIsoCapOptions.forEach { isoCap ->
+                OptionChip("$isoCap", state.photoIsoCap == isoCap) { controller.setPhotoIsoCap(isoCap) }
+            }
+        }
+        TuningFlagOptionGroup("noise reduction", state.photoNoiseReduction, controller::setPhotoNoiseReduction)
+        TuningFlagOptionGroup("edge enhancement", state.photoEdgeEnhancement, controller::setPhotoEdgeEnhancement)
+        TuningFlagOptionGroup("mfnr", state.photoMfnr, controller::setPhotoMfnr)
+        TuningFlagOptionGroup("zsl", state.photoZsl, controller::setPhotoZsl)
+        CameraOptionGroup("isp digital gain") {
+            OptionChip("Unset", state.photoIspDigitalGain == null) { controller.setPhotoIspDigitalGain(null) }
+            photoIspDigitalGainOptions.forEach { gain ->
+                OptionChip("$gain", state.photoIspDigitalGain == gain) { controller.setPhotoIspDigitalGain(gain) }
+            }
+        }
+        CameraOptionGroup("isp analog gain") {
+            OptionChip("Unset", state.photoIspAnalogGain == null) { controller.setPhotoIspAnalogGain(null) }
+            photoIspAnalogGainOptions.forEach { gain ->
+                OptionChip(gain, state.photoIspAnalogGain == gain) { controller.setPhotoIspAnalogGain(gain) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TuningFlagOptionGroup(label: String, value: Boolean?, onChange: (Boolean?) -> Unit) {
+    CameraOptionGroup(label) {
+        OptionChip("Unset", value == null) { onChange(null) }
+        OptionChip("On", value == true) { onChange(true) }
+        OptionChip("Off", value == false) { onChange(false) }
     }
 }
 
@@ -758,7 +826,7 @@ private fun CameraFovSettingsCard(controller: MentraExampleController) {
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
             Text("${CAMERA_FOV_MIN}°", color = AppColor.muted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
             Text(
-                "Default ${CAMERA_FOV_DEFAULT}°",
+                "Preset ${CAMERA_FOV_DEFAULT}°",
                 color = if (controlsEnabled) AppColor.greenAccent else AppColor.muted,
                 fontSize = 11.sp,
                 fontWeight = FontWeight.SemiBold,

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -772,12 +772,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func applyBarcodeScanPhotoPreset() {
-        // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
+        // Barcode scan tuning relies on ASG auto metering plus AE divisor / ISO cap.
         photoSize = .max
         photoCompression = .none
-        photoExposureManual = true
-        photoExposureTimeNs = photoExposureDefaultNs
-        photoIso = photoIsoDefault
+        photoExposureManual = false
         scanAeDivisor = 3
         scanIsoCap = 800
         photoAeExposureDivisor = 3
@@ -926,8 +924,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             sound: !scanMode,
             exposureTimeNs: photoExposureManual ? Double(photoExposureTimeNs) : nil,
             iso: photoExposureManual ? photoIso : nil,
-            aeExposureDivisor: photoAeExposureDivisor,
-            isoCap: photoIsoCap,
+            aeExposureDivisor: photoExposureManual ? nil : photoAeExposureDivisor,
+            isoCap: photoExposureManual ? nil : photoIsoCap,
             noiseReduction: photoNoiseReduction,
             edgeEnhancement: photoEdgeEnhancement,
             mfnr: photoMfnr,

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -64,6 +64,10 @@ let photoIsoDefault = 200
 let cameraFovMin = 62
 let cameraFovMax = 118
 let cameraFovDefault = 102
+let photoAeExposureDivisorOptions = [2, 3, 5]
+let photoIsoCapOptions = [400, 800, 1600]
+let photoIspDigitalGainOptions = [0, 1, 2, 4]
+let photoIspAnalogGainOptions = ["low"]
 let cameraRoiPositions: [(label: String, value: Int)] = [("Center", 0), ("Bottom", 1), ("Top", 2)]
 
 enum PhotoDestination {
@@ -287,6 +291,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var scanAeDivisor = 3
     @Published private(set) var scanIsoCap = 800
     @Published private(set) var photoCompression: PhotoCompression = .none
+    @Published private(set) var photoAeExposureDivisor: Int?
+    @Published private(set) var photoIsoCap: Int?
+    @Published private(set) var photoNoiseReduction: Bool?
+    @Published private(set) var photoEdgeEnhancement: Bool?
+    @Published private(set) var photoMfnr: Bool?
+    @Published private(set) var photoZsl: Bool?
+    @Published private(set) var photoIspDigitalGain: Int?
+    @Published private(set) var photoIspAnalogGain: String?
     @Published private(set) var photoExposureManual = false
     @Published private(set) var photoExposureTimeNs = photoExposureDefaultNs
     @Published private(set) var photoIso = photoIsoDefault
@@ -625,12 +637,12 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 if enabled {
                     // Keep hardware-button captures at max detail while scan mode is enabled.
                     _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                        ButtonPhotoSettings(size: .max)
+                        scanButtonPreset(aeDivisor: scanAeDivisor, isoCap: scanIsoCap)
                     )
                 } else {
                     let size = ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max
                     _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                        ButtonPhotoSettings(size: size)
+                        ButtonPhotoSettings(size: size, mfnr: true, zsl: true, resetCaptureTuning: true)
                     )
                 }
             } catch {
@@ -661,12 +673,60 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         Task {
             do {
                 _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                    ButtonPhotoSettings(size: .max)
+                    scanButtonPreset(aeDivisor: aeDivisor, isoCap: isoCap)
                 )
             } catch {
                 cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
             }
         }
+    }
+
+    private func scanButtonPreset(aeDivisor: Int, isoCap: Int) -> ButtonPhotoSettings {
+        ButtonPhotoSettings(
+            size: .max,
+            mfnr: false,
+            zsl: false,
+            noiseReduction: false,
+            edgeEnhancement: false,
+            ispDigitalGain: 0,
+            ispAnalogGain: "low",
+            aeExposureDivisor: aeDivisor,
+            isoCap: isoCap,
+            compress: "none",
+            sound: false
+        )
+    }
+
+    func setPhotoAeExposureDivisor(_ divisor: Int?) {
+        photoAeExposureDivisor = divisor.flatMap { photoAeExposureDivisorOptions.contains($0) ? $0 : nil }
+    }
+
+    func setPhotoIsoCap(_ isoCap: Int?) {
+        photoIsoCap = isoCap.flatMap { photoIsoCapOptions.contains($0) ? $0 : nil }
+    }
+
+    func setPhotoNoiseReduction(_ value: Bool?) {
+        photoNoiseReduction = value
+    }
+
+    func setPhotoEdgeEnhancement(_ value: Bool?) {
+        photoEdgeEnhancement = value
+    }
+
+    func setPhotoMfnr(_ value: Bool?) {
+        photoMfnr = value
+    }
+
+    func setPhotoZsl(_ value: Bool?) {
+        photoZsl = value
+    }
+
+    func setPhotoIspDigitalGain(_ gain: Int?) {
+        photoIspDigitalGain = gain.flatMap { photoIspDigitalGainOptions.contains($0) ? $0 : nil }
+    }
+
+    func setPhotoIspAnalogGain(_ gain: String?) {
+        photoIspAnalogGain = gain.flatMap { photoIspAnalogGainOptions.contains($0) ? $0 : nil }
     }
 
     func setPhotoExposureManual(_ enabled: Bool) {
@@ -805,7 +865,15 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 size: .max,
                 webhookUrl: webhookUrl,
                 compress: PhotoCompression.none,
-                sound: false
+                sound: false,
+                aeExposureDivisor: scanAeDivisor,
+                isoCap: scanIsoCap,
+                noiseReduction: false,
+                edgeEnhancement: false,
+                mfnr: false,
+                zsl: false,
+                ispDigitalGain: 0,
+                ispAnalogGain: "low"
             )
         }
         return PhotoRequest(
@@ -816,7 +884,15 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             compress: photoCompression,
             sound: true,
             exposureTimeNs: photoExposureManual ? Double(photoExposureTimeNs) : nil,
-            iso: photoExposureManual ? photoIso : nil
+            iso: photoExposureManual ? photoIso : nil,
+            aeExposureDivisor: photoAeExposureDivisor,
+            isoCap: photoIsoCap,
+            noiseReduction: photoNoiseReduction,
+            edgeEnhancement: photoEdgeEnhancement,
+            mfnr: photoMfnr,
+            zsl: photoZsl,
+            ispDigitalGain: photoIspDigitalGain,
+            ispAnalogGain: photoIspAnalogGain
         )
     }
 

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -721,8 +721,20 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             aeExposureDivisor: photoAeExposureDivisor,
             isoCap: photoIsoCap,
             compress: photoCompression.rawValue,
-            sound: false
+            sound: false,
+            resetCaptureTuning: shouldResetCaptureTuning()
         )
+    }
+
+    private func shouldResetCaptureTuning() -> Bool {
+        photoAeExposureDivisor == nil ||
+            photoIsoCap == nil ||
+            photoNoiseReduction == nil ||
+            photoEdgeEnhancement == nil ||
+            photoMfnr == nil ||
+            photoZsl == nil ||
+            photoIspDigitalGain == nil ||
+            photoIspAnalogGain == nil
     }
 
     func setPhotoAeExposureDivisor(_ divisor: Int?) {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -729,6 +729,23 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         photoIspAnalogGain = gain.flatMap { photoIspAnalogGainOptions.contains($0) ? $0 : nil }
     }
 
+    func applyBarcodeScanPhotoPreset() {
+        let preset = scanButtonPreset(aeDivisor: 3, isoCap: 800)
+        photoSize = .max
+        photoCompression = .none
+        photoExposureManual = true
+        photoExposureTimeNs = photoExposureDefaultNs
+        photoIso = photoIsoDefault
+        photoAeExposureDivisor = preset.aeExposureDivisor
+        photoIsoCap = preset.isoCap
+        photoNoiseReduction = preset.noiseReduction
+        photoEdgeEnhancement = preset.edgeEnhancement
+        photoMfnr = preset.mfnr
+        photoZsl = preset.zsl
+        photoIspDigitalGain = preset.ispDigitalGain
+        photoIspAnalogGain = preset.ispAnalogGain
+    }
+
     func setPhotoExposureManual(_ enabled: Bool) {
         photoExposureManual = enabled
     }

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -272,6 +272,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var activeActions: [Int: String] = [:]
     private var activeActionOrder: [Int] = []
     private var streamConfigurationChangeInProgress = false
+    private var buttonPhotoSettingsSyncGeneration = 0
+    private var buttonPhotoSettingsSyncTask: Task<Void, Never>?
     @Published private(set) var cameraStatus = "Camera: phone receiver will start before capture"
     @Published var webhookUrl = defaultPhotoUploadUrl {
         didSet {
@@ -637,22 +639,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             applyBarcodeScanPhotoPreset()
         }
         guard glassesConnected else { return }
-        Task {
-            do {
-                if enabled {
-                    // Keep hardware-button captures at max detail while scan mode is enabled.
-                    _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                        scanButtonPreset()
-                    )
-                } else {
-                    let size = ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max
-                    _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                        ButtonPhotoSettings(size: size, mfnr: true, zsl: true, resetCaptureTuning: true)
-                    )
-                }
-            } catch {
-                cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
-            }
+        if enabled {
+            syncButtonPhotoSettings("Apply scan preset on glasses", settings: scanButtonPreset())
+        } else {
+            let size = ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max
+            syncButtonPhotoSettings(
+                "Restore photo preset on glasses",
+                settings: ButtonPhotoSettings(size: size, mfnr: true, zsl: true, resetCaptureTuning: true)
+            )
         }
     }
 
@@ -676,15 +670,28 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func pushScanButtonPreset() {
         guard glassesConnected else { return }
-        // Re-assert the max-size scan button preset so the hardware button stays in sync.
-        Task {
+        syncButtonPhotoSettings("Apply scan preset on glasses", settings: scanButtonPreset())
+    }
+
+    private func syncButtonPhotoSettings(_ label: String, settings: ButtonPhotoSettings) {
+        buttonPhotoSettingsSyncGeneration += 1
+        let generation = buttonPhotoSettingsSyncGeneration
+        let previousTask = buttonPhotoSettingsSyncTask
+        buttonPhotoSettingsSyncTask = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self, generation == self.buttonPhotoSettingsSyncGeneration, self.glassesConnected else { return }
+            let actionId = self.beginAction(label)
+            self.lastAction = "Running: \(label)"
+            self.append(tag: "TX", text: label)
             do {
-                _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                    scanButtonPreset()
-                )
+                _ = try await self.mentraBluetoothSdk.setButtonPhotoSettings(settings)
+                self.lastAction = "Requested: \(label)"
             } catch {
-                cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
+                self.cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
+                self.lastAction = "Failed: \(label) - \(error.localizedDescription)"
+                self.append(tag: "TX", text: "\(label) failed: \(error.localizedDescription)")
             }
+            self.endAction(actionId)
         }
     }
 
@@ -757,6 +764,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func applyBarcodeScanPhotoPreset() {
+        // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
         photoSize = .max
         photoCompression = .none
         photoExposureManual = true

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -623,21 +623,26 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     func setPhotoSize(_ size: PhotoSize) {
         photoSize = size
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoCompression(_ compression: PhotoCompression) {
         photoCompression = compression
+        syncScanButtonPresetIfEnabled()
     }
 
     func setScanMode(_ enabled: Bool) {
         scanMode = enabled
+        if enabled {
+            applyBarcodeScanPhotoPreset()
+        }
         guard glassesConnected else { return }
         Task {
             do {
                 if enabled {
                     // Keep hardware-button captures at max detail while scan mode is enabled.
                     _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                        scanButtonPreset(aeDivisor: scanAeDivisor, isoCap: scanIsoCap)
+                        scanButtonPreset()
                     )
                 } else {
                     let size = ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max
@@ -654,26 +659,28 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     func setScanAeDivisor(_ divisor: Int) {
         let nextDivisor = divisor > 3 ? 5 : 3
         scanAeDivisor = nextDivisor
+        photoAeExposureDivisor = nextDivisor
         if scanMode {
-            pushScanButtonPreset(aeDivisor: nextDivisor, isoCap: scanIsoCap)
+            pushScanButtonPreset()
         }
     }
 
     func setScanIsoCap(_ isoCap: Int) {
         let nextIsoCap = isoCap <= 400 ? 400 : 800
         scanIsoCap = nextIsoCap
+        photoIsoCap = nextIsoCap
         if scanMode {
-            pushScanButtonPreset(aeDivisor: scanAeDivisor, isoCap: nextIsoCap)
+            pushScanButtonPreset()
         }
     }
 
-    private func pushScanButtonPreset(aeDivisor: Int, isoCap: Int) {
+    private func pushScanButtonPreset() {
         guard glassesConnected else { return }
         // Re-assert the max-size scan button preset so the hardware button stays in sync.
         Task {
             do {
                 _ = try await mentraBluetoothSdk.setButtonPhotoSettings(
-                    scanButtonPreset(aeDivisor: aeDivisor, isoCap: isoCap)
+                    scanButtonPreset()
                 )
             } catch {
                 cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
@@ -681,69 +688,90 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func scanButtonPreset(aeDivisor: Int, isoCap: Int) -> ButtonPhotoSettings {
+    private func syncScanButtonPresetIfEnabled() {
+        if scanMode {
+            pushScanButtonPreset()
+        }
+    }
+
+    private func scanButtonPreset() -> ButtonPhotoSettings {
         ButtonPhotoSettings(
-            size: .max,
-            mfnr: false,
-            zsl: false,
-            noiseReduction: false,
-            edgeEnhancement: false,
-            ispDigitalGain: 0,
-            ispAnalogGain: "low",
-            aeExposureDivisor: aeDivisor,
-            isoCap: isoCap,
-            compress: "none",
+            size: ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max,
+            mfnr: photoMfnr,
+            zsl: photoZsl,
+            noiseReduction: photoNoiseReduction,
+            edgeEnhancement: photoEdgeEnhancement,
+            ispDigitalGain: photoIspDigitalGain,
+            ispAnalogGain: photoIspAnalogGain,
+            aeExposureDivisor: photoAeExposureDivisor,
+            isoCap: photoIsoCap,
+            compress: photoCompression.rawValue,
             sound: false
         )
     }
 
     func setPhotoAeExposureDivisor(_ divisor: Int?) {
         photoAeExposureDivisor = divisor.flatMap { photoAeExposureDivisorOptions.contains($0) ? $0 : nil }
+        if photoAeExposureDivisor == 3 || photoAeExposureDivisor == 5 {
+            scanAeDivisor = photoAeExposureDivisor!
+        }
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoIsoCap(_ isoCap: Int?) {
         photoIsoCap = isoCap.flatMap { photoIsoCapOptions.contains($0) ? $0 : nil }
+        if photoIsoCap == 400 || photoIsoCap == 800 {
+            scanIsoCap = photoIsoCap!
+        }
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoNoiseReduction(_ value: Bool?) {
         photoNoiseReduction = value
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoEdgeEnhancement(_ value: Bool?) {
         photoEdgeEnhancement = value
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoMfnr(_ value: Bool?) {
         photoMfnr = value
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoZsl(_ value: Bool?) {
         photoZsl = value
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoIspDigitalGain(_ gain: Int?) {
         photoIspDigitalGain = gain.flatMap { photoIspDigitalGainOptions.contains($0) ? $0 : nil }
+        syncScanButtonPresetIfEnabled()
     }
 
     func setPhotoIspAnalogGain(_ gain: String?) {
         photoIspAnalogGain = gain.flatMap { photoIspAnalogGainOptions.contains($0) ? $0 : nil }
+        syncScanButtonPresetIfEnabled()
     }
 
     func applyBarcodeScanPhotoPreset() {
-        let preset = scanButtonPreset(aeDivisor: 3, isoCap: 800)
         photoSize = .max
         photoCompression = .none
         photoExposureManual = true
         photoExposureTimeNs = photoExposureDefaultNs
         photoIso = photoIsoDefault
-        photoAeExposureDivisor = preset.aeExposureDivisor
-        photoIsoCap = preset.isoCap
-        photoNoiseReduction = preset.noiseReduction
-        photoEdgeEnhancement = preset.edgeEnhancement
-        photoMfnr = preset.mfnr
-        photoZsl = preset.zsl
-        photoIspDigitalGain = preset.ispDigitalGain
-        photoIspAnalogGain = preset.ispAnalogGain
+        scanAeDivisor = 3
+        scanIsoCap = 800
+        photoAeExposureDivisor = 3
+        photoIsoCap = 800
+        photoNoiseReduction = false
+        photoEdgeEnhancement = false
+        photoMfnr = false
+        photoZsl = false
+        photoIspDigitalGain = 0
+        photoIspAnalogGain = "low"
     }
 
     func setPhotoExposureManual(_ enabled: Bool) {
@@ -795,7 +823,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func captureAndUpload() {
-        runAsyncAction("Capture & upload") { [self] in
+        runAsyncAction(scanMode ? "Capture scan photo" : "Capture & upload") { [self] in
             try requireConnected("capture photos")
             try requireGlassesWifi("capture photos")
             if photoDestination == .thisPhone {
@@ -873,33 +901,13 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     private func buildPhotoRequest(requestId: String, appId: String, webhookUrl: String) -> PhotoRequest {
-        if scanMode {
-            // Hardware-button scan settings are synced separately.
-            // App-triggered captures use max detail to match the scan preset's output tier.
-            return PhotoRequest(
-                requestId: requestId,
-                appId: appId,
-                size: .max,
-                webhookUrl: webhookUrl,
-                compress: PhotoCompression.none,
-                sound: false,
-                aeExposureDivisor: scanAeDivisor,
-                isoCap: scanIsoCap,
-                noiseReduction: false,
-                edgeEnhancement: false,
-                mfnr: false,
-                zsl: false,
-                ispDigitalGain: 0,
-                ispAnalogGain: "low"
-            )
-        }
         return PhotoRequest(
             requestId: requestId,
             appId: appId,
             size: photoSize,
             webhookUrl: webhookUrl,
             compress: photoCompression,
-            sound: true,
+            sound: !scanMode,
             exposureTimeNs: photoExposureManual ? Double(photoExposureTimeNs) : nil,
             iso: photoExposureManual ? photoIso : nil,
             aeExposureDivisor: photoAeExposureDivisor,
@@ -1686,7 +1694,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         } else if !wasConnected {
             // Re-apply scan preset on reconnect so button captures stay in sync.
             if scanMode {
-                pushScanButtonPreset(aeDivisor: scanAeDivisor, isoCap: scanIsoCap)
+                pushScanButtonPreset()
             }
         }
         refreshGalleryServerStatusForCurrentHotspot(defaultStatus: hotspotEnabled ? galleryServerStatus : "Gallery server: hotspot off")

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -14,10 +14,23 @@ private enum CameraCaptureMode {
     case video
 }
 
+private func boolTuningLine(_ name: String, _ value: Bool?) -> String? {
+    guard let value else { return nil }
+    return "      \(name): \(value),"
+}
+
 private func cameraSdkCall(
     mode: CameraCaptureMode,
     size: String,
     compression: String,
+    aeExposureDivisor: Int?,
+    isoCap: Int?,
+    noiseReduction: Bool?,
+    edgeEnhancement: Bool?,
+    mfnr: Bool?,
+    zsl: Bool?,
+    ispDigitalGain: Int?,
+    ispAnalogGain: String?,
     exposureManual: Bool,
     exposureTimeNs: Int,
     iso: Int,
@@ -38,7 +51,15 @@ private func cameraSdkCall(
           size: .max,
           webhookUrl: uploadUrl,
           compress: PhotoCompression.none,
-          sound: false
+          sound: false,
+          aeExposureDivisor: \(scanAeDivisor),
+          isoCap: \(scanIsoCap),
+          noiseReduction: false,
+          edgeEnhancement: false,
+          mfnr: false,
+          zsl: false,
+          ispDigitalGain: 0,
+          ispAnalogGain: "low"
         )
     )
     print("Scan photo delivered: \\(photo.requestId)")
@@ -50,6 +71,17 @@ private func cameraSdkCall(
     let isoLine = exposureManual
         ? "      iso: \(iso)"
         : "      iso: nil // auto ISO"
+    let tuningLines = [
+        aeExposureDivisor.map { "      aeExposureDivisor: \($0)," },
+        isoCap.map { "      isoCap: \($0)," },
+        boolTuningLine("noiseReduction", noiseReduction),
+        boolTuningLine("edgeEnhancement", edgeEnhancement),
+        boolTuningLine("mfnr", mfnr),
+        boolTuningLine("zsl", zsl),
+        ispDigitalGain.map { "      ispDigitalGain: \($0)," },
+        ispAnalogGain.map { "      ispAnalogGain: \"\($0)\"," },
+    ].compactMap { $0 }.joined(separator: "\n")
+    let optionalTuningLines = tuningLines.isEmpty ? "" : "\n\(tuningLines)"
     let prefix = """
     let cameraFovResult = try await mentraBluetoothSdk.setCameraFov(
         CameraFov(fov: \(cameraFov), roiPosition: CameraRoiPosition.from(rawValue: \(cameraRoiPosition)))
@@ -84,7 +116,7 @@ private func cameraSdkCall(
           compress: .\(compression),
           sound: true,
     \(exposureLine)
-    \(isoLine)
+    \(isoLine)\(optionalTuningLines)
         )
     )
     print("Photo delivered: \\(photo.requestId)")
@@ -387,6 +419,14 @@ struct CameraScreen: View {
             mode: captureMode,
             size: model.photoSize.rawValue,
             compression: model.photoCompression.rawValue,
+            aeExposureDivisor: model.photoAeExposureDivisor,
+            isoCap: model.photoIsoCap,
+            noiseReduction: model.photoNoiseReduction,
+            edgeEnhancement: model.photoEdgeEnhancement,
+            mfnr: model.photoMfnr,
+            zsl: model.photoZsl,
+            ispDigitalGain: model.photoIspDigitalGain,
+            ispAnalogGain: model.photoIspAnalogGain,
             exposureManual: model.photoExposureManual,
             exposureTimeNs: model.photoExposureTimeNs,
             iso: model.photoIso,
@@ -572,7 +612,10 @@ struct CameraScreen: View {
                         }
                     }
 
-                    ExposureSettingsCard(model: model)
+                    if !model.scanMode {
+                        ExposureSettingsCard(model: model)
+                        PhotoRequestTuningSettingsCard(model: model)
+                    }
                 }
                 CameraFovSettingsCard(model: model)
             }
@@ -696,20 +739,17 @@ private struct ScanModeSettingsCard: View {
                 Text("Syncs max-size preset to the glasses hardware button. Tap Capture to take a max-res, no-compression scan photo via the app.")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(AppColor.muted)
-                Text("AE÷ and ISO cap will ship on app captures in SDK 0.1.13+. Until then these chips only update the hardware button preset.")
-                    .font(.system(size: 11, weight: .regular))
-                    .foregroundColor(AppColor.muted)
                 HStack(spacing: 8) {
                     CameraOptionChip(value: "AE ÷3", highlight: model.scanAeDivisor == 3)
-                        .opacity(0.5)
+                        .onTapGesture { model.setScanAeDivisor(3) }
                     CameraOptionChip(value: "AE ÷5", highlight: model.scanAeDivisor == 5)
-                        .opacity(0.5)
+                        .onTapGesture { model.setScanAeDivisor(5) }
                 }
                 HStack(spacing: 8) {
                     CameraOptionChip(value: "ISO 800", highlight: model.scanIsoCap == 800)
-                        .opacity(0.5)
+                        .onTapGesture { model.setScanIsoCap(800) }
                     CameraOptionChip(value: "ISO 400", highlight: model.scanIsoCap == 400)
-                        .opacity(0.5)
+                        .onTapGesture { model.setScanIsoCap(400) }
                 }
             }
         }
@@ -742,36 +782,36 @@ private struct ExposureSettingsCard: View {
                 .labelsHidden()
                 .toggleStyle(SwitchToggleStyle(tint: AppColor.greenAccent))
             }
-            HStack(spacing: 10) {
-                CameraSliderNudgeButton(label: "-", disabled: !model.photoExposureManual || model.photoExposureTimeNs <= photoExposureMinNs) {
-                    model.setPhotoExposureTimeNs(model.photoExposureTimeNs - 500_000)
+            if model.photoExposureManual {
+                HStack(spacing: 10) {
+                    CameraSliderNudgeButton(label: "-", disabled: model.photoExposureTimeNs <= photoExposureMinNs) {
+                        model.setPhotoExposureTimeNs(model.photoExposureTimeNs - 500_000)
+                    }
+                    Slider(
+                        value: Binding(
+                            get: { Double(model.photoExposureTimeNs) },
+                            set: { model.setPhotoExposureTimeNs(Int(($0 / 500_000).rounded()) * 500_000) }
+                        ),
+                        in: Double(photoExposureMinNs) ... Double(photoExposureMaxNs),
+                        step: 500_000
+                    )
+                    .tint(AppColor.greenAccent)
+                    CameraSliderNudgeButton(label: "+", disabled: model.photoExposureTimeNs >= photoExposureMaxNs) {
+                        model.setPhotoExposureTimeNs(model.photoExposureTimeNs + 500_000)
+                    }
                 }
-                Slider(
-                    value: Binding(
-                        get: { Double(model.photoExposureTimeNs) },
-                        set: { model.setPhotoExposureTimeNs(Int(($0 / 500_000).rounded()) * 500_000) }
-                    ),
-                    in: Double(photoExposureMinNs) ... Double(photoExposureMaxNs),
-                    step: 500_000
-                )
-                .tint(AppColor.greenAccent)
-                .disabled(!model.photoExposureManual)
-                CameraSliderNudgeButton(label: "+", disabled: !model.photoExposureManual || model.photoExposureTimeNs >= photoExposureMaxNs) {
-                    model.setPhotoExposureTimeNs(model.photoExposureTimeNs + 500_000)
+                HStack {
+                    Text("1/1000s")
+                    Spacer()
+                    Button("Preset 1/120s") { model.setPhotoExposureTimeNs(photoExposureDefaultNs) }
+                        .buttonStyle(.plain)
+                        .foregroundColor(AppColor.greenAccent)
+                    Spacer()
+                    Text("1/30s")
                 }
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(AppColor.muted)
             }
-            .opacity(model.photoExposureManual ? 1 : 0.45)
-            HStack {
-                Text("1/1000s")
-                Spacer()
-                Button("Default 1/120s") { model.setPhotoExposureTimeNs(photoExposureDefaultNs) }
-                    .buttonStyle(.plain)
-                    .foregroundColor(AppColor.greenAccent)
-                Spacer()
-                Text("1/30s")
-            }
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundColor(AppColor.muted)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("ISO")
@@ -783,40 +823,119 @@ private struct ExposureSettingsCard: View {
                     .foregroundColor(AppColor.greenAccent)
             }
             .padding(.top, 4)
-            HStack(spacing: 10) {
-                CameraSliderNudgeButton(label: "-", disabled: !model.photoExposureManual || model.photoIso <= photoIsoMin) {
-                    model.setPhotoIso(model.photoIso - 50)
+            if model.photoExposureManual {
+                HStack(spacing: 10) {
+                    CameraSliderNudgeButton(label: "-", disabled: model.photoIso <= photoIsoMin) {
+                        model.setPhotoIso(model.photoIso - 50)
+                    }
+                    Slider(
+                        value: Binding(
+                            get: { Double(model.photoIso) },
+                            set: { model.setPhotoIso(Int(($0 / 50).rounded()) * 50) }
+                        ),
+                        in: Double(photoIsoMin) ... Double(photoIsoMax),
+                        step: 50
+                    )
+                    .tint(AppColor.greenAccent)
+                    CameraSliderNudgeButton(label: "+", disabled: model.photoIso >= photoIsoMax) {
+                        model.setPhotoIso(model.photoIso + 50)
+                    }
                 }
-                Slider(
-                    value: Binding(
-                        get: { Double(model.photoIso) },
-                        set: { model.setPhotoIso(Int(($0 / 50).rounded()) * 50) }
-                    ),
-                    in: Double(photoIsoMin) ... Double(photoIsoMax),
-                    step: 50
-                )
-                .tint(AppColor.greenAccent)
-                .disabled(!model.photoExposureManual)
-                CameraSliderNudgeButton(label: "+", disabled: !model.photoExposureManual || model.photoIso >= photoIsoMax) {
-                    model.setPhotoIso(model.photoIso + 50)
+                HStack {
+                    Text("ISO \(photoIsoMin)")
+                    Spacer()
+                    Button("Preset ISO \(photoIsoDefault)") { model.setPhotoIso(photoIsoDefault) }
+                        .buttonStyle(.plain)
+                        .foregroundColor(AppColor.greenAccent)
+                    Spacer()
+                    Text("ISO \(photoIsoMax)")
                 }
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(AppColor.muted)
             }
-            .opacity(model.photoExposureManual ? 1 : 0.45)
-            HStack {
-                Text("ISO \(photoIsoMin)")
-                Spacer()
-                Button("Default ISO \(photoIsoDefault)") { model.setPhotoIso(photoIsoDefault) }
-                    .buttonStyle(.plain)
-                    .foregroundColor(AppColor.greenAccent)
-                Spacer()
-                Text("ISO \(photoIsoMax)")
-            }
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundColor(AppColor.muted)
         }
         .padding(14)
         .background(AppColor.ink.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+private struct PhotoRequestTuningSettingsCard: View {
+    @ObservedObject var model: BluetoothViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("PHOTO REQUEST TUNING")
+                    .font(.system(size: 10, weight: .bold))
+                    .tracking(1.1)
+                    .foregroundColor(AppColor.muted)
+                Text("Optional request parameters")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(AppColor.greenAccent)
+            }
+
+            CameraOptionGroup(label: "ae divisor") {
+                CameraOptionChip(value: "Unset", highlight: model.photoAeExposureDivisor == nil)
+                    .onTapGesture { model.setPhotoAeExposureDivisor(nil) }
+                ForEach(photoAeExposureDivisorOptions, id: \.self) { divisor in
+                    CameraOptionChip(value: "÷\(divisor)", highlight: model.photoAeExposureDivisor == divisor)
+                        .onTapGesture { model.setPhotoAeExposureDivisor(divisor) }
+                }
+            }
+
+            CameraOptionGroup(label: "iso cap") {
+                CameraOptionChip(value: "Unset", highlight: model.photoIsoCap == nil)
+                    .onTapGesture { model.setPhotoIsoCap(nil) }
+                ForEach(photoIsoCapOptions, id: \.self) { isoCap in
+                    CameraOptionChip(value: "\(isoCap)", highlight: model.photoIsoCap == isoCap)
+                        .onTapGesture { model.setPhotoIsoCap(isoCap) }
+                }
+            }
+
+            BoolTuningOptionGroup(label: "noise reduction", value: model.photoNoiseReduction, onChange: model.setPhotoNoiseReduction)
+            BoolTuningOptionGroup(label: "edge enhancement", value: model.photoEdgeEnhancement, onChange: model.setPhotoEdgeEnhancement)
+            BoolTuningOptionGroup(label: "mfnr", value: model.photoMfnr, onChange: model.setPhotoMfnr)
+            BoolTuningOptionGroup(label: "zsl", value: model.photoZsl, onChange: model.setPhotoZsl)
+
+            CameraOptionGroup(label: "isp digital gain") {
+                CameraOptionChip(value: "Unset", highlight: model.photoIspDigitalGain == nil)
+                    .onTapGesture { model.setPhotoIspDigitalGain(nil) }
+                ForEach(photoIspDigitalGainOptions, id: \.self) { gain in
+                    CameraOptionChip(value: "\(gain)", highlight: model.photoIspDigitalGain == gain)
+                        .onTapGesture { model.setPhotoIspDigitalGain(gain) }
+                }
+            }
+
+            CameraOptionGroup(label: "isp analog gain") {
+                CameraOptionChip(value: "Unset", highlight: model.photoIspAnalogGain == nil)
+                    .onTapGesture { model.setPhotoIspAnalogGain(nil) }
+                ForEach(photoIspAnalogGainOptions, id: \.self) { gain in
+                    CameraOptionChip(value: gain, highlight: model.photoIspAnalogGain == gain)
+                        .onTapGesture { model.setPhotoIspAnalogGain(gain) }
+                }
+            }
+        }
+        .padding(14)
+        .background(AppColor.ink.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+private struct BoolTuningOptionGroup: View {
+    let label: String
+    let value: Bool?
+    let onChange: (Bool?) -> Void
+
+    var body: some View {
+        CameraOptionGroup(label: label) {
+            CameraOptionChip(value: "Unset", highlight: value == nil)
+                .onTapGesture { onChange(nil) }
+            CameraOptionChip(value: "On", highlight: value == true)
+                .onTapGesture { onChange(true) }
+            CameraOptionChip(value: "Off", highlight: value == false)
+                .onTapGesture { onChange(false) }
+        }
     }
 }
 
@@ -870,7 +989,7 @@ private struct CameraFovSettingsCard: View {
             HStack {
                 Text("\(cameraFovMin)°")
                 Spacer()
-                Button("Default \(cameraFovDefault)°") { model.setCameraFov(cameraFovDefault) }
+                Button("Preset \(cameraFovDefault)°") { model.setCameraFov(cameraFovDefault) }
                     .buttonStyle(.plain)
                     .foregroundColor(controlsDisabled ? AppColor.muted : AppColor.greenAccent)
                     .disabled(controlsDisabled)

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -41,9 +41,11 @@ private func cameraSdkCall(
     let exposureLine = exposureManual
         ? "      exposureTimeNs: \(exposureTimeNs),"
         : "      exposureTimeNs: nil, // auto exposure"
+    let effectiveAeExposureDivisor = exposureManual ? nil : aeExposureDivisor
+    let effectiveIsoCap = exposureManual ? nil : isoCap
     let tuningLines = [
-        aeExposureDivisor.map { "      aeExposureDivisor: \($0)," },
-        isoCap.map { "      isoCap: \($0)," },
+        effectiveAeExposureDivisor.map { "      aeExposureDivisor: \($0)," },
+        effectiveIsoCap.map { "      isoCap: \($0)," },
         boolTuningLine("noiseReduction", noiseReduction),
         boolTuningLine("edgeEnhancement", edgeEnhancement),
         boolTuningLine("mfnr", mfnr),
@@ -704,7 +706,7 @@ private struct ScanModeSettingsCard: View {
                     .toggleStyle(SwitchToggleStyle(tint: AppColor.greenAccent))
             }
             if model.scanMode {
-                Text("Applies the barcode capture preset and keeps the glasses button preset in sync. Tune the live request fields below.")
+                Text("Applies the AE-divisor / ISO-cap barcode preset and keeps the glasses button preset in sync.")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(AppColor.muted)
             }
@@ -722,11 +724,11 @@ private struct ExposureSettingsCard: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("EXPOSURE")
+                    Text("MANUAL EXPOSURE")
                         .font(.system(size: 10, weight: .bold))
                         .tracking(1.1)
                         .foregroundColor(AppColor.muted)
-                    Text(model.photoExposureManual ? exposureLabel(model.photoExposureTimeNs) : "Auto exposure")
+                    Text(model.photoExposureManual ? exposureLabel(model.photoExposureTimeNs) : "Auto metered by glasses")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(AppColor.greenAccent)
                 }
@@ -774,7 +776,7 @@ private struct ExposureSettingsCard: View {
                     .font(.system(size: 10, weight: .bold))
                     .tracking(1.1)
                     .foregroundColor(AppColor.muted)
-                Text(model.photoExposureManual ? "ISO \(model.photoIso)" : "Auto ISO")
+                Text(model.photoExposureManual ? "ISO \(model.photoIso)" : "Auto / derived ISO")
                     .font(.system(size: 12, weight: .bold))
                     .foregroundColor(AppColor.greenAccent)
             }
@@ -820,32 +822,33 @@ private struct PhotoRequestTuningSettingsCard: View {
     @ObservedObject var model: BluetoothViewModel
 
     var body: some View {
+        let scanExposureDisabled = model.photoExposureManual
         VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("PHOTO REQUEST TUNING")
                     .font(.system(size: 10, weight: .bold))
                     .tracking(1.1)
                     .foregroundColor(AppColor.muted)
-                Text("Optional request parameters")
+                Text(scanExposureDisabled ? "AE divisor / ISO cap disabled in manual mode" : "Optional request parameters")
                     .font(.system(size: 12, weight: .bold))
                     .foregroundColor(AppColor.greenAccent)
             }
 
             CameraOptionGroup(label: "ae divisor") {
-                CameraOptionChip(value: "Unset", highlight: model.photoAeExposureDivisor == nil)
-                    .onTapGesture { model.setPhotoAeExposureDivisor(nil) }
+                CameraOptionChip(value: "Unset", highlight: model.photoAeExposureDivisor == nil, disabled: scanExposureDisabled)
+                    .onTapGesture { if !scanExposureDisabled { model.setPhotoAeExposureDivisor(nil) } }
                 ForEach(photoAeExposureDivisorOptions, id: \.self) { divisor in
-                    CameraOptionChip(value: "÷\(divisor)", highlight: model.photoAeExposureDivisor == divisor)
-                        .onTapGesture { model.setPhotoAeExposureDivisor(divisor) }
+                    CameraOptionChip(value: "÷\(divisor)", highlight: model.photoAeExposureDivisor == divisor, disabled: scanExposureDisabled)
+                        .onTapGesture { if !scanExposureDisabled { model.setPhotoAeExposureDivisor(divisor) } }
                 }
             }
 
             CameraOptionGroup(label: "iso cap") {
-                CameraOptionChip(value: "Unset", highlight: model.photoIsoCap == nil)
-                    .onTapGesture { model.setPhotoIsoCap(nil) }
+                CameraOptionChip(value: "Unset", highlight: model.photoIsoCap == nil, disabled: scanExposureDisabled)
+                    .onTapGesture { if !scanExposureDisabled { model.setPhotoIsoCap(nil) } }
                 ForEach(photoIsoCapOptions, id: \.self) { isoCap in
-                    CameraOptionChip(value: "\(isoCap)", highlight: model.photoIsoCap == isoCap)
-                        .onTapGesture { model.setPhotoIsoCap(isoCap) }
+                    CameraOptionChip(value: "\(isoCap)", highlight: model.photoIsoCap == isoCap, disabled: scanExposureDisabled)
+                        .onTapGesture { if !scanExposureDisabled { model.setPhotoIsoCap(isoCap) } }
                 }
             }
 
@@ -1379,19 +1382,20 @@ private struct FixedMediaServerRow: View {
 struct CameraOptionChip: View {
     let value: String
     var highlight: Bool = false
+    var disabled: Bool = false
 
     var body: some View {
         HStack(spacing: 6) {
             if highlight { Image(systemName: "bolt.fill").font(.system(size: 9)).foregroundColor(AppColor.amber) }
             Text(value)
                 .font(.system(size: 12, weight: .bold))
-                .foregroundColor(highlight ? AppColor.greenAccent : AppColor.ink)
+                .foregroundColor(disabled ? AppColor.muted.opacity(0.7) : highlight ? AppColor.greenAccent : AppColor.ink)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
-        .background(highlight ? Color(hex: 0x7DD89E).opacity(0.16) : Color.white.opacity(0.6))
-        .overlay(Capsule().stroke(highlight ? AppColor.greenAccent.opacity(0.32) : AppColor.ink.opacity(0.06), lineWidth: 1))
+        .background(disabled ? Color.white.opacity(0.32) : highlight ? Color(hex: 0x7DD89E).opacity(0.16) : Color.white.opacity(0.6))
+        .overlay(Capsule().stroke(disabled ? AppColor.ink.opacity(0.04) : highlight ? AppColor.greenAccent.opacity(0.32) : AppColor.ink.opacity(0.06), lineWidth: 1))
         .clipShape(Capsule())
     }
 }

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -36,35 +36,8 @@ private func cameraSdkCall(
     iso: Int,
     cameraFov: Int,
     cameraRoiPosition: Int,
-    scanMode: Bool,
-    scanAeDivisor: Int,
-    scanIsoCap: Int
+    scanMode: Bool
 ) -> String {
-    if scanMode {
-        return """
-    // Scan tuning is synced through button photo settings.
-    // App-triggered captures use max detail:
-    let photo = try await mentraBluetoothSdk.requestPhoto(
-        PhotoRequest(
-          requestId: requestId,
-          appId: "com.mentra.bluetoothsdk.example.ios",
-          size: .max,
-          webhookUrl: uploadUrl,
-          compress: PhotoCompression.none,
-          sound: false,
-          aeExposureDivisor: \(scanAeDivisor),
-          isoCap: \(scanIsoCap),
-          noiseReduction: false,
-          edgeEnhancement: false,
-          mfnr: false,
-          zsl: false,
-          ispDigitalGain: 0,
-          ispAnalogGain: "low"
-        )
-    )
-    print("Scan photo delivered: \\(photo.requestId)")
-    """
-    }
     let exposureLine = exposureManual
         ? "      exposureTimeNs: \(exposureTimeNs),"
         : "      exposureTimeNs: nil, // auto exposure"
@@ -115,7 +88,7 @@ private func cameraSdkCall(
           size: .\(size),
           webhookUrl: uploadUrl,
           compress: .\(compression),
-          sound: true,
+          sound: \(scanMode ? "false" : "true"),
     \(exposureLine)
     \(isoLine)\(optionalTuningLines)
         )
@@ -266,7 +239,7 @@ struct CameraScreen: View {
             } label: {
                 HStack(spacing: 10) {
                     Image(systemName: "camera").foregroundColor(.white).font(.system(size: 15, weight: .bold))
-                    Text(!model.glassesConnected ? "Connect glasses first" : !model.glassesWifiConnected ? "Connect glasses to Wi-Fi" : model.activeAction == "Capture & upload" ? "Capturing..." : model.scanMode ? "Capture scan photo" : "Capture photo").foregroundColor(.white).font(.system(size: 15, weight: .semibold))
+                    Text(!model.glassesConnected ? "Connect glasses first" : !model.glassesWifiConnected ? "Connect glasses to Wi-Fi" : (model.activeAction == "Capture & upload" || model.activeAction == "Capture scan photo") ? "Capturing..." : model.scanMode ? "Capture scan photo" : "Capture photo").foregroundColor(.white).font(.system(size: 15, weight: .semibold))
                 }
                 .frame(maxWidth: .infinity).padding(.vertical, 16)
                 .background(LinearGradient(colors: [Color(hex: 0x26473A), Color(hex: 0x1F3A2A)], startPoint: .top, endPoint: .bottom))
@@ -433,9 +406,7 @@ struct CameraScreen: View {
             iso: model.photoIso,
             cameraFov: model.cameraFov,
             cameraRoiPosition: model.cameraRoiPosition,
-            scanMode: model.scanMode,
-            scanAeDivisor: model.scanAeDivisor,
-            scanIsoCap: model.scanIsoCap
+            scanMode: model.scanMode
         )
         return VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 8) {
@@ -596,11 +567,9 @@ struct CameraScreen: View {
                         ForEach(photoSizeOptions, id: \.display) { option in
                             CameraOptionChip(
                                 value: option.display,
-                                highlight: !model.scanMode && model.photoSize == option.size
+                                highlight: model.photoSize == option.size
                             )
-                            .opacity(model.scanMode ? 0.45 : 1)
                             .onTapGesture {
-                                guard !model.scanMode else { return }
                                 model.setPhotoSize(option.size)
                             }
                         }
@@ -613,10 +582,8 @@ struct CameraScreen: View {
                         }
                     }
 
-                    if !model.scanMode {
-                        ExposureSettingsCard(model: model)
-                        PhotoRequestTuningSettingsCard(model: model)
-                    }
+                    ExposureSettingsCard(model: model)
+                    PhotoRequestTuningSettingsCard(model: model)
                 }
                 CameraFovSettingsCard(model: model)
             }
@@ -727,7 +694,7 @@ private struct ScanModeSettingsCard: View {
                         .font(.system(size: 10, weight: .bold))
                         .tracking(1.1)
                         .foregroundColor(AppColor.muted)
-                    Text(model.scanMode ? "Document / barcode capture preset" : "Standard photo capture")
+                    Text(model.scanMode ? "Barcode capture preset" : "Standard photo capture")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(AppColor.greenAccent)
                 }
@@ -737,21 +704,9 @@ private struct ScanModeSettingsCard: View {
                     .toggleStyle(SwitchToggleStyle(tint: AppColor.greenAccent))
             }
             if model.scanMode {
-                Text("Syncs max-size preset to the glasses hardware button. Tap Capture to take a max-res, no-compression scan photo via the app.")
+                Text("Applies the barcode capture preset and keeps the glasses button preset in sync. Tune the live request fields below.")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(AppColor.muted)
-                HStack(spacing: 8) {
-                    CameraOptionChip(value: "AE ÷3", highlight: model.scanAeDivisor == 3)
-                        .onTapGesture { model.setScanAeDivisor(3) }
-                    CameraOptionChip(value: "AE ÷5", highlight: model.scanAeDivisor == 5)
-                        .onTapGesture { model.setScanAeDivisor(5) }
-                }
-                HStack(spacing: 8) {
-                    CameraOptionChip(value: "ISO 800", highlight: model.scanIsoCap == 800)
-                        .onTapGesture { model.setScanIsoCap(800) }
-                    CameraOptionChip(value: "ISO 400", highlight: model.scanIsoCap == 400)
-                        .onTapGesture { model.setScanIsoCap(400) }
-                }
             }
         }
         .padding(14)
@@ -866,28 +821,14 @@ private struct PhotoRequestTuningSettingsCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("PHOTO REQUEST TUNING")
-                        .font(.system(size: 10, weight: .bold))
-                        .tracking(1.1)
-                        .foregroundColor(AppColor.muted)
-                    Text("Optional request parameters")
-                        .font(.system(size: 12, weight: .bold))
-                        .foregroundColor(AppColor.greenAccent)
-                }
-                Spacer()
-                Button("Barcode preset") {
-                    model.applyBarcodeScanPhotoPreset()
-                }
-                .font(.system(size: 12, weight: .bold))
-                .foregroundColor(AppColor.greenAccent)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(AppColor.greenAccent.opacity(0.16))
-                .overlay(Capsule().stroke(AppColor.greenAccent.opacity(0.28), lineWidth: 1))
-                .clipShape(Capsule())
-                .buttonStyle(.plain)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("PHOTO REQUEST TUNING")
+                    .font(.system(size: 10, weight: .bold))
+                    .tracking(1.1)
+                    .foregroundColor(AppColor.muted)
+                Text("Optional request parameters")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(AppColor.greenAccent)
             }
 
             CameraOptionGroup(label: "ae divisor") {

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -866,14 +866,28 @@ private struct PhotoRequestTuningSettingsCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("PHOTO REQUEST TUNING")
-                    .font(.system(size: 10, weight: .bold))
-                    .tracking(1.1)
-                    .foregroundColor(AppColor.muted)
-                Text("Optional request parameters")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(AppColor.greenAccent)
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("PHOTO REQUEST TUNING")
+                        .font(.system(size: 10, weight: .bold))
+                        .tracking(1.1)
+                        .foregroundColor(AppColor.muted)
+                    Text("Optional request parameters")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(AppColor.greenAccent)
+                }
+                Spacer()
+                Button("Barcode preset") {
+                    model.applyBarcodeScanPhotoPreset()
+                }
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(AppColor.greenAccent)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(AppColor.greenAccent.opacity(0.16))
+                .overlay(Capsule().stroke(AppColor.greenAccent.opacity(0.28), lineWidth: 1))
+                .clipShape(Capsule())
+                .buttonStyle(.plain)
             }
 
             CameraOptionGroup(label: "ae divisor") {

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -68,9 +68,6 @@ private func cameraSdkCall(
     let exposureLine = exposureManual
         ? "      exposureTimeNs: \(exposureTimeNs),"
         : "      exposureTimeNs: nil, // auto exposure"
-    let isoLine = exposureManual
-        ? "      iso: \(iso)"
-        : "      iso: nil // auto ISO"
     let tuningLines = [
         aeExposureDivisor.map { "      aeExposureDivisor: \($0)," },
         isoCap.map { "      isoCap: \($0)," },
@@ -81,7 +78,11 @@ private func cameraSdkCall(
         ispDigitalGain.map { "      ispDigitalGain: \($0)," },
         ispAnalogGain.map { "      ispAnalogGain: \"\($0)\"," },
     ].compactMap { $0 }.joined(separator: "\n")
-    let optionalTuningLines = tuningLines.isEmpty ? "" : "\n\(tuningLines)"
+    let hasTuningLines = !tuningLines.isEmpty
+    let isoLine = exposureManual
+        ? "      iso: \(iso)\(hasTuningLines ? "," : "")"
+        : "      iso: nil\(hasTuningLines ? "," : "") // auto ISO"
+    let optionalTuningLines = hasTuningLines ? "\n\(tuningLines)" : ""
     let prefix = """
     let cameraFovResult = try await mentraBluetoothSdk.setCameraFov(
         CameraFov(fov: \(cameraFov), roiPosition: CameraRoiPosition.from(rawValue: \(cameraRoiPosition)))

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -165,7 +165,7 @@ struct CameraScreen: View {
         .background(AppColor.bg)
         .scrollDismissesKeyboard(.interactively)
         .onChange(of: model.activeAction) { action in
-            if action == "Capture & upload" {
+            if action == "Capture & upload" || action == "Capture scan photo" {
                 captureMode = .photo
             } else if action == "Start video recording" || action == "Stop & upload video" {
                 captureMode = .video

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -78,8 +78,8 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
         `  sound: ${scanMode ? 'false' : 'true'},`,
         exposureManual ? `  exposureTimeNs: ${exposureTimeNs},` : '  exposureTimeNs: null, // auto exposure',
         exposureManual ? `  iso: ${iso},` : '  iso: null, // auto ISO',
-        aeExposureDivisor !== null ? `  aeExposureDivisor: ${aeExposureDivisor},` : null,
-        isoCap !== null ? `  isoCap: ${isoCap},` : null,
+        !exposureManual && aeExposureDivisor !== null ? `  aeExposureDivisor: ${aeExposureDivisor},` : null,
+        !exposureManual && isoCap !== null ? `  isoCap: ${isoCap},` : null,
         tuningFlagLine('noiseReduction', noiseReduction),
         tuningFlagLine('edgeEnhancement', edgeEnhancement),
         tuningFlagLine('mfnr', mfnr),
@@ -554,6 +554,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           onMfnrChange={sdk.setPhotoMfnr}
           onNoiseReductionChange={sdk.setPhotoNoiseReduction}
           onZslChange={sdk.setPhotoZsl}
+          manualExposure={sdk.photoExposureManual}
           zsl={sdk.photoZsl}
         />
           </>
@@ -1048,7 +1049,7 @@ function ScanModeSettingsCard({
       </View>
       {enabled ? (
         <Text style={styles.settingDescription}>
-          Applies the barcode capture preset and scans captured photo previews for barcodes. Tune the live request fields below.
+          Applies the AE-divisor / ISO-cap barcode preset and scans captured photo previews for barcodes.
         </Text>
       ) : (
         <Text style={styles.settingDescription}>
@@ -1080,8 +1081,8 @@ function ExposureControl({
     <View style={[styles.settingCard, disabled && styles.sliderDisabled]}>
       <View style={styles.settingHeader}>
         <View>
-          <Text style={styles.settingLabel}>EXPOSURE</Text>
-          <Text style={styles.settingHint}>{enabled ? exposureLabel(value) : 'Auto exposure'}</Text>
+          <Text style={styles.settingLabel}>MANUAL EXPOSURE</Text>
+          <Text style={styles.settingHint}>{enabled ? exposureLabel(value) : 'Auto metered by glasses'}</Text>
         </View>
         <Switch
           disabled={disabled}
@@ -1114,7 +1115,7 @@ function ExposureControl({
       <View style={styles.isoHeader}>
         <View>
           <Text style={styles.settingLabel}>ISO</Text>
-          <Text style={styles.settingHint}>{enabled ? `ISO ${iso}` : 'Auto ISO'}</Text>
+          <Text style={styles.settingHint}>{enabled ? `ISO ${iso}` : 'Auto / derived ISO'}</Text>
         </View>
       </View>
       {enabled ? (
@@ -1147,6 +1148,7 @@ function PhotoRequestTuningControl({
   ispAnalogGain,
   ispDigitalGain,
   isoCap,
+  manualExposure,
   mfnr,
   noiseReduction,
   onAeExposureDivisorChange,
@@ -1165,6 +1167,7 @@ function PhotoRequestTuningControl({
   ispAnalogGain: PhotoIspAnalogGain | null;
   ispDigitalGain: PhotoIspDigitalGain | null;
   isoCap: PhotoIsoCap | null;
+  manualExposure: boolean;
   mfnr: PhotoTuningFlag;
   noiseReduction: PhotoTuningFlag;
   onAeExposureDivisorChange: (divisor: PhotoAeExposureDivisor | null) => void;
@@ -1177,18 +1180,22 @@ function PhotoRequestTuningControl({
   onZslChange: (value: PhotoTuningFlag) => void;
   zsl: PhotoTuningFlag;
 }) {
+  const scanExposureDisabled = disabled || manualExposure;
+
   return (
     <View style={[styles.settingCard, disabled && styles.sliderDisabled]}>
       <View style={styles.settingHeader}>
         <View>
           <Text style={styles.settingLabel}>PHOTO REQUEST TUNING</Text>
-          <Text style={styles.settingHint}>Optional request parameters</Text>
+          <Text style={styles.settingHint}>
+            {manualExposure ? 'AE divisor / ISO cap disabled in manual mode' : 'Optional request parameters'}
+          </Text>
         </View>
       </View>
       <OptionGroup label="ae divisor">
         <Chip
           active={aeExposureDivisor === null}
-          disabled={disabled}
+          disabled={scanExposureDisabled}
           value="Unset"
           onPress={() => onAeExposureDivisorChange(null)}
         />
@@ -1196,7 +1203,7 @@ function PhotoRequestTuningControl({
           <Chip
             key={option}
             active={aeExposureDivisor === option}
-            disabled={disabled}
+            disabled={scanExposureDisabled}
             value={`÷${option}`}
             onPress={() => onAeExposureDivisorChange(option)}
           />
@@ -1205,7 +1212,7 @@ function PhotoRequestTuningControl({
       <OptionGroup label="iso cap">
         <Chip
           active={isoCap === null}
-          disabled={disabled}
+          disabled={scanExposureDisabled}
           value="Unset"
           onPress={() => onIsoCapChange(null)}
         />
@@ -1213,7 +1220,7 @@ function PhotoRequestTuningControl({
           <Chip
             key={option}
             active={isoCap === option}
-            disabled={disabled}
+            disabled={scanExposureDisabled}
             value={String(option)}
             onPress={() => onIsoCapChange(option)}
           />

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -26,8 +26,6 @@ import {
   PHOTO_ISP_DIGITAL_GAIN_OPTIONS,
   PHOTO_SIZES,
   PHOTO_TUNING_FLAG_OPTIONS,
-  SCAN_AE_DIVISOR_OPTIONS,
-  SCAN_ISO_CAP_OPTIONS,
   type BluetoothSdkExampleModel,
   type PhotoAeExposureDivisor,
   type PhotoCompression,
@@ -37,7 +35,6 @@ import {
   type PhotoPreviewDetails,
   type PhotoSize,
   type PhotoTuningFlag,
-  type ScanAeDivisor,
   type VideoPreviewDetails,
 } from '../useBluetoothSdkExample';
 
@@ -71,28 +68,14 @@ function photoSdkCall(
   cameraFov: number,
   cameraRoiPosition: (typeof CAMERA_ROI_POSITIONS)[number]['value'],
   scanMode: boolean,
-  scanAeDivisor: ScanAeDivisor,
-  scanIsoCap: number,
 ) {
   const prefix = `const cameraFov = await BluetoothSdk.setCameraFov({ fov: ${cameraFov}, roiPosition: "${cameraRoiPosition}" });
 console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
 `;
-  const requestFields = scanMode
-    ? `  size: "max",
-  compress: "none",
-  sound: false,
-  aeExposureDivisor: ${scanAeDivisor},
-  isoCap: ${scanIsoCap},
-  noiseReduction: false,
-  edgeEnhancement: false,
-  mfnr: false,
-  zsl: false,
-  ispDigitalGain: 0,
-  ispAnalogGain: "low",`
-    : [
+  const requestFields = [
         `  size: "${size}",`,
         `  compress: "${compression}",`,
-        '  sound: true,',
+        `  sound: ${scanMode ? 'false' : 'true'},`,
         exposureManual ? `  exposureTimeNs: ${exposureTimeNs},` : '  exposureTimeNs: null, // auto exposure',
         exposureManual ? `  iso: ${iso},` : '  iso: null, // auto ISO',
         aeExposureDivisor !== null ? `  aeExposureDivisor: ${aeExposureDivisor},` : null,
@@ -197,8 +180,6 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
         sdk.cameraFov,
         sdk.cameraRoiPosition,
         sdk.scanMode,
-        sdk.scanAeDivisor,
-        sdk.scanIsoCap,
       );
 
   React.useEffect(() => {
@@ -338,12 +319,8 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
         </Pressable>
         <View style={styles.scanModeBelowCapture}>
           <ScanModeSettingsCard
-            aeDivisor={sdk.scanAeDivisor}
             enabled={sdk.scanMode}
-            isoCap={sdk.scanIsoCap}
-            onAeDivisorChange={sdk.setScanAeDivisor}
             onEnabledChange={sdk.setScanMode}
-            onIsoCapChange={sdk.setScanIsoCap}
           />
         </View>
         <PhotoDetailsCard
@@ -537,8 +514,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           {PHOTO_SIZES.map((size) => (
             <Chip
               key={size}
-              active={!sdk.scanMode && sdk.photoSize === size}
-              disabled={sdk.scanMode}
+              active={sdk.photoSize === size}
               value={size}
               onPress={() => sdk.setPhotoSize(size)}
             />
@@ -549,14 +525,12 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Chip
               key={compression}
               active={sdk.photoCompression === compression}
-              disabled={sdk.scanMode}
               value={compression}
               onPress={() => sdk.setPhotoCompression(compression)}
             />
           ))}
         </OptionGroup>
         <ExposureControl
-          disabled={sdk.scanMode}
           enabled={sdk.photoExposureManual}
           onEnabledChange={sdk.setPhotoExposureManual}
           onIsoChange={sdk.setPhotoIso}
@@ -566,7 +540,6 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
         />
         <PhotoRequestTuningControl
           aeExposureDivisor={sdk.photoAeExposureDivisor}
-          disabled={sdk.scanMode}
           edgeEnhancement={sdk.photoEdgeEnhancement}
           ispAnalogGain={sdk.photoIspAnalogGain}
           ispDigitalGain={sdk.photoIspDigitalGain}
@@ -578,7 +551,6 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           onIspAnalogGainChange={sdk.setPhotoIspAnalogGain}
           onIspDigitalGainChange={sdk.setPhotoIspDigitalGain}
           onIsoCapChange={sdk.setPhotoIsoCap}
-          onApplyBarcodePreset={sdk.applyBarcodeScanPhotoPreset}
           onMfnrChange={sdk.setPhotoMfnr}
           onNoiseReductionChange={sdk.setPhotoNoiseReduction}
           onZslChange={sdk.setPhotoZsl}
@@ -1051,27 +1023,19 @@ function photoCaptureMetadataDetail(config: PhotoStatusExtras['captureMetadata']
 }
 
 function ScanModeSettingsCard({
-  aeDivisor,
   enabled,
-  isoCap,
-  onAeDivisorChange,
   onEnabledChange,
-  onIsoCapChange,
 }: {
-  aeDivisor: ScanAeDivisor;
   enabled: boolean;
-  isoCap: number;
-  onAeDivisorChange: (divisor: ScanAeDivisor) => void;
   onEnabledChange: (enabled: boolean) => void;
-  onIsoCapChange: (isoCap: number) => void;
 }) {
   return (
     <View style={styles.settingCard}>
       <View style={styles.settingHeader}>
         <View style={{ flex: 1 }}>
-          <Text style={styles.settingLabel}>SCAN MODE</Text>
+          <Text style={styles.settingLabel}>BARCODE SCANNING</Text>
           <Text style={styles.settingHint}>
-            {enabled ? `Max res · AE÷${aeDivisor} · ISO cap ${isoCap}` : 'Document / barcode capture preset'}
+            {enabled ? 'Barcode scanning on' : 'Standard photo capture'}
           </Text>
         </View>
         <Switch
@@ -1083,34 +1047,12 @@ function ScanModeSettingsCard({
         />
       </View>
       {enabled ? (
-        <>
-          <Text style={styles.settingDescription}>
-            Pushes size, MFNR, NR, edge, and ISP gain presets to glasses (HAL may warn on NR/ISP). Capture still sends AE÷ and ISO cap in take_photo.
-          </Text>
-          <OptionGroup label="ae divisor">
-            {SCAN_AE_DIVISOR_OPTIONS.map((option) => (
-              <Chip
-                key={option}
-                active={aeDivisor === option}
-                value={`÷${option}`}
-                onPress={() => onAeDivisorChange(option)}
-              />
-            ))}
-          </OptionGroup>
-          <OptionGroup label="iso cap">
-            {SCAN_ISO_CAP_OPTIONS.map((option) => (
-              <Chip
-                key={option}
-                active={isoCap === option}
-                value={String(option)}
-                onPress={() => onIsoCapChange(option)}
-              />
-            ))}
-          </OptionGroup>
-        </>
+        <Text style={styles.settingDescription}>
+          Applies the barcode capture preset and scans captured photo previews for barcodes. Tune the live request fields below.
+        </Text>
       ) : (
         <Text style={styles.settingDescription}>
-          Off — capture uses the size, compress, and exposure options below.
+          Off - capture uses the current fields below without barcode recognition.
         </Text>
       )}
     </View>
@@ -1208,7 +1150,6 @@ function PhotoRequestTuningControl({
   mfnr,
   noiseReduction,
   onAeExposureDivisorChange,
-  onApplyBarcodePreset,
   onEdgeEnhancementChange,
   onIspAnalogGainChange,
   onIspDigitalGainChange,
@@ -1227,7 +1168,6 @@ function PhotoRequestTuningControl({
   mfnr: PhotoTuningFlag;
   noiseReduction: PhotoTuningFlag;
   onAeExposureDivisorChange: (divisor: PhotoAeExposureDivisor | null) => void;
-  onApplyBarcodePreset: () => void;
   onEdgeEnhancementChange: (value: PhotoTuningFlag) => void;
   onIspAnalogGainChange: (gain: PhotoIspAnalogGain | null) => void;
   onIspDigitalGainChange: (gain: PhotoIspDigitalGain | null) => void;
@@ -1244,9 +1184,6 @@ function PhotoRequestTuningControl({
           <Text style={styles.settingLabel}>PHOTO REQUEST TUNING</Text>
           <Text style={styles.settingHint}>Optional request parameters</Text>
         </View>
-        <Pressable disabled={disabled} onPress={onApplyBarcodePreset} style={styles.applyChip}>
-          <Text style={styles.applyChipText}>Barcode preset</Text>
-        </Pressable>
       </View>
       <OptionGroup label="ae divisor">
         <Chip

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -13,6 +13,7 @@ import {
   CAMERA_FOV_MAX,
   CAMERA_FOV_MIN,
   CAMERA_ROI_POSITIONS,
+  PHOTO_BLE_FALLBACK_QUALITY_WARNING,
   PHOTO_AE_EXPOSURE_DIVISOR_OPTIONS,
   PHOTO_COMPRESSIONS,
   PHOTO_EXPOSURE_DEFAULT_NS,
@@ -147,7 +148,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   );
   const bleFallbackWarning = sdk.photoPreviewDetails?.bleFallbackUsed
     ? sdk.photoPreviewDetails.bleFallbackMessage ??
-      'Wi-Fi upload failed; photo was compressed and delivered through Bluetooth.'
+      PHOTO_BLE_FALLBACK_QUALITY_WARNING
     : null;
   const cloudSetupHint = localCameraSetupHint(sdk.webhookUrl, sdk.cameraStatus);
   const photoStateText = sdk.photoPreviewUrl

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -578,6 +578,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           onIspAnalogGainChange={sdk.setPhotoIspAnalogGain}
           onIspDigitalGainChange={sdk.setPhotoIspDigitalGain}
           onIsoCapChange={sdk.setPhotoIsoCap}
+          onApplyBarcodePreset={sdk.applyBarcodeScanPhotoPreset}
           onMfnrChange={sdk.setPhotoMfnr}
           onNoiseReductionChange={sdk.setPhotoNoiseReduction}
           onZslChange={sdk.setPhotoZsl}
@@ -1207,6 +1208,7 @@ function PhotoRequestTuningControl({
   mfnr,
   noiseReduction,
   onAeExposureDivisorChange,
+  onApplyBarcodePreset,
   onEdgeEnhancementChange,
   onIspAnalogGainChange,
   onIspDigitalGainChange,
@@ -1225,6 +1227,7 @@ function PhotoRequestTuningControl({
   mfnr: PhotoTuningFlag;
   noiseReduction: PhotoTuningFlag;
   onAeExposureDivisorChange: (divisor: PhotoAeExposureDivisor | null) => void;
+  onApplyBarcodePreset: () => void;
   onEdgeEnhancementChange: (value: PhotoTuningFlag) => void;
   onIspAnalogGainChange: (gain: PhotoIspAnalogGain | null) => void;
   onIspDigitalGainChange: (gain: PhotoIspDigitalGain | null) => void;
@@ -1241,6 +1244,9 @@ function PhotoRequestTuningControl({
           <Text style={styles.settingLabel}>PHOTO REQUEST TUNING</Text>
           <Text style={styles.settingHint}>Optional request parameters</Text>
         </View>
+        <Pressable disabled={disabled} onPress={onApplyBarcodePreset} style={styles.applyChip}>
+          <Text style={styles.applyChipText}>Barcode preset</Text>
+        </Pressable>
       </View>
       <OptionGroup label="ae divisor">
         <Chip

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -13,20 +13,30 @@ import {
   CAMERA_FOV_MAX,
   CAMERA_FOV_MIN,
   CAMERA_ROI_POSITIONS,
+  PHOTO_AE_EXPOSURE_DIVISOR_OPTIONS,
   PHOTO_COMPRESSIONS,
   PHOTO_EXPOSURE_DEFAULT_NS,
   PHOTO_EXPOSURE_MAX_NS,
   PHOTO_EXPOSURE_MIN_NS,
+  PHOTO_ISO_CAP_OPTIONS,
   PHOTO_ISO_DEFAULT,
   PHOTO_ISO_MAX,
   PHOTO_ISO_MIN,
+  PHOTO_ISP_ANALOG_GAIN_OPTIONS,
+  PHOTO_ISP_DIGITAL_GAIN_OPTIONS,
   PHOTO_SIZES,
+  PHOTO_TUNING_FLAG_OPTIONS,
   SCAN_AE_DIVISOR_OPTIONS,
   SCAN_ISO_CAP_OPTIONS,
   type BluetoothSdkExampleModel,
+  type PhotoAeExposureDivisor,
   type PhotoCompression,
+  type PhotoIsoCap,
+  type PhotoIspAnalogGain,
+  type PhotoIspDigitalGain,
   type PhotoPreviewDetails,
   type PhotoSize,
+  type PhotoTuningFlag,
   type ScanAeDivisor,
   type VideoPreviewDetails,
 } from '../useBluetoothSdkExample';
@@ -36,10 +46,25 @@ const PHOTO_ISO_STEP = 50;
 const CAMERA_FOV_STEP = 1;
 type CameraCaptureMode = 'photo' | 'video';
 
+function tuningFlagLine(name: string, value: PhotoTuningFlag) {
+  if (value === 'unset') {
+    return null;
+  }
+  return `  ${name}: ${value === 'on' ? 'true' : 'false'},`;
+}
+
 function photoSdkCall(
   size: PhotoSize,
   compression: PhotoCompression,
   useCloudServer: boolean,
+  aeExposureDivisor: PhotoAeExposureDivisor | null,
+  isoCap: PhotoIsoCap | null,
+  noiseReduction: PhotoTuningFlag,
+  edgeEnhancement: PhotoTuningFlag,
+  mfnr: PhotoTuningFlag,
+  zsl: PhotoTuningFlag,
+  ispDigitalGain: PhotoIspDigitalGain | null,
+  ispAnalogGain: PhotoIspAnalogGain | null,
   exposureManual: boolean,
   exposureTimeNs: number,
   iso: number,
@@ -61,6 +86,7 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
   noiseReduction: false,
   edgeEnhancement: false,
   mfnr: false,
+  zsl: false,
   ispDigitalGain: 0,
   ispAnalogGain: "low",`
     : [
@@ -69,7 +95,15 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
         '  sound: true,',
         exposureManual ? `  exposureTimeNs: ${exposureTimeNs},` : '  exposureTimeNs: null, // auto exposure',
         exposureManual ? `  iso: ${iso},` : '  iso: null, // auto ISO',
-      ].join('\n');
+        aeExposureDivisor !== null ? `  aeExposureDivisor: ${aeExposureDivisor},` : null,
+        isoCap !== null ? `  isoCap: ${isoCap},` : null,
+        tuningFlagLine('noiseReduction', noiseReduction),
+        tuningFlagLine('edgeEnhancement', edgeEnhancement),
+        tuningFlagLine('mfnr', mfnr),
+        tuningFlagLine('zsl', zsl),
+        ispDigitalGain !== null ? `  ispDigitalGain: ${ispDigitalGain},` : null,
+        ispAnalogGain !== null ? `  ispAnalogGain: "${ispAnalogGain}",` : null,
+      ].filter((line): line is string => line !== null).join('\n');
   if (!useCloudServer) {
     return `${prefix}const photoRequestId = \`photo-\${Date.now()}\`;
 const { uploadUrl } = await MentraPhotoReceiver.startPhotoReceiver();
@@ -149,6 +183,14 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
         sdk.photoSize,
         sdk.photoCompression,
         sdk.photoCloudServerEnabled,
+        sdk.photoAeExposureDivisor,
+        sdk.photoIsoCap,
+        sdk.photoNoiseReduction,
+        sdk.photoEdgeEnhancement,
+        sdk.photoMfnr,
+        sdk.photoZsl,
+        sdk.photoIspDigitalGain,
+        sdk.photoIspAnalogGain,
         sdk.photoExposureManual,
         sdk.photoExposureTimeNs,
         sdk.photoIso,
@@ -521,6 +563,25 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           onValueChange={sdk.setPhotoExposureTimeNs}
           iso={sdk.photoIso}
           value={sdk.photoExposureTimeNs}
+        />
+        <PhotoRequestTuningControl
+          aeExposureDivisor={sdk.photoAeExposureDivisor}
+          disabled={sdk.scanMode}
+          edgeEnhancement={sdk.photoEdgeEnhancement}
+          ispAnalogGain={sdk.photoIspAnalogGain}
+          ispDigitalGain={sdk.photoIspDigitalGain}
+          isoCap={sdk.photoIsoCap}
+          mfnr={sdk.photoMfnr}
+          noiseReduction={sdk.photoNoiseReduction}
+          onAeExposureDivisorChange={sdk.setPhotoAeExposureDivisor}
+          onEdgeEnhancementChange={sdk.setPhotoEdgeEnhancement}
+          onIspAnalogGainChange={sdk.setPhotoIspAnalogGain}
+          onIspDigitalGainChange={sdk.setPhotoIspDigitalGain}
+          onIsoCapChange={sdk.setPhotoIsoCap}
+          onMfnrChange={sdk.setPhotoMfnr}
+          onNoiseReductionChange={sdk.setPhotoNoiseReduction}
+          onZslChange={sdk.setPhotoZsl}
+          zsl={sdk.photoZsl}
         />
           </>
         )}
@@ -1072,7 +1133,6 @@ function ExposureControl({
   iso: number;
   value: number;
 }) {
-  const controlsDisabled = disabled || !enabled;
   return (
     <View style={[styles.settingCard, disabled && styles.sliderDisabled]}>
       <View style={styles.settingHeader}>
@@ -1089,43 +1149,208 @@ function ExposureControl({
           value={enabled}
         />
       </View>
-      <RangeSlider
-        disabled={controlsDisabled}
-        max={PHOTO_EXPOSURE_MAX_NS}
-        min={PHOTO_EXPOSURE_MIN_NS}
-        onChange={onValueChange}
-        step={PHOTO_EXPOSURE_STEP_NS}
-        value={value}
-      />
-      <View style={styles.settingRangeRow}>
-        <Text style={styles.settingRangeText}>1/1000s</Text>
-        <Pressable onPress={() => onValueChange(PHOTO_EXPOSURE_DEFAULT_NS)}>
-          <Text style={styles.settingHint}>Default 1/120s</Text>
-        </Pressable>
-        <Text style={styles.settingRangeText}>1/30s</Text>
-      </View>
+      {enabled ? (
+        <>
+          <RangeSlider
+            disabled={disabled}
+            max={PHOTO_EXPOSURE_MAX_NS}
+            min={PHOTO_EXPOSURE_MIN_NS}
+            onChange={onValueChange}
+            step={PHOTO_EXPOSURE_STEP_NS}
+            value={value}
+          />
+          <View style={styles.settingRangeRow}>
+            <Text style={styles.settingRangeText}>1/1000s</Text>
+            <Pressable disabled={disabled} onPress={() => onValueChange(PHOTO_EXPOSURE_DEFAULT_NS)}>
+              <Text style={styles.settingHint}>Preset 1/120s</Text>
+            </Pressable>
+            <Text style={styles.settingRangeText}>1/30s</Text>
+          </View>
+        </>
+      ) : null}
       <View style={styles.isoHeader}>
         <View>
           <Text style={styles.settingLabel}>ISO</Text>
           <Text style={styles.settingHint}>{enabled ? `ISO ${iso}` : 'Auto ISO'}</Text>
         </View>
       </View>
-      <RangeSlider
-        disabled={controlsDisabled}
-        max={PHOTO_ISO_MAX}
-        min={PHOTO_ISO_MIN}
-        onChange={onIsoChange}
-        step={PHOTO_ISO_STEP}
-        value={iso}
-      />
-      <View style={styles.settingRangeRow}>
-        <Text style={styles.settingRangeText}>ISO {PHOTO_ISO_MIN}</Text>
-        <Pressable onPress={() => onIsoChange(PHOTO_ISO_DEFAULT)}>
-          <Text style={styles.settingHint}>Default ISO {PHOTO_ISO_DEFAULT}</Text>
-        </Pressable>
-        <Text style={styles.settingRangeText}>ISO {PHOTO_ISO_MAX}</Text>
-      </View>
+      {enabled ? (
+        <>
+          <RangeSlider
+            disabled={disabled}
+            max={PHOTO_ISO_MAX}
+            min={PHOTO_ISO_MIN}
+            onChange={onIsoChange}
+            step={PHOTO_ISO_STEP}
+            value={iso}
+          />
+          <View style={styles.settingRangeRow}>
+            <Text style={styles.settingRangeText}>ISO {PHOTO_ISO_MIN}</Text>
+            <Pressable disabled={disabled} onPress={() => onIsoChange(PHOTO_ISO_DEFAULT)}>
+              <Text style={styles.settingHint}>Preset ISO {PHOTO_ISO_DEFAULT}</Text>
+            </Pressable>
+            <Text style={styles.settingRangeText}>ISO {PHOTO_ISO_MAX}</Text>
+          </View>
+        </>
+      ) : null}
     </View>
+  );
+}
+
+function PhotoRequestTuningControl({
+  aeExposureDivisor,
+  disabled = false,
+  edgeEnhancement,
+  ispAnalogGain,
+  ispDigitalGain,
+  isoCap,
+  mfnr,
+  noiseReduction,
+  onAeExposureDivisorChange,
+  onEdgeEnhancementChange,
+  onIspAnalogGainChange,
+  onIspDigitalGainChange,
+  onIsoCapChange,
+  onMfnrChange,
+  onNoiseReductionChange,
+  onZslChange,
+  zsl,
+}: {
+  aeExposureDivisor: PhotoAeExposureDivisor | null;
+  disabled?: boolean;
+  edgeEnhancement: PhotoTuningFlag;
+  ispAnalogGain: PhotoIspAnalogGain | null;
+  ispDigitalGain: PhotoIspDigitalGain | null;
+  isoCap: PhotoIsoCap | null;
+  mfnr: PhotoTuningFlag;
+  noiseReduction: PhotoTuningFlag;
+  onAeExposureDivisorChange: (divisor: PhotoAeExposureDivisor | null) => void;
+  onEdgeEnhancementChange: (value: PhotoTuningFlag) => void;
+  onIspAnalogGainChange: (gain: PhotoIspAnalogGain | null) => void;
+  onIspDigitalGainChange: (gain: PhotoIspDigitalGain | null) => void;
+  onIsoCapChange: (isoCap: PhotoIsoCap | null) => void;
+  onMfnrChange: (value: PhotoTuningFlag) => void;
+  onNoiseReductionChange: (value: PhotoTuningFlag) => void;
+  onZslChange: (value: PhotoTuningFlag) => void;
+  zsl: PhotoTuningFlag;
+}) {
+  return (
+    <View style={[styles.settingCard, disabled && styles.sliderDisabled]}>
+      <View style={styles.settingHeader}>
+        <View>
+          <Text style={styles.settingLabel}>PHOTO REQUEST TUNING</Text>
+          <Text style={styles.settingHint}>Optional request parameters</Text>
+        </View>
+      </View>
+      <OptionGroup label="ae divisor">
+        <Chip
+          active={aeExposureDivisor === null}
+          disabled={disabled}
+          value="Unset"
+          onPress={() => onAeExposureDivisorChange(null)}
+        />
+        {PHOTO_AE_EXPOSURE_DIVISOR_OPTIONS.map((option) => (
+          <Chip
+            key={option}
+            active={aeExposureDivisor === option}
+            disabled={disabled}
+            value={`÷${option}`}
+            onPress={() => onAeExposureDivisorChange(option)}
+          />
+        ))}
+      </OptionGroup>
+      <OptionGroup label="iso cap">
+        <Chip
+          active={isoCap === null}
+          disabled={disabled}
+          value="Unset"
+          onPress={() => onIsoCapChange(null)}
+        />
+        {PHOTO_ISO_CAP_OPTIONS.map((option) => (
+          <Chip
+            key={option}
+            active={isoCap === option}
+            disabled={disabled}
+            value={String(option)}
+            onPress={() => onIsoCapChange(option)}
+          />
+        ))}
+      </OptionGroup>
+      <TuningFlagGroup
+        disabled={disabled}
+        label="noise reduction"
+        onChange={onNoiseReductionChange}
+        value={noiseReduction}
+      />
+      <TuningFlagGroup
+        disabled={disabled}
+        label="edge enhancement"
+        onChange={onEdgeEnhancementChange}
+        value={edgeEnhancement}
+      />
+      <TuningFlagGroup disabled={disabled} label="mfnr" onChange={onMfnrChange} value={mfnr} />
+      <TuningFlagGroup disabled={disabled} label="zsl" onChange={onZslChange} value={zsl} />
+      <OptionGroup label="isp digital gain">
+        <Chip
+          active={ispDigitalGain === null}
+          disabled={disabled}
+          value="Unset"
+          onPress={() => onIspDigitalGainChange(null)}
+        />
+        {PHOTO_ISP_DIGITAL_GAIN_OPTIONS.map((option) => (
+          <Chip
+            key={option}
+            active={ispDigitalGain === option}
+            disabled={disabled}
+            value={String(option)}
+            onPress={() => onIspDigitalGainChange(option)}
+          />
+        ))}
+      </OptionGroup>
+      <OptionGroup label="isp analog gain">
+        <Chip
+          active={ispAnalogGain === null}
+          disabled={disabled}
+          value="Unset"
+          onPress={() => onIspAnalogGainChange(null)}
+        />
+        {PHOTO_ISP_ANALOG_GAIN_OPTIONS.map((option) => (
+          <Chip
+            key={option}
+            active={ispAnalogGain === option}
+            disabled={disabled}
+            value={option}
+            onPress={() => onIspAnalogGainChange(option)}
+          />
+        ))}
+      </OptionGroup>
+    </View>
+  );
+}
+
+function TuningFlagGroup({
+  disabled,
+  label,
+  onChange,
+  value,
+}: {
+  disabled: boolean;
+  label: string;
+  onChange: (value: PhotoTuningFlag) => void;
+  value: PhotoTuningFlag;
+}) {
+  return (
+    <OptionGroup label={label}>
+      {PHOTO_TUNING_FLAG_OPTIONS.map((option) => (
+        <Chip
+          key={option}
+          active={value === option}
+          disabled={disabled}
+          value={option === 'unset' ? 'Unset' : option === 'on' ? 'On' : 'Off'}
+          onPress={() => onChange(option)}
+        />
+      ))}
+    </OptionGroup>
   );
 }
 
@@ -1177,7 +1402,7 @@ function CameraSettingsControl({
         <Text style={styles.settingRangeText}>{CAMERA_FOV_MIN}°</Text>
         <Pressable disabled={controlsDisabled} onPress={() => onFovChange(CAMERA_FOV_DEFAULT)}>
           <Text style={[styles.settingHint, controlsDisabled && styles.settingRangeText]}>
-            Default {CAMERA_FOV_DEFAULT}°
+            Preset {CAMERA_FOV_DEFAULT}°
           </Text>
         </Pressable>
         <Text style={styles.settingRangeText}>{CAMERA_FOV_MAX}°</Text>

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -476,6 +476,8 @@ const VIDEO_POLL_ATTEMPTS = 180;
 const DIRECT_PHOTO_UPLOAD_TIMEOUT_MS = 75_000;
 export const PHOTO_BLE_FALLBACK_QUALITY_WARNING =
   'Wi-Fi upload failed; photo was compressed for Bluetooth fallback, so image quality is lower.';
+const PHOTO_BLE_FALLBACK_COMPRESSION_MESSAGE =
+  'Wi-Fi upload failed; compressing photo for Bluetooth fallback.';
 const DIRECT_WEBRTC_RECEIVER_WARMUP_MS = 1000;
 const BARCODE_SCAN_VISIBLE_TIMEOUT_MS = 2_500;
 const ANDROID_12_API_LEVEL = 31;
@@ -1638,6 +1640,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       handlePhotoResponse(response);
     } catch (error) {
       if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
+        clearPhotoUploadTimeout();
         markPhotoRequestStillWaiting(requestId, 'Phone receiver', error);
         return;
       }
@@ -4111,7 +4114,7 @@ function photoStatusLabel(event: PhotoStatusEvent, galleryModeButtonPhoto = fals
 
 function photoBleFallbackMessage(status: string) {
   return status === 'ble_fallback_compression'
-    ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
+    ? PHOTO_BLE_FALLBACK_COMPRESSION_MESSAGE
     : null;
 }
 

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1619,15 +1619,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     markPhotoRequestStarted(requestId);
     resetBarcodeScan();
     setCameraStatus(`Camera: phone upload requested (${requestId})`);
-    clearPhotoUploadTimeout();
-    photoUploadTimeoutRef.current = setTimeout(() => {
-      if (activePhotoRequestIdRef.current === requestId) {
-        activePhotoRequestIdRef.current = null;
-        setCameraStatus('Camera: timed out waiting for phone upload');
-        markPhotoRequestFailed(requestId, 'UPLOAD_TIMEOUT', 'Timed out waiting for phone upload');
-        addEvent('TX', `phone photo upload timed out ${requestId}`);
-      }
-    }, DIRECT_PHOTO_UPLOAD_TIMEOUT_MS);
+    startPhonePhotoUploadTimeout(requestId);
 
     try {
       const response = await BluetoothSdk.requestPhoto({
@@ -1640,8 +1632,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       handlePhotoResponse(response);
     } catch (error) {
       if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
-        clearPhotoUploadTimeout();
         markPhotoRequestStillWaiting(requestId, 'Phone receiver', error);
+        startPhonePhotoUploadTimeout(requestId);
         return;
       }
       clearPhotoUploadTimeout();
@@ -1838,6 +1830,18 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       'LIVE',
       `photo request still waiting after SDK timeout ${requestId}: ${formatError(error)}`,
     );
+  }
+
+  function startPhonePhotoUploadTimeout(requestId: string) {
+    clearPhotoUploadTimeout();
+    photoUploadTimeoutRef.current = setTimeout(() => {
+      if (activePhotoRequestIdRef.current === requestId) {
+        activePhotoRequestIdRef.current = null;
+        setCameraStatus('Camera: timed out waiting for phone upload');
+        markPhotoRequestFailed(requestId, 'UPLOAD_TIMEOUT', 'Timed out waiting for phone upload');
+        addEvent('TX', `phone photo upload timed out ${requestId}`);
+      }
+    }, DIRECT_PHOTO_UPLOAD_TIMEOUT_MS);
   }
 
   function handlePhotoStatus(payload: PhotoStatusEvent) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -474,6 +474,8 @@ const PHOTO_APP_ID = 'com.mentra.examples.reactnative';
 const PHOTO_POLL_ATTEMPTS = 45;
 const VIDEO_POLL_ATTEMPTS = 180;
 const DIRECT_PHOTO_UPLOAD_TIMEOUT_MS = 75_000;
+export const PHOTO_BLE_FALLBACK_QUALITY_WARNING =
+  'Wi-Fi upload failed; photo was compressed for Bluetooth fallback, so image quality is lower.';
 const DIRECT_WEBRTC_RECEIVER_WARMUP_MS = 1000;
 const BARCODE_SCAN_VISIBLE_TIMEOUT_MS = 2_500;
 const ANDROID_12_API_LEVEL = 31;
@@ -1589,6 +1591,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         });
         handlePhotoResponse(response);
       } catch (error) {
+        if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
+          markPhotoRequestStillWaiting(requestId, 'Cloud server', error);
+          void pollPhotoPreview(requestId, statusUrl, pollGeneration);
+          return;
+        }
         if (activePhotoRequestIdRef.current === requestId) {
           activePhotoRequestIdRef.current = null;
         }
@@ -1630,6 +1637,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       });
       handlePhotoResponse(response);
     } catch (error) {
+      if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
+        markPhotoRequestStillWaiting(requestId, 'Phone receiver', error);
+        return;
+      }
       clearPhotoUploadTimeout();
       if (activePhotoRequestIdRef.current === requestId) {
         activePhotoRequestIdRef.current = null;
@@ -1708,7 +1719,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoPreviewDetails((current) => ({
       ...current,
       bleFallbackMessage: current?.bleFallbackUsed
-        ? 'Wi-Fi upload failed; photo was compressed and delivered through Bluetooth.'
+        ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
         : current?.bleFallbackMessage,
       byteCount: payload.byteCount,
       previewUrl: payload.fileUri,
@@ -1798,6 +1809,32 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       errorCode,
       errorMessage,
     });
+  }
+
+  function markPhotoRequestStillWaiting(
+    requestId: string,
+    source: PhotoPreviewDetails['source'],
+    error: unknown,
+  ) {
+    setPhotoStatus({
+      type: 'photo_status',
+      requestId,
+      status: 'uploading',
+      timestamp: Date.now(),
+    });
+    setPhotoPreviewDetails((current) => ({
+      ...current,
+      error: undefined,
+      requestId,
+      source,
+      state: current?.state === 'preview' ? 'preview' : 'acknowledged',
+      timestamp: Date.now(),
+    }));
+    setCameraStatus('Camera: still waiting for photo delivery');
+    addEvent(
+      'LIVE',
+      `photo request still waiting after SDK timeout ${requestId}: ${formatError(error)}`,
+    );
   }
 
   function handlePhotoStatus(payload: PhotoStatusEvent) {
@@ -2105,7 +2142,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             setPhotoPreviewDetails((current) => ({
               ...current,
               bleFallbackMessage: current?.bleFallbackUsed
-                ? 'Wi-Fi upload failed; photo was compressed and delivered through Bluetooth.'
+                ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
                 : current?.bleFallbackMessage,
               byteCount: typeof json.fileSizeBytes === 'number' ? json.fileSizeBytes : current?.byteCount,
               contentType: json.contentType ?? current?.contentType,
@@ -4074,16 +4111,16 @@ function photoStatusLabel(event: PhotoStatusEvent, galleryModeButtonPhoto = fals
 
 function photoBleFallbackMessage(status: string) {
   return status === 'ble_fallback_compression'
-    ? 'Wi-Fi upload failed; compressing photo for Bluetooth fallback.'
+    ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
     : null;
 }
 
 function photoBleFallbackProgressMessage(status: string, currentMessage?: string) {
   switch (status) {
     case 'ready_for_transfer':
-      return 'Wi-Fi upload failed; compressed photo is ready for Bluetooth fallback.';
+      return PHOTO_BLE_FALLBACK_QUALITY_WARNING;
     case 'transferring':
-      return 'Wi-Fi upload failed; sending compressed photo over Bluetooth.';
+      return PHOTO_BLE_FALLBACK_QUALITY_WARNING;
     default:
       return currentMessage;
   }
@@ -4257,6 +4294,14 @@ function otaStatusSessionKey(status: OtaStatusEvent) {
 
 function formatError(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isPhotoRequestTimeoutError(error: unknown) {
+  const message = formatError(error).toLowerCase();
+  return (
+    message.includes('request_timeout') ||
+    message.includes('timed out waiting for glasses response')
+  );
 }
 
 function webhookReachabilityErrorMessage(error: unknown, healthUrl: string) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1219,47 +1219,67 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       compress: overrides.compress ?? photoCompression,
       sound: false,
     };
+    let shouldResetCaptureTuning = false;
     const aeExposureDivisor = hasOverride('aeExposureDivisor')
       ? overrides.aeExposureDivisor
       : photoAeExposureDivisor;
     if (aeExposureDivisor != null) {
       settings.aeExposureDivisor = aeExposureDivisor;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const isoCap = hasOverride('isoCap') ? overrides.isoCap : photoIsoCap;
     if (isoCap != null) {
       settings.isoCap = isoCap;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const noiseReduction = hasOverride('noiseReduction')
       ? overrides.noiseReduction
       : optionalTuningFlag(photoNoiseReduction);
     if (noiseReduction != null) {
       settings.noiseReduction = noiseReduction;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const edgeEnhancement = hasOverride('edgeEnhancement')
       ? overrides.edgeEnhancement
       : optionalTuningFlag(photoEdgeEnhancement);
     if (edgeEnhancement != null) {
       settings.edgeEnhancement = edgeEnhancement;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const mfnr = hasOverride('mfnr') ? overrides.mfnr : optionalTuningFlag(photoMfnr);
     if (mfnr != null) {
       settings.mfnr = mfnr;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const zsl = hasOverride('zsl') ? overrides.zsl : optionalTuningFlag(photoZsl);
     if (zsl != null) {
       settings.zsl = zsl;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const ispDigitalGain = hasOverride('ispDigitalGain')
       ? overrides.ispDigitalGain
       : photoIspDigitalGain;
     if (ispDigitalGain != null) {
       settings.ispDigitalGain = ispDigitalGain;
+    } else {
+      shouldResetCaptureTuning = true;
     }
     const ispAnalogGain = hasOverride('ispAnalogGain')
       ? overrides.ispAnalogGain
       : photoIspAnalogGain;
     if (ispAnalogGain != null) {
       settings.ispAnalogGain = ispAnalogGain;
+    } else {
+      shouldResetCaptureTuning = true;
+    }
+    if (shouldResetCaptureTuning) {
+      settings.resetCaptureTuning = true;
     }
     return settings;
   }

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -214,8 +214,6 @@ export type PhotoIspDigitalGain = 0 | 1 | 2 | 4;
 export type PhotoIspAnalogGain = 'low';
 export type PhotoTuningFlag = 'unset' | 'on' | 'off';
 export type ScanAeDivisor = 3 | 5;
-export const SCAN_AE_DIVISOR_OPTIONS: ScanAeDivisor[] = [3, 5];
-export const SCAN_ISO_CAP_OPTIONS = [400, 800] as const;
 export const SCAN_DEFAULT_AE_DIVISOR: ScanAeDivisor = 3;
 export const SCAN_DEFAULT_ISO_CAP = 800;
 
@@ -232,16 +230,6 @@ export const SCAN_MODE_BUTTON_PRESET = {
   sound: false,
 } as const;
 
-function buildScanButtonPreset(
-  aeExposureDivisor: ScanAeDivisor,
-  isoCap: number,
-): ButtonPhotoSettings & { aeExposureDivisor: ScanAeDivisor; isoCap: number } {
-  return {
-    ...SCAN_MODE_BUTTON_PRESET,
-    aeExposureDivisor,
-    isoCap,
-  };
-}
 export const SCAN_MODELS = [DeviceModels.MentraLive, DeviceModels.G2] as const;
 export type ScanModel = (typeof SCAN_MODELS)[number];
 type StreamStartRequest = {
@@ -263,6 +251,18 @@ type PersistedCloudUrls = {
   streamUrl?: string;
   version: 1;
   webhookUrl?: string;
+};
+type ButtonPhotoSettingsOverrides = {
+  aeExposureDivisor?: number | null;
+  compress?: PhotoCompression;
+  edgeEnhancement?: boolean;
+  ispAnalogGain?: string | null;
+  ispDigitalGain?: number | null;
+  isoCap?: number | null;
+  mfnr?: boolean;
+  noiseReduction?: boolean;
+  size?: ButtonPhotoSettings['size'];
+  zsl?: boolean;
 };
 
 export const RGB_LED_COLORS: LedColor[] = ['red', 'green', 'blue', 'orange', 'white'];
@@ -444,7 +444,6 @@ export type BluetoothSdkExampleActions = {
   setPhotoZsl: (value: PhotoTuningFlag) => void;
   setPhotoIspDigitalGain: (gain: PhotoIspDigitalGain | null) => void;
   setPhotoIspAnalogGain: (gain: PhotoIspAnalogGain | null) => void;
-  applyBarcodeScanPhotoPreset: () => void;
   setPhotoExposureManual: (enabled: boolean) => void;
   setPhotoIso: (iso: number) => void;
   setPhotoExposureTimeNs: (exposureTimeNs: number) => void;
@@ -609,6 +608,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const pollGenerationRef = useRef(0);
   const videoPollGenerationRef = useRef(0);
   const photoCloudServerEnabledRef = useRef(false);
+  const scanModeRef = useRef(false);
   const streamCloudServerEnabledRef = useRef(false);
   const activeTabRef = useRef<ExampleTabKey>('device');
   const galleryModeEnabledRef = useRef(false);
@@ -905,7 +905,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (glassesConnected) {
       if (!wasConnectedRef.current && scanMode) {
         // Re-apply scan preset on reconnect so glasses button preset stays in sync.
-        void syncScanCapturePreset(scanMode, scanAeDivisor, scanIsoCap);
+        void syncScanCapturePreset(true, buildButtonPhotoSettings());
       }
       wasConnectedRef.current = true;
       return;
@@ -1135,8 +1135,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   async function syncScanCapturePreset(
     enabled: boolean,
-    aeDivisor: ScanAeDivisor = scanAeDivisor,
-    isoCapValue: number = scanIsoCap,
+    settings?: ButtonPhotoSettings,
   ) {
     if (!isGlassesConnected(bluetooth.glasses)) {
       return;
@@ -1144,9 +1143,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     await runAction(enabled ? 'Apply scan preset on glasses' : 'Restore photo preset on glasses', async () => {
       requireConnected('sync photo capture settings');
       if (enabled) {
-        await BluetoothSdk.setButtonPhotoSettings(
-          buildScanButtonPreset(aeDivisor, isoCapValue),
-        );
+        await BluetoothSdk.setButtonPhotoSettings(settings ?? buildButtonPhotoSettings());
       } else {
         await BluetoothSdk.setButtonPhotoSettings({
           size: photoSize,
@@ -1159,21 +1156,30 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   function setScanModeAction(enabled: boolean) {
+    scanModeRef.current = enabled;
     setScanMode(enabled);
-    void syncScanCapturePreset(enabled);
+    if (enabled) {
+      applyBarcodeScanPhotoPresetValues();
+      void syncScanCapturePreset(true, buttonPhotoSettingsFromBarcodePreset());
+    } else {
+      resetBarcodeScan();
+      void syncScanCapturePreset(false);
+    }
   }
 
   function setScanAeDivisorAction(divisor: ScanAeDivisor) {
     setScanAeDivisor(divisor);
+    setPhotoAeExposureDivisor(divisor);
     if (scanMode) {
-      void syncScanCapturePreset(true, divisor, scanIsoCap);
+      void syncScanCapturePreset(true, buildButtonPhotoSettings({aeExposureDivisor: divisor}));
     }
   }
 
   function setScanIsoCapAction(isoCapValue: number) {
     setScanIsoCap(isoCapValue);
+    setPhotoIsoCap(isoCapValue as PhotoIsoCap);
     if (scanMode) {
-      void syncScanCapturePreset(true, scanAeDivisor, isoCapValue);
+      void syncScanCapturePreset(true, buildButtonPhotoSettings({isoCap: isoCapValue}));
     }
   }
 
@@ -1182,6 +1188,73 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       return undefined;
     }
     return value === 'on';
+  }
+
+  function buttonPhotoSettingsFromBarcodePreset(): ButtonPhotoSettings {
+    return {
+      ...SCAN_MODE_BUTTON_PRESET,
+      aeExposureDivisor: BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor,
+      isoCap: BARCODE_SCAN_PHOTO_PRESET.isoCap,
+    };
+  }
+
+  function buildButtonPhotoSettings(overrides: ButtonPhotoSettingsOverrides = {}): ButtonPhotoSettings {
+    const hasOverride = (key: keyof ButtonPhotoSettingsOverrides) =>
+      Object.prototype.hasOwnProperty.call(overrides, key);
+    const settings: ButtonPhotoSettings = {
+      size: overrides.size ?? photoSize,
+      compress: overrides.compress ?? photoCompression,
+      sound: false,
+    };
+    const aeExposureDivisor = hasOverride('aeExposureDivisor')
+      ? overrides.aeExposureDivisor
+      : photoAeExposureDivisor;
+    if (aeExposureDivisor != null) {
+      settings.aeExposureDivisor = aeExposureDivisor;
+    }
+    const isoCap = hasOverride('isoCap') ? overrides.isoCap : photoIsoCap;
+    if (isoCap != null) {
+      settings.isoCap = isoCap;
+    }
+    const noiseReduction = hasOverride('noiseReduction')
+      ? overrides.noiseReduction
+      : optionalTuningFlag(photoNoiseReduction);
+    if (noiseReduction != null) {
+      settings.noiseReduction = noiseReduction;
+    }
+    const edgeEnhancement = hasOverride('edgeEnhancement')
+      ? overrides.edgeEnhancement
+      : optionalTuningFlag(photoEdgeEnhancement);
+    if (edgeEnhancement != null) {
+      settings.edgeEnhancement = edgeEnhancement;
+    }
+    const mfnr = hasOverride('mfnr') ? overrides.mfnr : optionalTuningFlag(photoMfnr);
+    if (mfnr != null) {
+      settings.mfnr = mfnr;
+    }
+    const zsl = hasOverride('zsl') ? overrides.zsl : optionalTuningFlag(photoZsl);
+    if (zsl != null) {
+      settings.zsl = zsl;
+    }
+    const ispDigitalGain = hasOverride('ispDigitalGain')
+      ? overrides.ispDigitalGain
+      : photoIspDigitalGain;
+    if (ispDigitalGain != null) {
+      settings.ispDigitalGain = ispDigitalGain;
+    }
+    const ispAnalogGain = hasOverride('ispAnalogGain')
+      ? overrides.ispAnalogGain
+      : photoIspAnalogGain;
+    if (ispAnalogGain != null) {
+      settings.ispAnalogGain = ispAnalogGain;
+    }
+    return settings;
+  }
+
+  function syncButtonPresetIfScanMode(settings?: ButtonPhotoSettings) {
+    if (scanModeRef.current) {
+      void syncScanCapturePreset(true, settings);
+    }
   }
 
   function addRequestTuningFields(
@@ -1222,27 +1295,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     PhotoRequestParams,
     'requestId' | 'appId' | 'webhookUrl' | 'authToken'
   > {
-    if (scanMode) {
-      return {
-        size: 'max',
-        compress: 'none',
-        sound: false,
-        exposureTimeNs: null,
-        iso: null,
-        aeExposureDivisor: scanAeDivisor,
-        isoCap: scanIsoCap,
-        noiseReduction: false,
-        edgeEnhancement: false,
-        mfnr: false,
-        zsl: false,
-        ispDigitalGain: 0,
-        ispAnalogGain: 'low',
-      };
-    }
     return addRequestTuningFields({
       size: photoSize,
       compress: photoCompression,
-      sound: true,
+      sound: !scanMode,
       exposureTimeNs: photoExposureManual ? photoExposureTimeNs : null,
       iso: photoExposureManual ? photoIso : null,
     });
@@ -1558,7 +1614,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       state: 'preview',
     }));
     void updatePhotoPreviewMetadata(payload.fileUri);
-    void scanPreviewBarcode(payload.fileUri);
+    if (scanModeRef.current) {
+      void scanPreviewBarcode(payload.fileUri);
+    }
     setCameraStatus(`Camera: phone photo ready (${Math.round(payload.byteCount / 1024)} KB)`);
     addEvent('LIVE', `phone photo ready ${payload.fileUri}`);
   }
@@ -1955,7 +2013,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
               uploadedAt: json.uploadedAt ?? current?.uploadedAt,
             }));
             void updatePhotoPreviewMetadata(json.photoUrl);
-            void scanPreviewBarcode(json.photoUrl);
+            if (scanModeRef.current) {
+              void scanPreviewBarcode(json.photoUrl);
+            }
             setCameraStatus('Camera: loaded photo preview');
             addEvent('LIVE', `local photo ready ${json.photoUrl}`);
             activePhotoRequestIdRef.current = null;
@@ -2196,9 +2256,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoIsoState(clampRounded(iso, PHOTO_ISO_MIN, PHOTO_ISO_MAX));
   }
 
-  function applyBarcodeScanPhotoPresetAction() {
+  function applyBarcodeScanPhotoPresetValues() {
     setPhotoSize(BARCODE_SCAN_PHOTO_PRESET.size);
     setPhotoCompression(BARCODE_SCAN_PHOTO_PRESET.compress);
+    setScanAeDivisor(BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor);
+    setScanIsoCap(BARCODE_SCAN_PHOTO_PRESET.isoCap);
     setPhotoExposureManual(true);
     setPhotoExposureTimeNsState(BARCODE_SCAN_PHOTO_PRESET.exposureTimeNs);
     setPhotoIsoState(BARCODE_SCAN_PHOTO_PRESET.iso);
@@ -2210,6 +2272,62 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoZsl(BARCODE_SCAN_PHOTO_PRESET.zsl);
     setPhotoIspDigitalGain(BARCODE_SCAN_PHOTO_PRESET.ispDigitalGain);
     setPhotoIspAnalogGain(BARCODE_SCAN_PHOTO_PRESET.ispAnalogGain);
+  }
+
+  function setPhotoSizeAction(size: PhotoSize) {
+    setPhotoSize(size);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({size}));
+  }
+
+  function setPhotoCompressionAction(compression: PhotoCompression) {
+    setPhotoCompression(compression);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({compress: compression}));
+  }
+
+  function setPhotoAeExposureDivisorAction(divisor: PhotoAeExposureDivisor | null) {
+    setPhotoAeExposureDivisor(divisor);
+    if (divisor === 3 || divisor === 5) {
+      setScanAeDivisor(divisor);
+    }
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({aeExposureDivisor: divisor}));
+  }
+
+  function setPhotoIsoCapAction(isoCap: PhotoIsoCap | null) {
+    setPhotoIsoCap(isoCap);
+    if (isoCap === 400 || isoCap === 800) {
+      setScanIsoCap(isoCap);
+    }
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({isoCap}));
+  }
+
+  function setPhotoNoiseReductionAction(value: PhotoTuningFlag) {
+    setPhotoNoiseReduction(value);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({noiseReduction: optionalTuningFlag(value)}));
+  }
+
+  function setPhotoEdgeEnhancementAction(value: PhotoTuningFlag) {
+    setPhotoEdgeEnhancement(value);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({edgeEnhancement: optionalTuningFlag(value)}));
+  }
+
+  function setPhotoMfnrAction(value: PhotoTuningFlag) {
+    setPhotoMfnr(value);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({mfnr: optionalTuningFlag(value)}));
+  }
+
+  function setPhotoZslAction(value: PhotoTuningFlag) {
+    setPhotoZsl(value);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({zsl: optionalTuningFlag(value)}));
+  }
+
+  function setPhotoIspDigitalGainAction(gain: PhotoIspDigitalGain | null) {
+    setPhotoIspDigitalGain(gain);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({ispDigitalGain: gain}));
+  }
+
+  function setPhotoIspAnalogGainAction(gain: PhotoIspAnalogGain | null) {
+    setPhotoIspAnalogGain(gain);
+    syncButtonPresetIfScanMode(buildButtonPhotoSettings({ispAnalogGain: gain}));
   }
 
   function setCameraFovAction(fov: number) {
@@ -3148,21 +3266,20 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     selectProtocol,
     sendWifiCredentials,
     setGalleryModeEnabled: setGalleryModeEnabledAction,
-    setPhotoCompression,
+    setPhotoCompression: setPhotoCompressionAction,
     setPhotoCloudServerEnabled: setPhotoCloudServerEnabledAction,
-    setPhotoAeExposureDivisor,
-    setPhotoIsoCap,
-    setPhotoNoiseReduction,
-    setPhotoEdgeEnhancement,
-    setPhotoMfnr,
-    setPhotoZsl,
-    setPhotoIspDigitalGain,
-    setPhotoIspAnalogGain,
-    applyBarcodeScanPhotoPreset: applyBarcodeScanPhotoPresetAction,
+    setPhotoAeExposureDivisor: setPhotoAeExposureDivisorAction,
+    setPhotoIsoCap: setPhotoIsoCapAction,
+    setPhotoNoiseReduction: setPhotoNoiseReductionAction,
+    setPhotoEdgeEnhancement: setPhotoEdgeEnhancementAction,
+    setPhotoMfnr: setPhotoMfnrAction,
+    setPhotoZsl: setPhotoZslAction,
+    setPhotoIspDigitalGain: setPhotoIspDigitalGainAction,
+    setPhotoIspAnalogGain: setPhotoIspAnalogGainAction,
     setPhotoExposureManual,
     setPhotoIso: setPhotoIsoAction,
     setPhotoExposureTimeNs: setPhotoExposureTimeNsAction,
-    setPhotoSize,
+    setPhotoSize: setPhotoSizeAction,
     setScanMode: setScanModeAction,
     setScanAeDivisor: setScanAeDivisorAction,
     setScanIsoCap: setScanIsoCapAction,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -286,8 +286,6 @@ const photoTuningFlagFromPreset = (value: boolean): Exclude<PhotoTuningFlag, 'un
   value ? 'on' : 'off';
 export const BARCODE_SCAN_PHOTO_PRESET = {
   ...SCAN_MODE_BUTTON_PRESET,
-  exposureTimeNs: PHOTO_EXPOSURE_DEFAULT_NS,
-  iso: PHOTO_ISO_DEFAULT,
   aeExposureDivisor: SCAN_DEFAULT_AE_DIVISOR,
   isoCap: SCAN_DEFAULT_ISO_CAP,
   noiseReduction: photoTuningFlagFromPreset(SCAN_MODE_BUTTON_PRESET.noiseReduction),
@@ -1365,10 +1363,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   function addRequestTuningFields(
     fields: Omit<PhotoRequestParams, 'requestId' | 'appId' | 'webhookUrl' | 'authToken'>,
   ) {
-    if (photoAeExposureDivisor !== null) {
+    if (!photoExposureManual && photoAeExposureDivisor !== null) {
       fields.aeExposureDivisor = photoAeExposureDivisor;
     }
-    if (photoIsoCap !== null) {
+    if (!photoExposureManual && photoIsoCap !== null) {
       fields.isoCap = photoIsoCap;
     }
     const noiseReduction = optionalTuningFlag(photoNoiseReduction);
@@ -2366,10 +2364,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoCompression(BARCODE_SCAN_PHOTO_PRESET.compress);
     setScanAeDivisor(BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor);
     setScanIsoCap(BARCODE_SCAN_PHOTO_PRESET.isoCap);
-    // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
-    setPhotoExposureManual(true);
-    setPhotoExposureTimeNsState(BARCODE_SCAN_PHOTO_PRESET.exposureTimeNs);
-    setPhotoIsoState(BARCODE_SCAN_PHOTO_PRESET.iso);
+    // Barcode scan tuning relies on ASG auto metering plus AE divisor / ISO cap.
+    setPhotoExposureManual(false);
     setPhotoAeExposureDivisor(BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor);
     setPhotoIsoCap(BARCODE_SCAN_PHOTO_PRESET.isoCap);
     setPhotoNoiseReduction(BARCODE_SCAN_PHOTO_PRESET.noiseReduction);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -208,6 +208,11 @@ type RgbLedAction = 'on' | 'off';
 export type LedColor = 'red' | 'green' | 'blue' | 'orange' | 'white';
 export type PhotoSize = 'low' | 'medium' | 'high' | 'max';
 export type PhotoCompression = 'none' | 'medium' | 'heavy';
+export type PhotoAeExposureDivisor = 2 | 3 | 5;
+export type PhotoIsoCap = 400 | 800 | 1600;
+export type PhotoIspDigitalGain = 0 | 1 | 2 | 4;
+export type PhotoIspAnalogGain = 'low';
+export type PhotoTuningFlag = 'unset' | 'on' | 'off';
 export type ScanAeDivisor = 3 | 5;
 export const SCAN_AE_DIVISOR_OPTIONS: ScanAeDivisor[] = [3, 5];
 export const SCAN_ISO_CAP_OPTIONS = [400, 800] as const;
@@ -263,6 +268,11 @@ type PersistedCloudUrls = {
 export const RGB_LED_COLORS: LedColor[] = ['red', 'green', 'blue', 'orange', 'white'];
 export const PHOTO_SIZES: PhotoSize[] = ['low', 'medium', 'high', 'max'];
 export const PHOTO_COMPRESSIONS: PhotoCompression[] = ['none', 'medium', 'heavy'];
+export const PHOTO_AE_EXPOSURE_DIVISOR_OPTIONS: PhotoAeExposureDivisor[] = [2, 3, 5];
+export const PHOTO_ISO_CAP_OPTIONS: PhotoIsoCap[] = [400, 800, 1600];
+export const PHOTO_ISP_DIGITAL_GAIN_OPTIONS: PhotoIspDigitalGain[] = [0, 1, 2, 4];
+export const PHOTO_ISP_ANALOG_GAIN_OPTIONS: PhotoIspAnalogGain[] = ['low'];
+export const PHOTO_TUNING_FLAG_OPTIONS: PhotoTuningFlag[] = ['unset', 'on', 'off'];
 export const STREAM_MIN_FPS = 1;
 export const STREAM_MAX_FPS = 24;
 export const STREAM_DEFAULT_FPS = 15;
@@ -340,6 +350,14 @@ export type BluetoothSdkExampleState = {
   phonePhotoUploadUrl: string | null;
   photoCompression: PhotoCompression;
   photoCloudServerEnabled: boolean;
+  photoAeExposureDivisor: PhotoAeExposureDivisor | null;
+  photoIsoCap: PhotoIsoCap | null;
+  photoNoiseReduction: PhotoTuningFlag;
+  photoEdgeEnhancement: PhotoTuningFlag;
+  photoMfnr: PhotoTuningFlag;
+  photoZsl: PhotoTuningFlag;
+  photoIspDigitalGain: PhotoIspDigitalGain | null;
+  photoIspAnalogGain: PhotoIspAnalogGain | null;
   photoExposureManual: boolean;
   photoIso: number;
   photoExposureTimeNs: number;
@@ -405,6 +423,14 @@ export type BluetoothSdkExampleActions = {
   setGalleryModeEnabled: (enabled: boolean) => Promise<void>;
   setPhotoCompression: (compression: PhotoCompression) => void;
   setPhotoCloudServerEnabled: (enabled: boolean) => Promise<void>;
+  setPhotoAeExposureDivisor: (divisor: PhotoAeExposureDivisor | null) => void;
+  setPhotoIsoCap: (isoCap: PhotoIsoCap | null) => void;
+  setPhotoNoiseReduction: (value: PhotoTuningFlag) => void;
+  setPhotoEdgeEnhancement: (value: PhotoTuningFlag) => void;
+  setPhotoMfnr: (value: PhotoTuningFlag) => void;
+  setPhotoZsl: (value: PhotoTuningFlag) => void;
+  setPhotoIspDigitalGain: (gain: PhotoIspDigitalGain | null) => void;
+  setPhotoIspAnalogGain: (gain: PhotoIspAnalogGain | null) => void;
   setPhotoExposureManual: (enabled: boolean) => void;
   setPhotoIso: (iso: number) => void;
   setPhotoExposureTimeNs: (exposureTimeNs: number) => void;
@@ -501,6 +527,17 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [scanMode, setScanMode] = useState(false);
   const [scanAeDivisor, setScanAeDivisor] = useState<ScanAeDivisor>(SCAN_DEFAULT_AE_DIVISOR);
   const [scanIsoCap, setScanIsoCap] = useState(SCAN_DEFAULT_ISO_CAP);
+  const [photoAeExposureDivisor, setPhotoAeExposureDivisor] =
+    useState<PhotoAeExposureDivisor | null>(null);
+  const [photoIsoCap, setPhotoIsoCap] = useState<PhotoIsoCap | null>(null);
+  const [photoNoiseReduction, setPhotoNoiseReduction] = useState<PhotoTuningFlag>('unset');
+  const [photoEdgeEnhancement, setPhotoEdgeEnhancement] = useState<PhotoTuningFlag>('unset');
+  const [photoMfnr, setPhotoMfnr] = useState<PhotoTuningFlag>('unset');
+  const [photoZsl, setPhotoZsl] = useState<PhotoTuningFlag>('unset');
+  const [photoIspDigitalGain, setPhotoIspDigitalGain] =
+    useState<PhotoIspDigitalGain | null>(null);
+  const [photoIspAnalogGain, setPhotoIspAnalogGain] =
+    useState<PhotoIspAnalogGain | null>(null);
   const [photoExposureManual, setPhotoExposureManual] = useState(false);
   const [photoExposureTimeNs, setPhotoExposureTimeNsState] = useState(PHOTO_EXPOSURE_DEFAULT_NS);
   const [photoIso, setPhotoIsoState] = useState(PHOTO_ISO_DEFAULT);
@@ -1126,6 +1163,47 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
   }
 
+  function optionalTuningFlag(value: PhotoTuningFlag) {
+    if (value === 'unset') {
+      return undefined;
+    }
+    return value === 'on';
+  }
+
+  function addRequestTuningFields(
+    fields: Omit<PhotoRequestParams, 'requestId' | 'appId' | 'webhookUrl' | 'authToken'>,
+  ) {
+    if (photoAeExposureDivisor !== null) {
+      fields.aeExposureDivisor = photoAeExposureDivisor;
+    }
+    if (photoIsoCap !== null) {
+      fields.isoCap = photoIsoCap;
+    }
+    const noiseReduction = optionalTuningFlag(photoNoiseReduction);
+    if (noiseReduction !== undefined) {
+      fields.noiseReduction = noiseReduction;
+    }
+    const edgeEnhancement = optionalTuningFlag(photoEdgeEnhancement);
+    if (edgeEnhancement !== undefined) {
+      fields.edgeEnhancement = edgeEnhancement;
+    }
+    const mfnr = optionalTuningFlag(photoMfnr);
+    if (mfnr !== undefined) {
+      fields.mfnr = mfnr;
+    }
+    const zsl = optionalTuningFlag(photoZsl);
+    if (zsl !== undefined) {
+      fields.zsl = zsl;
+    }
+    if (photoIspDigitalGain !== null) {
+      fields.ispDigitalGain = photoIspDigitalGain;
+    }
+    if (photoIspAnalogGain !== null) {
+      fields.ispAnalogGain = photoIspAnalogGain;
+    }
+    return fields;
+  }
+
   function buildPhotoRequestFields(): Omit<
     PhotoRequestParams,
     'requestId' | 'appId' | 'webhookUrl' | 'authToken'
@@ -1147,13 +1225,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         ispAnalogGain: 'low',
       };
     }
-    return {
+    return addRequestTuningFields({
       size: photoSize,
       compress: photoCompression,
       sound: true,
       exposureTimeNs: photoExposureManual ? photoExposureTimeNs : null,
       iso: photoExposureManual ? photoIso : null,
-    };
+    });
   }
 
   async function captureAndUpload() {
@@ -3006,6 +3084,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     phonePhotoUploadUrl,
     photoCompression,
     photoCloudServerEnabled,
+    photoAeExposureDivisor,
+    photoIsoCap,
+    photoNoiseReduction,
+    photoEdgeEnhancement,
+    photoMfnr,
+    photoZsl,
+    photoIspDigitalGain,
+    photoIspAnalogGain,
     photoExposureManual,
     photoIso,
     photoExposureTimeNs,
@@ -3034,6 +3120,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setGalleryModeEnabled: setGalleryModeEnabledAction,
     setPhotoCompression,
     setPhotoCloudServerEnabled: setPhotoCloudServerEnabledAction,
+    setPhotoAeExposureDivisor,
+    setPhotoIsoCap,
+    setPhotoNoiseReduction,
+    setPhotoEdgeEnhancement,
+    setPhotoMfnr,
+    setPhotoZsl,
+    setPhotoIspDigitalGain,
+    setPhotoIspAnalogGain,
     setPhotoExposureManual,
     setPhotoIso: setPhotoIsoAction,
     setPhotoExposureTimeNs: setPhotoExposureTimeNsAction,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -230,7 +230,7 @@ export const SCAN_MODE_BUTTON_PRESET = {
   ispAnalogGain: 'low' as const,
   compress: 'none' as const,
   sound: false,
-};
+} as const;
 
 function buildScanButtonPreset(
   aeExposureDivisor: ScanAeDivisor,
@@ -282,6 +282,19 @@ export const PHOTO_EXPOSURE_DEFAULT_NS = 8_333_333;
 export const PHOTO_ISO_MIN = 100;
 export const PHOTO_ISO_MAX = 6400;
 export const PHOTO_ISO_DEFAULT = 200;
+const photoTuningFlagFromPreset = (value: boolean): Exclude<PhotoTuningFlag, 'unset'> =>
+  value ? 'on' : 'off';
+export const BARCODE_SCAN_PHOTO_PRESET = {
+  ...SCAN_MODE_BUTTON_PRESET,
+  exposureTimeNs: PHOTO_EXPOSURE_DEFAULT_NS,
+  iso: PHOTO_ISO_DEFAULT,
+  aeExposureDivisor: SCAN_DEFAULT_AE_DIVISOR,
+  isoCap: SCAN_DEFAULT_ISO_CAP,
+  noiseReduction: photoTuningFlagFromPreset(SCAN_MODE_BUTTON_PRESET.noiseReduction),
+  edgeEnhancement: photoTuningFlagFromPreset(SCAN_MODE_BUTTON_PRESET.edgeEnhancement),
+  mfnr: photoTuningFlagFromPreset(SCAN_MODE_BUTTON_PRESET.mfnr),
+  zsl: photoTuningFlagFromPreset(SCAN_MODE_BUTTON_PRESET.zsl),
+} as const;
 export const CAMERA_FOV_MIN = 62;
 export const CAMERA_FOV_MAX = 118;
 export const CAMERA_FOV_DEFAULT = 102;
@@ -431,6 +444,7 @@ export type BluetoothSdkExampleActions = {
   setPhotoZsl: (value: PhotoTuningFlag) => void;
   setPhotoIspDigitalGain: (gain: PhotoIspDigitalGain | null) => void;
   setPhotoIspAnalogGain: (gain: PhotoIspAnalogGain | null) => void;
+  applyBarcodeScanPhotoPreset: () => void;
   setPhotoExposureManual: (enabled: boolean) => void;
   setPhotoIso: (iso: number) => void;
   setPhotoExposureTimeNs: (exposureTimeNs: number) => void;
@@ -2182,6 +2196,22 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoIsoState(clampRounded(iso, PHOTO_ISO_MIN, PHOTO_ISO_MAX));
   }
 
+  function applyBarcodeScanPhotoPresetAction() {
+    setPhotoSize(BARCODE_SCAN_PHOTO_PRESET.size);
+    setPhotoCompression(BARCODE_SCAN_PHOTO_PRESET.compress);
+    setPhotoExposureManual(true);
+    setPhotoExposureTimeNsState(BARCODE_SCAN_PHOTO_PRESET.exposureTimeNs);
+    setPhotoIsoState(BARCODE_SCAN_PHOTO_PRESET.iso);
+    setPhotoAeExposureDivisor(BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor);
+    setPhotoIsoCap(BARCODE_SCAN_PHOTO_PRESET.isoCap);
+    setPhotoNoiseReduction(BARCODE_SCAN_PHOTO_PRESET.noiseReduction);
+    setPhotoEdgeEnhancement(BARCODE_SCAN_PHOTO_PRESET.edgeEnhancement);
+    setPhotoMfnr(BARCODE_SCAN_PHOTO_PRESET.mfnr);
+    setPhotoZsl(BARCODE_SCAN_PHOTO_PRESET.zsl);
+    setPhotoIspDigitalGain(BARCODE_SCAN_PHOTO_PRESET.ispDigitalGain);
+    setPhotoIspAnalogGain(BARCODE_SCAN_PHOTO_PRESET.ispAnalogGain);
+  }
+
   function setCameraFovAction(fov: number) {
     const nextFov = clampRounded(fov, CAMERA_FOV_MIN, CAMERA_FOV_MAX);
     setCameraFovState(nextFov);
@@ -3128,6 +3158,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoZsl,
     setPhotoIspDigitalGain,
     setPhotoIspAnalogGain,
+    applyBarcodeScanPhotoPreset: applyBarcodeScanPhotoPresetAction,
     setPhotoExposureManual,
     setPhotoIso: setPhotoIsoAction,
     setPhotoExposureTimeNs: setPhotoExposureTimeNsAction,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -609,6 +609,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const videoPollGenerationRef = useRef(0);
   const photoCloudServerEnabledRef = useRef(false);
   const scanModeRef = useRef(false);
+  const buttonPhotoSettingsSyncGenerationRef = useRef(0);
+  const buttonPhotoSettingsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
   const streamCloudServerEnabledRef = useRef(false);
   const activeTabRef = useRef<ExampleTabKey>('device');
   const galleryModeEnabledRef = useRef(false);
@@ -1133,26 +1135,37 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     });
   }
 
-  async function syncScanCapturePreset(
+  function syncScanCapturePreset(
     enabled: boolean,
     settings?: ButtonPhotoSettings,
   ) {
     if (!isGlassesConnected(bluetooth.glasses)) {
       return;
     }
-    await runAction(enabled ? 'Apply scan preset on glasses' : 'Restore photo preset on glasses', async () => {
-      requireConnected('sync photo capture settings');
-      if (enabled) {
-        await BluetoothSdk.setButtonPhotoSettings(settings ?? buildButtonPhotoSettings());
-      } else {
-        await BluetoothSdk.setButtonPhotoSettings({
+    const generation = buttonPhotoSettingsSyncGenerationRef.current + 1;
+    buttonPhotoSettingsSyncGenerationRef.current = generation;
+    const label = enabled ? 'Apply scan preset on glasses' : 'Restore photo preset on glasses';
+    const nextSettings = enabled
+      ? settings ?? buildButtonPhotoSettings()
+      : {
           size: photoSize,
           mfnr: true,
           zsl: true,
           resetCaptureTuning: true,
-        });
+        };
+    const syncTask = buttonPhotoSettingsSyncQueueRef.current.catch(() => undefined).then(async () => {
+      if (generation !== buttonPhotoSettingsSyncGenerationRef.current) {
+        return;
       }
+      await runAction(label, async () => {
+        if (generation !== buttonPhotoSettingsSyncGenerationRef.current) {
+          return;
+        }
+        requireConnected('sync photo capture settings');
+        await BluetoothSdk.setButtonPhotoSettings(nextSettings);
+      });
     });
+    buttonPhotoSettingsSyncQueueRef.current = syncTask;
   }
 
   function setScanModeAction(enabled: boolean) {
@@ -2261,6 +2274,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoCompression(BARCODE_SCAN_PHOTO_PRESET.compress);
     setScanAeDivisor(BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor);
     setScanIsoCap(BARCODE_SCAN_PHOTO_PRESET.isoCap);
+    // The barcode preset intentionally leaves auto exposure by setting both exposure and ISO.
     setPhotoExposureManual(true);
     setPhotoExposureTimeNsState(BARCODE_SCAN_PHOTO_PRESET.exposureTimeNs);
     setPhotoIsoState(BARCODE_SCAN_PHOTO_PRESET.iso);


### PR DESCRIPTION
## Summary
- add camera-tab controls for optional photo request tuning fields across React Native, Android, and iOS examples
- forward AE divisor, ISO cap, NR/edge/MFNR/ZSL, and ISP gain fields into app-triggered photo requests
- hide manual exposure/ISO preset controls while auto exposure is enabled and rename reset buttons as presets
- update scan-mode request snippets and native scan request/preset wiring for SDK 0.1.13 fields

## Validation
- `bunx tsc --noEmit` in `examples/react-native`
- `./gradlew :app:assembleDebug` in `examples/android`
- `xcodebuild -project examples/ios/MentraExample.xcodeproj -scheme MentraExample -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how example apps build photo requests and push hardware-button presets to connected glasses, which can alter real capture behavior during testing; scope is limited to example apps, not the core SDK.
> 
> **Overview**
> Adds **photo request tuning** to the Android, iOS, and React Native example camera tabs: AE divisor, ISO cap, noise reduction, edge enhancement, MFNR, ZSL, and ISP digital/analog gain, with unset/on/off chips and manual exposure hiding AE divisor / ISO cap.
> 
> **App-triggered captures** no longer use a separate scan-only `PhotoRequest` (max size, fixed tuning). They use the current size/compress settings and forward the optional tuning fields; scan mode mainly turns off shutter sound and applies the barcode preset when enabled.
> 
> **Scan / barcode mode** applies a shared barcode preset (max, no compress, AE÷3, ISO 800, tuning off/low) into UI state, pushes a full `ButtonPhotoSettings` built from that state to the glasses hardware button, and re-syncs on reconnect or when tuning changes. Button preset sync is **serialized** (mutex + generation on Android; queued tasks on iOS/RN) so rapid toggles do not race.
> 
> Camera UI tweaks: photo size/compress stay editable in scan mode; manual exposure sliders only when manual is on; new tuning card; scan card copy simplified (AE/ISO chips removed from scan card—they live under tuning). SDK sample snippets include the new `PhotoRequest` fields.
> 
> React Native also treats SDK photo **request timeouts** as “still waiting” and keeps polling for delivery, and only runs barcode recognition on previews when scan mode is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6a2c746ddb401ca6d7af0b821fe4529a1d24f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->