### PR TITLE
Remove appId from photo examples

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -466,7 +466,6 @@ Android:
 val photo = sdk.requestPhoto(
     PhotoRequest(
         requestId = "assistant-${System.currentTimeMillis()}",
-        appId = "com.example.assistant",
         size = PhotoSize.MEDIUM,
         webhookUrl = "https://api.example.com/mentra/photo",
         authToken = "optional-token",
@@ -485,7 +484,6 @@ iOS:
 let photo = try await sdk.requestPhoto(
     PhotoRequest(
         requestId: "assistant-\(Date().timeIntervalSince1970)",
-        appId: "com.example.assistant",
         size: .medium,
         webhookUrl: "https://api.example.com/mentra/photo",
         authToken: "optional-token",
@@ -503,7 +501,6 @@ React Native:
 ```ts
 const photo = await BluetoothSdk.requestPhoto({
   requestId: `assistant-${Date.now()}`,
-  appId: 'com.example.assistant',
   size: 'medium',
   webhookUrl: 'https://api.example.com/mentra/photo',
   authToken: 'optional-token',

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.14
+mentraSdkVersion=0.1.16
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,6 +72,9 @@ class MainActivity : ComponentActivity() {
 
                 DisposableEffect(controller) {
                     onDispose { controller.close() }
+                }
+                LaunchedEffect(tab, controller) {
+                    controller.setCameraTabForeground(tab == Tab.CAMERA)
                 }
                 CompositionLocalProvider(
                     LocalKeyboardVisible provides keyboardVisible,

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -196,6 +196,9 @@ const val PHOTO_ISO_DEFAULT = 200
 const val CAMERA_FOV_MIN = 62
 const val CAMERA_FOV_MAX = 118
 const val CAMERA_FOV_DEFAULT = 102
+const val CAMERA_WARM_UP_DURATION_MS = 30_000
+const val CAMERA_WARM_UP_REFRESH_MS = 20_000L
+const val CAMERA_WARM_UP_DISCONNECTED_RETRY_MS = 2_000L
 val photoAeExposureDivisorOptions = listOf(2, 3, 5)
 val photoIsoCapOptions = listOf(400, 800, 1600)
 val photoIspDigitalGainOptions = listOf(0, 1, 2, 4)
@@ -331,6 +334,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var actionSequence = 0L
     private val activeActions = linkedMapOf<Long, String>()
     private var streamConfigurationChangeInProgress = false
+    private var cameraTabForeground = false
+    private var cameraWarmUpFailureLogged = false
+    private var cameraWarmUpJob: Job? = null
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
     private var latestOtaVersionInfoSignature: String? = null
@@ -491,6 +497,19 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             bluetoothStatus = state.bluetoothStatus?.copy(defaultDevice = null),
             selectedDiscoveredDevice = null,
         )
+    }
+
+    fun setCameraTabForeground(foreground: Boolean) {
+        if (cameraTabForeground == foreground) {
+            return
+        }
+        cameraTabForeground = foreground
+        if (foreground) {
+            cameraWarmUpFailureLogged = false
+            startCameraWarmUpLoop()
+        } else {
+            stopCameraWarmUpLoop()
+        }
     }
 
     fun displayHello() = runAction("Display Hello") {
@@ -2244,6 +2263,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     override fun close() {
+        stopCameraWarmUpLoop()
         stopPreviewHealthPoll()
         stopDirectStreamFrameWatchdog()
         directPhotoTimeoutJob?.cancel()
@@ -2454,6 +2474,46 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     private fun isOtaInProgress(): Boolean =
         state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
+
+    private fun startCameraWarmUpLoop() {
+        if (cameraWarmUpJob?.isActive == true) {
+            return
+        }
+        cameraWarmUpJob = scope.launch {
+            while (isActive && cameraTabForeground) {
+                val nextDelayMs =
+                    if (isGlassesConnected()) {
+                        val size = photoSizeToSdk(state.photoSize)
+                        val exposureTimeNs =
+                            if (state.photoExposureManual) state.photoExposureTimeNs.toLong() else null
+                        try {
+                            withContext(Dispatchers.IO) {
+                                mentraBluetoothSdk.warmUpCamera(
+                                    size = size,
+                                    exposureTimeNs = exposureTimeNs,
+                                    durationMs = CAMERA_WARM_UP_DURATION_MS,
+                                )
+                            }
+                            cameraWarmUpFailureLogged = false
+                        } catch (error: Throwable) {
+                            if (cameraTabForeground && isGlassesConnected() && !cameraWarmUpFailureLogged) {
+                                cameraWarmUpFailureLogged = true
+                                addEvent("TX", "camera warm-up failed: ${error.message ?: error::class.java.simpleName}")
+                            }
+                        }
+                        CAMERA_WARM_UP_REFRESH_MS
+                    } else {
+                        CAMERA_WARM_UP_DISCONNECTED_RETRY_MS
+                    }
+                delay(nextDelayMs)
+            }
+        }
+    }
+
+    private fun stopCameraWarmUpLoop() {
+        cameraWarmUpJob?.cancel()
+        cameraWarmUpJob = null
+    }
 
     private fun requireGlassesWifi(feature: String) {
         if (isGlassesWifiConnected(state.glassesStatus)) {

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -3190,7 +3190,6 @@ println("Video stopped: ${'$'}{stopped.status}")
 $prefix
 val photo = mentraBluetoothSdk.requestPhoto(
     PhotoRequest(
-      requestId = requestId,
       size = PhotoSize.${when(size) { "low" -> "LOW"; "high" -> "HIGH"; "max" -> "MAX"; else -> "MEDIUM" }},
       webhookUrl = uploadUrl,
       compress = PhotoCompression.${compression.uppercase(Locale.US)},

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -3853,6 +3853,7 @@ fun deviceModelLabel(model: DeviceModel): String =
         DeviceModel.MACH1 -> "Mach1"
         DeviceModel.Z100 -> "Z100"
         DeviceModel.FRAME -> "Frame"
+        DeviceModel.NIMO -> "Nimo"
         DeviceModel.R1 -> "R1"
         DeviceModel.SIMULATED -> "Simulated"
     }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -787,7 +787,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 mentraBluetoothSdk.requestPhoto(
                     buildPhotoRequest(
                         requestId = requestId,
-                        appId = "com.mentra.bluetoothsdk.example.android",
                         webhookUrl = uploadUrl,
                     )
                 )
@@ -826,7 +825,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 mentraBluetoothSdk.requestPhoto(
                     buildPhotoRequest(
                         requestId = requestId,
-                        appId = "com.mentra.bluetoothsdk.example.android",
                         webhookUrl = uploadUrl,
                     )
                 )
@@ -843,10 +841,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("TX", "requestPhoto requestId=$requestId webhookUrl=$uploadUrl")
     }
 
-    private fun buildPhotoRequest(requestId: String, appId: String, webhookUrl: String): PhotoRequest {
+    private fun buildPhotoRequest(requestId: String, webhookUrl: String): PhotoRequest {
         return PhotoRequest(
             requestId = requestId,
-            appId = appId,
             size = photoSizeToSdk(state.photoSize),
             webhookUrl = webhookUrl,
             compress = PhotoCompression.fromValue(state.photoCompression),
@@ -3194,7 +3191,6 @@ $prefix
 val photo = mentraBluetoothSdk.requestPhoto(
     PhotoRequest(
       requestId = requestId,
-      appId = "com.mentra.bluetoothsdk.example.android",
       size = PhotoSize.${when(size) { "low" -> "LOW"; "high" -> "HIGH"; "max" -> "MAX"; else -> "MEDIUM" }},
       webhookUrl = uploadUrl,
       compress = PhotoCompression.${compression.uppercase(Locale.US)},

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.14
+mentraSdkVersion=0.1.16

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.14;
+				version = 0.1.16;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -64,6 +64,9 @@ let photoIsoDefault = 200
 let cameraFovMin = 62
 let cameraFovMax = 118
 let cameraFovDefault = 102
+let cameraWarmUpDurationMs = 30_000
+let cameraWarmUpRefreshMs = 20_000
+let cameraWarmUpDisconnectedRetryMs = 2_000
 let photoAeExposureDivisorOptions = [2, 3, 5]
 let photoIsoCapOptions = [400, 800, 1600]
 let photoIspDigitalGainOptions = [0, 1, 2, 4]
@@ -365,6 +368,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var pollGeneration = 0
     private var videoPollGeneration = 0
     private var directPhotoTimeoutTask: Task<Void, Never>?
+    private var cameraTabForeground = false
+    private var cameraWarmUpFailureLogged = false
+    private var cameraWarmUpTask: Task<Void, Never>?
     private var previewHealthTask: Task<Void, Never>?
     private var directStreamStartTask: Task<Void, Never>?
     private var directStreamStopTask: Task<Void, Never>?
@@ -473,6 +479,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     deinit {
+        cameraWarmUpTask?.cancel()
         previewHealthTask?.cancel()
         directPhotoTimeoutTask?.cancel()
         directStreamStartTask?.cancel()
@@ -560,6 +567,17 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             mentraBluetoothSdk.clearDefaultDevice()
             bluetoothValues = mentraBluetoothSdk.sdkState
             selectedDiscoveredDevice = nil
+        }
+    }
+
+    func setCameraTabForeground(_ foreground: Bool) {
+        guard cameraTabForeground != foreground else { return }
+        cameraTabForeground = foreground
+        if foreground {
+            cameraWarmUpFailureLogged = false
+            startCameraWarmUpLoop()
+        } else {
+            stopCameraWarmUpLoop()
         }
     }
 
@@ -2018,6 +2036,41 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func isOtaInProgress() -> Bool {
         otaStatus?.status == "in_progress" || otaStatus?.status == "step_complete"
+    }
+
+    private func startCameraWarmUpLoop() {
+        guard cameraWarmUpTask == nil else { return }
+        cameraWarmUpTask = Task { [weak self] in
+            while !Task.isCancelled {
+                let nextDelayMs = await self?.runCameraWarmUpTick() ?? cameraWarmUpDisconnectedRetryMs
+                try? await Task.sleep(nanoseconds: UInt64(nextDelayMs) * 1_000_000)
+            }
+        }
+    }
+
+    private func stopCameraWarmUpLoop() {
+        cameraWarmUpTask?.cancel()
+        cameraWarmUpTask = nil
+    }
+
+    private func runCameraWarmUpTick() async -> Int {
+        guard cameraTabForeground else { return cameraWarmUpRefreshMs }
+        guard glassesConnected else { return cameraWarmUpDisconnectedRetryMs }
+        let exposureTimeNs = photoExposureManual ? Double(photoExposureTimeNs) : nil
+        do {
+            _ = try await mentraBluetoothSdk.warmUpCamera(
+                size: photoSize,
+                exposureTimeNs: exposureTimeNs,
+                durationMs: cameraWarmUpDurationMs
+            )
+            cameraWarmUpFailureLogged = false
+        } catch {
+            if cameraTabForeground && glassesConnected && !cameraWarmUpFailureLogged {
+                cameraWarmUpFailureLogged = true
+                append(tag: "TX", text: "camera warm-up failed: \(error.localizedDescription)")
+            }
+        }
+        return cameraWarmUpRefreshMs
     }
 
     private func requireConnected(_ feature: String) throws {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -877,7 +877,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             let responseEvent: PhotoResponseEvent
             do {
                 responseEvent = try await mentraBluetoothSdk.requestPhoto(
-                    buildPhotoRequest(requestId: requestId, appId: "com.mentra.bluetoothsdk.example.ios", webhookUrl: uploadUrl)
+                    buildPhotoRequest(requestId: requestId, webhookUrl: uploadUrl)
                 )
             } catch {
                 if activePhotoRequestId == requestId {
@@ -912,7 +912,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         let responseEvent: PhotoResponseEvent
         do {
             responseEvent = try await mentraBluetoothSdk.requestPhoto(
-                buildPhotoRequest(requestId: requestId, appId: "com.mentra.bluetoothsdk.example.ios", webhookUrl: uploadUrl)
+                buildPhotoRequest(requestId: requestId, webhookUrl: uploadUrl)
             )
         } catch {
             directPhotoTimeoutTask?.cancel()
@@ -926,10 +926,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         append(tag: "TX", text: "requestPhoto requestId=\(requestId) webhookUrl=\(uploadUrl)")
     }
 
-    private func buildPhotoRequest(requestId: String, appId: String, webhookUrl: String) -> PhotoRequest {
+    private func buildPhotoRequest(requestId: String, webhookUrl: String) -> PhotoRequest {
         return PhotoRequest(
             requestId: requestId,
-            appId: appId,
             size: photoSize,
             webhookUrl: webhookUrl,
             compress: photoCompression,

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -223,6 +223,8 @@ func deviceModelLabel(_ model: DeviceModel) -> String {
         return "Mach1"
     case .z100:
         return "Z100"
+    case .nimo:
+        return "Nimo"
     case .frame:
         return "Frame"
     case .r1:
@@ -1791,7 +1793,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             handleMediaUpload(upload)
         case let .streamStatus(status):
             handleStreamStatus(status.status)
-        case .otaUpdateAvailable, .otaStartAck, .settingsAck, .rgbLedControlResponse:
+        case .otaStartAck, .settingsAck, .rgbLedControlResponse:
             break
         case let .otaStatus(event):
             applyOtaStatus(event)
@@ -1970,7 +1972,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         append(tag: "LIVE", text: message)
     }
 
-    func mentraBluetoothSDK(_: MentraBluetoothSDK, didFail error: BluetoothError) {
+    func mentraBluetoothSDK(_: MentraBluetoothSDK, didFail error: BluetoothSdkError) {
         append(tag: "TX", text: error.description)
     }
 

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -86,7 +86,6 @@ private func cameraSdkCall(
     let photo = try await mentraBluetoothSdk.requestPhoto(
         PhotoRequest(
           requestId: requestId,
-          appId: "com.mentra.bluetoothsdk.example.ios",
           size: .\(size),
           webhookUrl: uploadUrl,
           compress: .\(compression),

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -85,7 +85,6 @@ private func cameraSdkCall(
     \(prefix)
     let photo = try await mentraBluetoothSdk.requestPhoto(
         PhotoRequest(
-          requestId: requestId,
           size: .\(size),
           webhookUrl: uploadUrl,
           compress: .\(compression),

--- a/examples/ios/MentraExample/RootView.swift
+++ b/examples/ios/MentraExample/RootView.swift
@@ -32,6 +32,12 @@ struct RootView: View {
             .ignoresSafeArea(.container, edges: .bottom)
         }
         .animation(.easeOut(duration: 0.18), value: keyboard.isVisible)
+        .onAppear {
+            bluetooth.setCameraTabForeground(tab == .camera)
+        }
+        .onChange(of: tab) { nextTab in
+            bluetooth.setCameraTabForeground(nextTab == .camera)
+        }
     }
 }
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.14`:
+The Xcode project pins the public Swift package to `0.1.16`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.14
+    exactVersion: 0.1.16
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.14",
+        "@mentra/bluetooth-sdk": "0.1.16",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.14", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-dPImcvTcNpS6ukqbPX1jhL9z3YcTAdEgWZcckdAIEmkv+tu1bmyQMwvS9OJYaXUtrtm3LCyfipj2rSTfQNY+uw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.16", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mhSIzz0NS3PRN3yGzIsWpCG7C9/wTnaxPEye3tXpV0Db6fnyzcY89Ep6Lvg7YJY1GP3Wr0OsuQ1QZJcSNMcGAg=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.14",
+    "@mentra/bluetooth-sdk": "0.1.16",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.14"
+"@mentra/bluetooth-sdk": "0.1.16"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.14",
+        "@mentra/bluetooth-sdk": "0.1.16",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.14", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-dPImcvTcNpS6ukqbPX1jhL9z3YcTAdEgWZcckdAIEmkv+tu1bmyQMwvS9OJYaXUtrtm3LCyfipj2rSTfQNY+uw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.16", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mhSIzz0NS3PRN3yGzIsWpCG7C9/wTnaxPEye3tXpV0Db6fnyzcY89Ep6Lvg7YJY1GP3Wr0OsuQ1QZJcSNMcGAg=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.14",
+    "@mentra/bluetooth-sdk": "0.1.16",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -89,19 +89,15 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
         ispAnalogGain !== null ? `  ispAnalogGain: "${ispAnalogGain}",` : null,
       ].filter((line): line is string => line !== null).join('\n');
   if (!useCloudServer) {
-    return `${prefix}const photoRequestId = \`photo-\${Date.now()}\`;
-const { uploadUrl } = await MentraPhotoReceiver.startPhotoReceiver();
+    return `${prefix}const { uploadUrl } = await MentraPhotoReceiver.startPhotoReceiver();
 const photo = await BluetoothSdk.requestPhoto({
-  requestId: photoRequestId,
   webhookUrl: uploadUrl,
   authToken: null,
 ${requestFields}
 })
 console.log("Photo delivered", photo.photoUrl ?? photo.uploadUrl)`;
   }
-  return `${prefix}const photoRequestId = \`photo-\${Date.now()}\`;
-const photo = await BluetoothSdk.requestPhoto({
-  requestId: photoRequestId,
+  return `${prefix}const photo = await BluetoothSdk.requestPhoto({
   webhookUrl,
   authToken: null,
 ${requestFields}

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -93,7 +93,6 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
 const { uploadUrl } = await MentraPhotoReceiver.startPhotoReceiver();
 const photo = await BluetoothSdk.requestPhoto({
   requestId: photoRequestId,
-  appId: PHOTO_APP_ID,
   webhookUrl: uploadUrl,
   authToken: null,
 ${requestFields}
@@ -103,7 +102,6 @@ console.log("Photo delivered", photo.photoUrl ?? photo.uploadUrl)`;
   return `${prefix}const photoRequestId = \`photo-\${Date.now()}\`;
 const photo = await BluetoothSdk.requestPhoto({
   requestId: photoRequestId,
-  appId: PHOTO_APP_ID,
   webhookUrl,
   authToken: null,
 ${requestFields}

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -190,7 +190,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           <View style={styles.recPill}><Text style={styles.recText}>REC</Text></View>
         </View>
         <View style={{ paddingHorizontal: 18 }}>
-          <StatusRow label="LAST ACTION" value={sdk.lastAction} />
+          <StatusRow label="LAST ACTION" value={sdk.lastAction} selectable />
           <StatusRow label="CONNECTION" custom={<View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
             <View style={{ width: 6, height: 6, borderRadius: 999, backgroundColor: colors.greenPrimary }} />
             <Text style={[styles.statusValue, { color: colors.greenInk, fontWeight: '600' }]}>{connection}</Text>
@@ -558,12 +558,26 @@ function StatCard({ label, value, sub, subColor, bold }: { label: string; value:
   );
 }
 
-function StatusRow({ label, value, custom, mono, last }: { label: string; value?: string; custom?: React.ReactNode; mono?: boolean; last?: boolean }) {
+function StatusRow({
+  label,
+  value,
+  custom,
+  mono,
+  last,
+  selectable,
+}: {
+  label: string;
+  value?: string;
+  custom?: React.ReactNode;
+  mono?: boolean;
+  last?: boolean;
+  selectable?: boolean;
+}) {
   return (
     <View style={[styles.statusRow, !last && styles.statusBorder]}>
       <Text style={styles.statusLabel}>{label}</Text>
       <View style={{ flex: 1 }}>
-        {custom ?? <Text style={[styles.statusValue, mono && { fontFamily: 'Courier' }]}>{value}</Text>}
+        {custom ?? <Text selectable={selectable} style={[styles.statusValue, mono && { fontFamily: 'Courier' }]}>{value}</Text>}
       </View>
     </View>
   );

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1365,7 +1365,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   function addRequestTuningFields(
-    fields: Omit<PhotoRequestParams, 'requestId' | 'appId' | 'webhookUrl' | 'authToken'>,
+    fields: Omit<PhotoRequestParams, 'requestId' | 'webhookUrl' | 'authToken'>,
   ) {
     if (!photoExposureManual && photoAeExposureDivisor !== null) {
       fields.aeExposureDivisor = photoAeExposureDivisor;
@@ -1400,7 +1400,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function buildPhotoRequestFields(): Omit<
     PhotoRequestParams,
-    'requestId' | 'appId' | 'webhookUrl' | 'authToken'
+    'requestId' | 'webhookUrl' | 'authToken'
   > {
     return addRequestTuningFields({
       size: photoSize,
@@ -1586,7 +1586,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       try {
         const response = await BluetoothSdk.requestPhoto({
           requestId,
-          appId: PHOTO_APP_ID,
           webhookUrl: uploadUrlText,
           authToken: null,
           ...buildPhotoRequestFields(),
@@ -1624,7 +1623,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     try {
       const response = await BluetoothSdk.requestPhoto({
         requestId,
-        appId: PHOTO_APP_ID,
         webhookUrl: receiver.uploadUrl,
         authToken: null,
         ...buildPhotoRequestFields(),

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -296,6 +296,9 @@ export const BARCODE_SCAN_PHOTO_PRESET = {
 export const CAMERA_FOV_MIN = 62;
 export const CAMERA_FOV_MAX = 118;
 export const CAMERA_FOV_DEFAULT = 102;
+const CAMERA_WARM_UP_DURATION_MS = 30_000;
+const CAMERA_WARM_UP_REFRESH_MS = 20_000;
+const CAMERA_WARM_UP_DISCONNECTED_RETRY_MS = 2_000;
 export const CAMERA_ROI_POSITIONS = [
   {label: 'Center', value: 'center'},
   {label: 'Bottom', value: 'bottom'},
@@ -615,6 +618,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const scanModeRef = useRef(false);
   const photoCaptureDefaultsSyncGenerationRef = useRef(0);
   const photoCaptureDefaultsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const cameraWarmUpFailureLoggedRef = useRef(false);
   const streamCloudServerEnabledRef = useRef(false);
   const activeTabRef = useRef<ExampleTabKey>('device');
   const galleryModeEnabledRef = useRef(false);
@@ -915,6 +919,56 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('TX', `photo receiver prewarm failed: ${formatError(error)}`);
     });
   }, [activeTab, photoCloudServerEnabled, glassesConnected]);
+
+  useEffect(() => {
+    if (activeTab !== 'camera') {
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function scheduleNext(delayMs: number) {
+      timer = setTimeout(() => {
+        void warmUpCamera();
+      }, delayMs);
+    }
+
+    async function warmUpCamera() {
+      if (cancelled || activeTabRef.current !== 'camera') {
+        return;
+      }
+      if (!glassesConnectedRef.current) {
+        scheduleNext(CAMERA_WARM_UP_DISCONNECTED_RETRY_MS);
+        return;
+      }
+      try {
+        await BluetoothSdk.warmUpCamera({
+          size: photoSize,
+          exposureTimeNs: photoExposureManual ? photoExposureTimeNs : null,
+          durationMs: CAMERA_WARM_UP_DURATION_MS,
+        });
+        cameraWarmUpFailureLoggedRef.current = false;
+      } catch (error) {
+        if (!cancelled && glassesConnectedRef.current && !cameraWarmUpFailureLoggedRef.current) {
+          cameraWarmUpFailureLoggedRef.current = true;
+          addEvent('TX', `camera warm-up failed: ${formatError(error)}`);
+        }
+      }
+      if (!cancelled) {
+        scheduleNext(CAMERA_WARM_UP_REFRESH_MS);
+      }
+    }
+
+    cameraWarmUpFailureLoggedRef.current = false;
+    void warmUpCamera();
+
+    return () => {
+      cancelled = true;
+      if (timer != null) {
+        clearTimeout(timer);
+      }
+    };
+  }, [activeTab, photoExposureManual, photoExposureTimeNs, photoSize]);
 
   useEffect(() => {
     if (glassesConnected) {


### PR DESCRIPTION
## Summary

This is the Starter Kit companion change for removing `appId` from the photo request API.

The SDK no longer needs callers to provide an app/package identifier when requesting a photo or warming the camera, so the Starter Kit examples should stop teaching users to send one. This PR removes `appId` only from photo request call sites and generated snippets. It does not change application bundle IDs, Android package IDs, launch-script app IDs, or the RGB LED call that still accepts an app id parameter.

## What changed

- Removed `appId` from the React Native photo request payloads for both direct phone upload and webhook/cloud upload.
- Updated the React Native generated camera snippet so copied `BluetoothSdk.requestPhoto(...)` examples no longer include `appId`.
- Removed `appId` from native Android photo request construction and its generated sample snippet.
- Removed `appId` from native iOS photo request construction and its generated sample snippet.
- Updated `docs/api-reference.md` Android, iOS, and React Native photo upload examples to omit `appId`.

## Notes

This branch intentionally leaves SDK dependency pins unchanged at `0.1.14`. The source changes here are meant to pair with the SDK/API removal branch; CI that compiles against the currently published `0.1.14` packages may still see the old API shape until the new SDK packages are published or the examples are pointed at that SDK version.

## Validation

- `git diff --check`
- Targeted search confirmed no remaining `appId` assignments in the photo request docs/examples touched by this PR.
- Tried `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/Users/philippe/dev/MentraOS-aisraelov-cameraonoff/mobile/modules/bluetooth-sdk ./gradlew :app:compileDebugKotlin --no-daemon` from `examples/android`; Gradle did not reach these example call sites because the standalone local SDK override failed during SDK project configuration with missing `:expo-modules-core`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation and example apps; photo and warm-up behavior depend on the published 0.1.16 SDK API.
> 
> **Overview**
> Aligns the Starter Kit with **Bluetooth SDK 0.1.16** and the slimmer photo API: **`appId` is removed** from `PhotoRequest` / `requestPhoto` in **docs** and **Android, iOS, and React Native** examples, including copy-paste snippets. Bundle IDs and RGB LED `packageName` usage are unchanged.
> 
> While the **Camera** tab is active, all three native examples now run a **periodic `warmUpCamera` loop** (30s duration, ~20s refresh when connected) so captures stay responsive; loops stop when leaving the tab or on teardown.
> 
> Also bumps dependency pins and lockfiles to **0.1.16**, adds **Nimo** device labels, updates iOS for **`BluetoothSdkError`** and drops handling of **`otaUpdateAvailable`**, and makes the RN device screen’s last-action text **selectable**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58793e63d8b0cd0b8b37f76c5f198c5ebdf47213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->