### PR TITLE
0.1.14

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -619,7 +619,7 @@ val started = sdk.startStream(
     StreamRequest(
         streamUrl = streamUrl,
         streamId = streamId,
-        video = StreamVideoConfig(frameRate = 15),
+        video = StreamVideoConfig(fps = 15),
     )
 )
 println("Stream started: ${started.status}")
@@ -636,7 +636,7 @@ let started = try await sdk.startStream(
     StreamRequest(
         streamUrl: streamUrl,
         streamId: streamId,
-        video: StreamVideoConfig(frameRate: 15)
+        video: StreamVideoConfig(fps: 15)
     )
 )
 print("Stream started: \(started.status)")
@@ -653,7 +653,7 @@ const started = await BluetoothSdk.startStream({
   type: 'start_stream',
   streamUrl,
   streamId,
-  video: {frameRate: 15},
+  video: {fps: 15},
 });
 console.log('Stream started', started.status);
 const stopped = await BluetoothSdk.stopStream();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -230,8 +230,8 @@ These are the supported React Native app developer entrypoints:
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
 | Display | `displayText`, `clearDisplay`, `showDashboard`, `setDashboardPosition`, `setHeadUpAngle`, `setScreenDisabled` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setButtonPhotoSettings`, `setButtonVideoRecordingSettings`, `setButtonCameraLed`, `setButtonMaxRecordingTime`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
-| Streaming | `startStream`, `keepStreamAlive`, `stopStream` |
+| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setVideoRecordingDefaults`, `setMaxVideoRecordingDuration`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
+| Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, `setPreferredMic`, `setVoiceActivityDetectionEnabled`, `setOwnAppAudioPlaying`, `getGlassesMediaVolume`, `setGlassesMediaVolume` |
 | LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate`, `retryOtaVersionCheck` |
 
@@ -311,10 +311,9 @@ sdk.setDashboardPosition(height = 4, depth = 6)
 sdk.setHeadUpAngle(angleDegrees = 20)
 sdk.setScreenDisabled(false)
 sdk.setGalleryModeEnabled(true)
-sdk.setButtonPhotoSettings(size = ButtonPhotoSize.MEDIUM)
-sdk.setButtonVideoRecordingSettings(width = 1280, height = 720, fps = 30)
-sdk.setButtonCameraLed(enabled = true)
-sdk.setButtonMaxRecordingTime(minutes = 3)
+sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size = PhotoSize.MEDIUM))
+sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width = 1280, height = 720, fps = 30))
+sdk.setMaxVideoRecordingDuration(minutes = 3)
 val cameraFov = sdk.setCameraFov(CameraFov(fov = 102, roiPosition = CameraRoiPosition.CENTER))
 println("Camera FOV applied at ${cameraFov.fov}°")
 ```
@@ -329,10 +328,9 @@ try await sdk.setDashboardPosition(height: 4, depth: 6)
 try await sdk.setHeadUpAngle(20)
 try await sdk.setScreenDisabled(false)
 try await sdk.setGalleryModeEnabled(true)
-try await sdk.setButtonPhotoSettings(size: .medium)
-try await sdk.setButtonVideoRecordingSettings(width: 1280, height: 720, fps: 30)
-try await sdk.setButtonCameraLed(enabled: true)
-try await sdk.setButtonMaxRecordingTime(minutes: 3)
+try await sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size: .medium))
+try await sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width: 1280, height: 720, fps: 30))
+try await sdk.setMaxVideoRecordingDuration(minutes: 3)
 let cameraFov = try await sdk.setCameraFov(CameraFov(fov: 102, roiPosition: .center))
 print("Camera FOV applied at \(cameraFov.fov)°")
 ```
@@ -347,10 +345,9 @@ await BluetoothSdk.setHeadUpAngle(20);
 await BluetoothSdk.setScreenDisabled(false);
 await BluetoothSdk.setGalleryModeEnabled(true);
 await BluetoothSdk.setGalleryModeEnabled(false);
-await BluetoothSdk.setButtonPhotoSettings('medium');
-await BluetoothSdk.setButtonVideoRecordingSettings(1280, 720, 30);
-await BluetoothSdk.setButtonCameraLed(true);
-await BluetoothSdk.setButtonMaxRecordingTime(3);
+await BluetoothSdk.setPhotoCaptureDefaults({size: 'medium'});
+await BluetoothSdk.setVideoRecordingDefaults({width: 1280, height: 720, fps: 30});
+await BluetoothSdk.setMaxVideoRecordingDuration(3);
 const cameraFov = await BluetoothSdk.setCameraFov({fov: 102, roiPosition: 'center'});
 console.log(`Camera FOV applied at ${cameraFov.fov}°`);
 ```
