### PR TITLE
Update example apps to Bluetooth SDK 0.1.17

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.16
+mentraSdkVersion=0.1.17
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.16
+mentraSdkVersion=0.1.17

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.16;
+				version = 0.1.17;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.16`:
+The Xcode project pins the public Swift package to `0.1.17`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.16
+    exactVersion: 0.1.17
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.16",
+        "@mentra/bluetooth-sdk": "0.1.17",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.16", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mhSIzz0NS3PRN3yGzIsWpCG7C9/wTnaxPEye3tXpV0Db6fnyzcY89Ep6Lvg7YJY1GP3Wr0OsuQ1QZJcSNMcGAg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.17", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yWCrdmPCMYxosh64Zjz0oC+EuOJbOJ2ox5FsFk1V1mIsLD1KnEdHctU2kHv9Iuxj7BTIhVMDabOO1+SloHEwvA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.16",
+    "@mentra/bluetooth-sdk": "0.1.17",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.16"
+"@mentra/bluetooth-sdk": "0.1.17"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.16",
+        "@mentra/bluetooth-sdk": "0.1.17",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.16", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mhSIzz0NS3PRN3yGzIsWpCG7C9/wTnaxPEye3tXpV0Db6fnyzcY89Ep6Lvg7YJY1GP3Wr0OsuQ1QZJcSNMcGAg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.17", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yWCrdmPCMYxosh64Zjz0oC+EuOJbOJ2ox5FsFk1V1mIsLD1KnEdHctU2kHv9Iuxj7BTIhVMDabOO1+SloHEwvA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.16",
+    "@mentra/bluetooth-sdk": "0.1.17",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
## Summary

- Updates the native Android example to `com.mentraglass:bluetooth-sdk:0.1.17` via `examples/android/gradle.properties`.
- Updates the native iOS example SwiftPM pin to `MentraBluetoothSDK` `0.1.17` in `project.yml` and the checked-in Xcode project.
- Updates both React Native example apps to `@mentra/bluetooth-sdk@0.1.17` and refreshes their Bun locks.
- Updates the example READMEs that mention the pinned SDK version.

## Validation

- Confirmed npm has `@mentra/bluetooth-sdk@0.1.17`.
- Confirmed Maven Central has `com.mentraglass:bluetooth-sdk:0.1.17` and `com.mentraglass:lc3Lib:0.1.17`.
- Confirmed SwiftPM tag `0.1.17` exists in `Mentra-Community/mentra-bluetooth-sdk-ios`.
- `bun install --frozen-lockfile` in `examples/react-native`.
- `bun x tsc --noEmit` in `examples/react-native`.
- `bun install --frozen-lockfile` in `examples/react-native-elevenlabs-audio`.
- `bun run typecheck` in `examples/react-native-elevenlabs-audio`.
- `./gradlew :app:compileDebugKotlin --no-daemon` in `examples/android`.
- `xcodebuild -resolvePackageDependencies -project examples/ios/MentraExample.xcodeproj -scheme MentraExample`.
- `xcodebuild -project MentraExample.xcodeproj -scheme MentraExample -configuration Debug -destination 'generic/platform=iOS' -clonedSourcePackagesDirPath SourcePackages CODE_SIGNING_ALLOWED=NO analyze` in `examples/ios`.
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps in example projects and lockfiles; no production app or SDK implementation changes.
> 
> **Overview**
> Bumps all starter-kit example apps from **Bluetooth SDK 0.1.16** to **0.1.17** so clones track the current published release.
> 
> **Android** uses `mentraSdkVersion=0.1.17` in `gradle.properties` (Maven `com.mentraglass:bluetooth-sdk`). **iOS** pins SwiftPM `MentraBluetoothSDK` to `0.1.17` in `project.yml` and the checked-in Xcode project. **React Native** examples (`react-native` and `react-native-elevenlabs-audio`) set `@mentra/bluetooth-sdk` to `0.1.17` with updated `bun.lock` entries. README snippets that document the pinned version are updated to match.
> 
> No example app source or SDK integration behavior changes—only dependency pins, lockfiles, and docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fac87caad93a1e493fb2eea3432974aef714d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->