### PR TITLE
[codex] Fix React Native cloud photo preview state

### DIFF
--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -2099,22 +2099,36 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('LIVE', `ignoring stale photo ${response.requestId}`);
       return;
     }
+    const previewUrl = response.photoUrl;
+    if (previewUrl) {
+      setPhotoPreviewUrl(previewUrl);
+      setPhotoStatus(null);
+      activePhotoRequestIdRef.current = null;
+    }
     setCameraStatus(
-      photoCloudServerEnabledRef.current
-        ? 'Camera: photo delivered to cloud webhook'
-        : 'Camera: photo delivered to phone receiver',
+      previewUrl
+        ? 'Camera: loaded photo preview'
+        : photoCloudServerEnabledRef.current
+          ? 'Camera: photo delivered to cloud webhook'
+          : 'Camera: photo delivered to phone receiver',
     );
     setPhotoPreviewDetails((current) => ({
       ...current,
       byteCount: typeof response.fileSizeBytes === 'number' ? response.fileSizeBytes : current?.byteCount,
       contentType: response.contentType ?? current?.contentType,
-      previewUrl: response.photoUrl ?? current?.previewUrl,
+      previewUrl: previewUrl ?? current?.previewUrl,
       requestId: response.requestId,
       source: photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver',
-      state: current?.state === 'preview' || response.photoUrl ? 'preview' : 'acknowledged',
+      state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
       timestamp: response.timestamp,
       uploadUrl: response.uploadUrl,
     }));
+    if (previewUrl) {
+      void updatePhotoPreviewMetadata(previewUrl);
+      if (scanModeRef.current) {
+        void scanPreviewBarcode(previewUrl);
+      }
+    }
     addEvent('LIVE', `photo response ${response.requestId}`);
   }
 


### PR DESCRIPTION
## Summary
- Update the React Native example to consume `photo_response.photoUrl` immediately for cloud uploads.
- Clear the lingering `photo_status` state once the final photo response includes a preview URL.
- Re-run preview metadata and barcode scanning from the final photo URL when available.

## Why
The glasses and local cloud server were successfully completing the upload, and logcat showed the SDK delivering a successful `photo_response` with `photoUrl`. The RN example could still sit on `Photo uploaded` because the UI waited on the polling path to populate `photoPreviewUrl` instead of using the final SDK response directly.

## Validation
- `bun x tsc --noEmit` in `examples/react-native`
- Rebuilt the React Native Android release APK locally
- Installed and launched the rebuilt APK on connected Android device `RFCX71TH0CR`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI/state handling only in one handler; no SDK or production app changes.
> 
> **Overview**
> Fixes the React Native example staying on **Photo uploaded** after a successful cloud capture when the SDK already returns `photoUrl` on `photo_response`.
> 
> **`handlePhotoResponse`** now treats `response.photoUrl` like the phone receiver and poll paths: it sets **`photoPreviewUrl`**, clears **`photoStatus`**, and ends the active request when a URL is present. Camera status becomes **loaded photo preview** instead of only reporting webhook delivery. Preview details move to **preview** state and trigger **`updatePhotoPreviewMetadata`** and **`scanPreviewBarcode`** when scan mode is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f03d43745923751bcc7da676a40ebf7faefc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->