@@ -618,9 +615,14 @@ Android:
 ```kotlin
 val streamId = "stream-${System.currentTimeMillis()}"
 
-val started = sdk.startStream(StreamRequest(streamUrl = streamUrl, streamId = streamId))
+val started = sdk.startStream(
+    StreamRequest(
+        streamUrl = streamUrl,
+        streamId = streamId,
+        video = StreamVideoConfig(frameRate = 15),
+    )
+)
 println("Stream started: ${started.status}")
-sdk.keepStreamAlive(StreamKeepAliveRequest(streamId = streamId, ackId = "ack-${System.currentTimeMillis()}"))
 val stopped = sdk.stopStream()
 println("Stream stopped: ${stopped.status}")
 ```
@@ -630,9 +632,14 @@ iOS:
 ```swift
 let streamId = "stream-\(Int(Date().timeIntervalSince1970 * 1000))"
 
-let started = try await sdk.startStream(StreamRequest(streamUrl: streamUrl, streamId: streamId))
+let started = try await sdk.startStream(
+    StreamRequest(
+        streamUrl: streamUrl,
+        streamId: streamId,
+        video: StreamVideoConfig(frameRate: 15)
+    )
+)
 print("Stream started: \(started.status)")
-sdk.keepStreamAlive(StreamKeepAliveRequest(streamId: streamId, ackId: "ack-\(Int(Date().timeIntervalSince1970 * 1000))"))
 let stopped = try await sdk.stopStream()
 print("Stream stopped: \(stopped.status)")
 ```
@@ -642,14 +649,18 @@ React Native:
 ```ts
 const streamId = `stream-${Date.now()}`;
 
-const started = await BluetoothSdk.startStream({type: 'start_stream', streamUrl, streamId});
+const started = await BluetoothSdk.startStream({
+  type: 'start_stream',
+  streamUrl,
+  streamId,
+  video: {frameRate: 15},
+});
 console.log('Stream started', started.status);
-await BluetoothSdk.keepStreamAlive({type: 'keep_stream_alive', streamId, ackId: `ack-${Date.now()}`});
 const stopped = await BluetoothSdk.stopStream();
 console.log('Stream stopped', stopped.status);
 ```
 
-When `keepAlive` is enabled, call `keepStreamAlive` about every 15 seconds while the stream is active. For local streaming development, use `examples/local-demo-cloud` and paste the printed RTMP, SRT, or WHIP publish URL into the example app.
+The SDK sends stream keep-alives automatically while streaming and reports keep-alive failures through `stream_status`. For local streaming development, use `examples/local-demo-cloud` and paste the printed RTMP, SRT, or WHIP publish URL into the example app.
 
 ## Wi-Fi And Hotspot
 
@@ -832,7 +843,7 @@ Android and iOS expose typed callbacks/delegate methods instead of the React Nat
 | `setMicState` | `useGlassesMic = true`, `sendTranscript = false`, and `sendLc3Data = false` unless explicitly set. |
 | `PhotoRequest` / `requestPhoto` | Pass explicit size, compression, and sound. `exposureTimeNs` is optional; omitted or `null` means auto exposure. `iso` is only used with manual `exposureTimeNs`. The camera light is always enabled by the SDK. |
 | `startVideoRecording` / `stopVideoRecording` | `startVideoRecording` resolves from `recording_started`. `stopVideoRecording` without a webhook resolves from `recording_stopped`; with a webhook it waits for `recording_stopped` plus video `media_success` and rejects on video `media_error`. |
-| `StreamRequest` / `startStream` | `keepAlive = true`, `keepAliveIntervalSeconds = 15`, and `sound = true` by default in native SDK calls. The camera light is always enabled by the SDK. |
+| `StreamRequest` / `startStream` | `sound = true` by default in native SDK calls. The SDK sends stream keep-alives automatically, and the camera light is always enabled while streaming. |
 
 ## Error Handling
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.13
+mentraSdkVersion=0.1.14
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -44,8 +44,7 @@ import com.mentra.bluetoothsdk.HotspotErrorEvent
 import com.mentra.bluetoothsdk.HotspotStatus
 import com.mentra.bluetoothsdk.HotspotStatusEvent
 import com.mentra.bluetoothsdk.PhoneSdkRuntimeState
-import com.mentra.bluetoothsdk.ButtonPhotoSettings
-import com.mentra.bluetoothsdk.ButtonPhotoSize
+import com.mentra.bluetoothsdk.PhotoCaptureDefaults
 import com.mentra.bluetoothsdk.PhotoCompression
 import com.mentra.bluetoothsdk.PhotoRequest
 import com.mentra.bluetoothsdk.PhotoResponse
@@ -335,8 +334,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
     private var latestOtaVersionInfoSignature: String? = null
-    private val buttonPhotoSettingsSyncMutex = Mutex()
-    private var buttonPhotoSettingsSyncGeneration = 0
+    private val photoCaptureDefaultsSyncMutex = Mutex()
+    private var photoCaptureDefaultsSyncGeneration = 0
     private var otaDisplayProgressSessionKey: String? = null
     private var otaDisplayOverallPercent: Int? = null
     private var postOtaCheckInProgress = false
@@ -554,14 +553,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             if (enabled) {
                 scanButtonPreset()
             } else {
-                ButtonPhotoSettings(
-                    size = buttonPhotoSizeToSdk(state.photoSize),
+                PhotoCaptureDefaults(
+                    size = photoSizeToSdk(state.photoSize),
                     mfnr = true,
                     zsl = true,
                     resetCaptureTuning = true,
                 )
             }
-        syncButtonPhotoSettings(
+        syncPhotoCaptureDefaults(
             if (enabled) "Apply scan preset on glasses" else "Restore photo preset on glasses",
             settings,
         )
@@ -584,8 +583,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     private fun scanButtonPreset() =
-        ButtonPhotoSettings(
-            size = buttonPhotoSizeToSdk(state.photoSize),
+        PhotoCaptureDefaults(
+            size = photoSizeToSdk(state.photoSize),
             mfnr = state.photoMfnr,
             zsl = state.photoZsl,
             noiseReduction = state.photoNoiseReduction,
@@ -613,19 +612,19 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected()) {
             return
         }
-        syncButtonPhotoSettings("Apply scan preset on glasses", scanButtonPreset())
+        syncPhotoCaptureDefaults("Apply scan preset on glasses", scanButtonPreset())
     }
 
-    private fun syncButtonPhotoSettings(label: String, settings: ButtonPhotoSettings) {
-        val generation = ++buttonPhotoSettingsSyncGeneration
+    private fun syncPhotoCaptureDefaults(label: String, settings: PhotoCaptureDefaults) {
+        val generation = ++photoCaptureDefaultsSyncGeneration
         runAction(label) {
             requireConnected("sync photo capture settings")
-            buttonPhotoSettingsSyncMutex.withLock {
-                if (generation != buttonPhotoSettingsSyncGeneration) {
+            photoCaptureDefaultsSyncMutex.withLock {
+                if (generation != photoCaptureDefaultsSyncGeneration) {
                     return@withLock
                 }
                 withContext(Dispatchers.IO) {
-                    mentraBluetoothSdk.setButtonPhotoSettings(settings)
+                    mentraBluetoothSdk.setPhotoCaptureDefaults(settings)
                 }
             }
         }
@@ -3127,13 +3126,6 @@ fun photoSizeToSdk(size: String): PhotoSize = when (size) {
     "high" -> PhotoSize.HIGH
     "max", "full" -> PhotoSize.MAX
     else -> PhotoSize.MEDIUM
-}
-
-fun buttonPhotoSizeToSdk(size: String): ButtonPhotoSize = when (size) {
-    "low" -> ButtonPhotoSize.LOW
-    "high" -> ButtonPhotoSize.HIGH
-    "max", "full" -> ButtonPhotoSize.MAX
-    else -> ButtonPhotoSize.MEDIUM
 }
 
 val photoSizeOptions = listOf("low", "medium", "high", "max")

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.13
+mentraSdkVersion=0.1.14

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.13;
+				version = 0.1.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -272,8 +272,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var activeActions: [Int: String] = [:]
     private var activeActionOrder: [Int] = []
     private var streamConfigurationChangeInProgress = false
-    private var buttonPhotoSettingsSyncGeneration = 0
-    private var buttonPhotoSettingsSyncTask: Task<Void, Never>?
+    private var photoCaptureDefaultsSyncGeneration = 0
+    private var photoCaptureDefaultsSyncTask: Task<Void, Never>?
     @Published private(set) var cameraStatus = "Camera: phone receiver will start before capture"
     @Published var webhookUrl = defaultPhotoUploadUrl {
         didSet {
@@ -648,12 +648,12 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
         guard glassesConnected else { return }
         if enabled {
-            syncButtonPhotoSettings("Apply scan preset on glasses", settings: scanButtonPreset())
+            syncPhotoCaptureDefaults("Apply scan preset on glasses", settings: scanButtonPreset())
         } else {
-            let size = ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max
-            syncButtonPhotoSettings(
+            let size = PhotoSize(rawValue: photoSize.rawValue) ?? .max
+            syncPhotoCaptureDefaults(
                 "Restore photo preset on glasses",
-                settings: ButtonPhotoSettings(size: size, mfnr: true, zsl: true, resetCaptureTuning: true)
+                settings: PhotoCaptureDefaults(size: size, mfnr: true, zsl: true, resetCaptureTuning: true)
             )
         }
     }
@@ -678,21 +678,21 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func pushScanButtonPreset() {
         guard glassesConnected else { return }
-        syncButtonPhotoSettings("Apply scan preset on glasses", settings: scanButtonPreset())
+        syncPhotoCaptureDefaults("Apply scan preset on glasses", settings: scanButtonPreset())
     }
 
-    private func syncButtonPhotoSettings(_ label: String, settings: ButtonPhotoSettings) {
-        buttonPhotoSettingsSyncGeneration += 1
-        let generation = buttonPhotoSettingsSyncGeneration
-        let previousTask = buttonPhotoSettingsSyncTask
-        buttonPhotoSettingsSyncTask = Task { @MainActor [weak self] in
+    private func syncPhotoCaptureDefaults(_ label: String, settings: PhotoCaptureDefaults) {
+        photoCaptureDefaultsSyncGeneration += 1
+        let generation = photoCaptureDefaultsSyncGeneration
+        let previousTask = photoCaptureDefaultsSyncTask
+        photoCaptureDefaultsSyncTask = Task { @MainActor [weak self] in
             await previousTask?.value
-            guard let self, generation == self.buttonPhotoSettingsSyncGeneration, self.glassesConnected else { return }
+            guard let self, generation == self.photoCaptureDefaultsSyncGeneration, self.glassesConnected else { return }
             let actionId = self.beginAction(label)
             self.lastAction = "Running: \(label)"
             self.append(tag: "TX", text: label)
             do {
-                _ = try await self.mentraBluetoothSdk.setButtonPhotoSettings(settings)
+                _ = try await self.mentraBluetoothSdk.setPhotoCaptureDefaults(settings)
                 self.lastAction = "Requested: \(label)"
             } catch {
                 self.cameraStatus = "Camera: failed to sync scan preset - \(error.localizedDescription)"
@@ -709,9 +709,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func scanButtonPreset() -> ButtonPhotoSettings {
-        ButtonPhotoSettings(
-            size: ButtonPhotoSize(rawValue: photoSize.rawValue) ?? .max,
+    private func scanButtonPreset() -> PhotoCaptureDefaults {
+        PhotoCaptureDefaults(
+            size: PhotoSize(rawValue: photoSize.rawValue) ?? .max,
             mfnr: photoMfnr,
             zsl: photoZsl,
             noiseReduction: photoNoiseReduction,

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.13`:
+The Xcode project pins the public Swift package to `0.1.14`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.13
+    exactVersion: 0.1.14
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.13",
+        "@mentra/bluetooth-sdk": "0.1.14",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.13", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-5GYfm5GxB8lPLhYsGPTPdZDq+NLBTZ9OxwcG9zF2qoaE4+X0c0DrL4MWtBelFM8DWZGAT9zySdTqiiCjdlECHA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.14", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-dPImcvTcNpS6ukqbPX1jhL9z3YcTAdEgWZcckdAIEmkv+tu1bmyQMwvS9OJYaXUtrtm3LCyfipj2rSTfQNY+uw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.13",
+    "@mentra/bluetooth-sdk": "0.1.14",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.13"
+"@mentra/bluetooth-sdk": "0.1.14"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.13",
+        "@mentra/bluetooth-sdk": "0.1.14",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.13", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-5GYfm5GxB8lPLhYsGPTPdZDq+NLBTZ9OxwcG9zF2qoaE4+X0c0DrL4MWtBelFM8DWZGAT9zySdTqiiCjdlECHA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.14", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-dPImcvTcNpS6ukqbPX1jhL9z3YcTAdEgWZcckdAIEmkv+tu1bmyQMwvS9OJYaXUtrtm3LCyfipj2rSTfQNY+uw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.13",
+    "@mentra/bluetooth-sdk": "0.1.14",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -7,7 +7,6 @@ import BluetoothSdk, {
   type AudioConnectedEvent,
   type ButtonPressEvent,
   type BluetoothSdkEventMap,
-  type ButtonPhotoSettings,
   type CameraFovResult,
   type CameraRoiPosition,
   type CompatibleGlassesSearchStopEvent,
@@ -17,6 +16,7 @@ import BluetoothSdk, {
   type MicLc3Event,
   type MicPcmEvent,
   type OtaStatusEvent,
+  type PhotoCaptureDefaults,
   type PhotoRequestParams,
   type PhotoSuccessResponseEvent,
   type PhotoStatusEvent,
@@ -252,7 +252,7 @@ type PersistedCloudUrls = {
   version: 1;
   webhookUrl?: string;
 };
-type ButtonPhotoSettingsOverrides = {
+type PhotoCaptureDefaultsOverrides = {
   aeExposureDivisor?: number | null;
   compress?: PhotoCompression;
   edgeEnhancement?: boolean;
@@ -261,7 +261,7 @@ type ButtonPhotoSettingsOverrides = {
   isoCap?: number | null;
   mfnr?: boolean;
   noiseReduction?: boolean;
-  size?: ButtonPhotoSettings['size'];
+  size?: PhotoCaptureDefaults['size'];
   zsl?: boolean;
 };
 
@@ -613,8 +613,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const videoPollGenerationRef = useRef(0);
   const photoCloudServerEnabledRef = useRef(false);
   const scanModeRef = useRef(false);
-  const buttonPhotoSettingsSyncGenerationRef = useRef(0);
-  const buttonPhotoSettingsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const photoCaptureDefaultsSyncGenerationRef = useRef(0);
+  const photoCaptureDefaultsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
   const streamCloudServerEnabledRef = useRef(false);
   const activeTabRef = useRef<ExampleTabKey>('device');
   const galleryModeEnabledRef = useRef(false);
@@ -920,7 +920,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (glassesConnected) {
       if (!wasConnectedRef.current && scanMode) {
         // Re-apply scan preset on reconnect so glasses button preset stays in sync.
-        void syncScanCapturePreset(true, buildButtonPhotoSettings());
+        void syncScanCapturePreset(true, buildPhotoCaptureDefaults());
       }
       wasConnectedRef.current = true;
       return;
@@ -1211,35 +1211,35 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function syncScanCapturePreset(
     enabled: boolean,
-    settings?: ButtonPhotoSettings,
+    settings?: PhotoCaptureDefaults,
   ) {
     if (!isGlassesConnected(bluetooth.glasses)) {
       return;
     }
-    const generation = buttonPhotoSettingsSyncGenerationRef.current + 1;
-    buttonPhotoSettingsSyncGenerationRef.current = generation;
+    const generation = photoCaptureDefaultsSyncGenerationRef.current + 1;
+    photoCaptureDefaultsSyncGenerationRef.current = generation;
     const label = enabled ? 'Apply scan preset on glasses' : 'Restore photo preset on glasses';
     const nextSettings = enabled
-      ? settings ?? buildButtonPhotoSettings()
+      ? settings ?? buildPhotoCaptureDefaults()
       : {
           size: photoSize,
           mfnr: true,
           zsl: true,
           resetCaptureTuning: true,
         };
-    const syncTask = buttonPhotoSettingsSyncQueueRef.current.catch(() => undefined).then(async () => {
-      if (generation !== buttonPhotoSettingsSyncGenerationRef.current) {
+    const syncTask = photoCaptureDefaultsSyncQueueRef.current.catch(() => undefined).then(async () => {
+      if (generation !== photoCaptureDefaultsSyncGenerationRef.current) {
         return;
       }
       await runAction(label, async () => {
-        if (generation !== buttonPhotoSettingsSyncGenerationRef.current) {
+        if (generation !== photoCaptureDefaultsSyncGenerationRef.current) {
           return;
         }
         requireConnected('sync photo capture settings');
-        await BluetoothSdk.setButtonPhotoSettings(nextSettings);
+        await BluetoothSdk.setPhotoCaptureDefaults(nextSettings);
       });
     });
-    buttonPhotoSettingsSyncQueueRef.current = syncTask;
+    photoCaptureDefaultsSyncQueueRef.current = syncTask;
   }
 
   function setScanModeAction(enabled: boolean) {
@@ -1247,7 +1247,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setScanMode(enabled);
     if (enabled) {
       applyBarcodeScanPhotoPresetValues();
-      void syncScanCapturePreset(true, buttonPhotoSettingsFromBarcodePreset());
+      void syncScanCapturePreset(true, photoCaptureDefaultsFromBarcodePreset());
     } else {
       resetBarcodeScan();
       void syncScanCapturePreset(false);
@@ -1258,7 +1258,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setScanAeDivisor(divisor);
     setPhotoAeExposureDivisor(divisor);
     if (scanMode) {
-      void syncScanCapturePreset(true, buildButtonPhotoSettings({aeExposureDivisor: divisor}));
+      void syncScanCapturePreset(true, buildPhotoCaptureDefaults({aeExposureDivisor: divisor}));
     }
   }
 
@@ -1266,7 +1266,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setScanIsoCap(isoCapValue);
     setPhotoIsoCap(isoCapValue as PhotoIsoCap);
     if (scanMode) {
-      void syncScanCapturePreset(true, buildButtonPhotoSettings({isoCap: isoCapValue}));
+      void syncScanCapturePreset(true, buildPhotoCaptureDefaults({isoCap: isoCapValue}));
     }
   }
 
@@ -1277,7 +1277,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     return value === 'on';
   }
 
-  function buttonPhotoSettingsFromBarcodePreset(): ButtonPhotoSettings {
+  function photoCaptureDefaultsFromBarcodePreset(): PhotoCaptureDefaults {
     return {
       ...SCAN_MODE_BUTTON_PRESET,
       aeExposureDivisor: BARCODE_SCAN_PHOTO_PRESET.aeExposureDivisor,
@@ -1285,10 +1285,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     };
   }
 
-  function buildButtonPhotoSettings(overrides: ButtonPhotoSettingsOverrides = {}): ButtonPhotoSettings {
-    const hasOverride = (key: keyof ButtonPhotoSettingsOverrides) =>
+  function buildPhotoCaptureDefaults(overrides: PhotoCaptureDefaultsOverrides = {}): PhotoCaptureDefaults {
+    const hasOverride = (key: keyof PhotoCaptureDefaultsOverrides) =>
       Object.prototype.hasOwnProperty.call(overrides, key);
-    const settings: ButtonPhotoSettings = {
+    const settings: PhotoCaptureDefaults = {
       size: overrides.size ?? photoSize,
       compress: overrides.compress ?? photoCompression,
       sound: false,
@@ -1358,7 +1358,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     return settings;
   }
 
-  function syncButtonPresetIfScanMode(settings?: ButtonPhotoSettings) {
+  function syncButtonPresetIfScanMode(settings?: PhotoCaptureDefaults) {
     if (scanModeRef.current) {
       void syncScanCapturePreset(true, settings);
     }
@@ -2422,12 +2422,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function setPhotoSizeAction(size: PhotoSize) {
     setPhotoSize(size);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({size}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({size}));
   }
 
   function setPhotoCompressionAction(compression: PhotoCompression) {
     setPhotoCompression(compression);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({compress: compression}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({compress: compression}));
   }
 
   function setPhotoAeExposureDivisorAction(divisor: PhotoAeExposureDivisor | null) {
@@ -2435,7 +2435,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (divisor === 3 || divisor === 5) {
       setScanAeDivisor(divisor);
     }
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({aeExposureDivisor: divisor}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({aeExposureDivisor: divisor}));
   }
 
   function setPhotoIsoCapAction(isoCap: PhotoIsoCap | null) {
@@ -2443,37 +2443,37 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (isoCap === 400 || isoCap === 800) {
       setScanIsoCap(isoCap);
     }
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({isoCap}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({isoCap}));
   }
 
   function setPhotoNoiseReductionAction(value: PhotoTuningFlag) {
     setPhotoNoiseReduction(value);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({noiseReduction: optionalTuningFlag(value)}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({noiseReduction: optionalTuningFlag(value)}));
   }
 
   function setPhotoEdgeEnhancementAction(value: PhotoTuningFlag) {
     setPhotoEdgeEnhancement(value);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({edgeEnhancement: optionalTuningFlag(value)}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({edgeEnhancement: optionalTuningFlag(value)}));
   }
 
   function setPhotoMfnrAction(value: PhotoTuningFlag) {
     setPhotoMfnr(value);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({mfnr: optionalTuningFlag(value)}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({mfnr: optionalTuningFlag(value)}));
   }
 
   function setPhotoZslAction(value: PhotoTuningFlag) {
     setPhotoZsl(value);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({zsl: optionalTuningFlag(value)}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({zsl: optionalTuningFlag(value)}));
   }
 
   function setPhotoIspDigitalGainAction(gain: PhotoIspDigitalGain | null) {
     setPhotoIspDigitalGain(gain);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({ispDigitalGain: gain}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({ispDigitalGain: gain}));
   }
 
   function setPhotoIspAnalogGainAction(gain: PhotoIspAnalogGain | null) {
     setPhotoIspAnalogGain(gain);
-    syncButtonPresetIfScanMode(buildButtonPhotoSettings({ispAnalogGain: gain}));
+    syncButtonPresetIfScanMode(buildPhotoCaptureDefaults({ispAnalogGain: gain}));
   }
 
   function setCameraFovAction(fov: number) {


### PR DESCRIPTION
## Summary

- Update the Starter Kit API reference to use the current Bluetooth SDK camera/default method names.
- Remove public `keepStreamAlive` examples and describe automatic stream keep-alives instead.
- Document `fps` as the stream video input field for Android, iOS, and React Native examples.

## Validation

- `rg -n 'frameRate|StreamVideoConfig\(frameRate|video: \{frameRate|frame rate|Frame rate' README.md docs examples -g '*.md' -g '*.mdx'`
- `git diff --check`
- Docs-only change; no app build was run locally in this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example-app call-site updates only; no SDK implementation changes in this diff.
> 
> **Overview**
> **Bumps the starter kit to Bluetooth SDK `0.1.14`** and rewrites docs and examples to match the current public API.
> 
> The **API reference** replaces legacy camera helpers (`setButtonPhotoSettings`, `setButtonVideoRecordingSettings`, `setButtonCameraLed`, `setButtonMaxRecordingTime`) with **`setPhotoCaptureDefaults`**, **`setVideoRecordingDefaults`**, and **`setMaxVideoRecordingDuration`**, drops **`keepStreamAlive`** from the documented surface, and documents **automatic stream keep-alives** (failures via `stream_status`). Streaming examples now pass **`video: { fps }`** / `StreamVideoConfig(fps:)`.
> 
> **Android, iOS, and React Native examples** pin **`0.1.14`**, rename scan-preset sync to **`setPhotoCaptureDefaults`** / `PhotoCaptureDefaults`, and remove the old button-photo size mapper where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9fc5cd38c18cf8de9cf38f03df2ba5d1920297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->