### PR TITLE
Update examples to Bluetooth SDK 0.1.18

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.17
+mentraSdkVersion=0.1.18
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.17
+mentraSdkVersion=0.1.18

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.17;
+				version = 0.1.18;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.17`:
+The Xcode project pins the public Swift package to `0.1.18`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.17
+    exactVersion: 0.1.18
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.17",
+        "@mentra/bluetooth-sdk": "0.1.18",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.17", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yWCrdmPCMYxosh64Zjz0oC+EuOJbOJ2ox5FsFk1V1mIsLD1KnEdHctU2kHv9Iuxj7BTIhVMDabOO1+SloHEwvA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.17",
+    "@mentra/bluetooth-sdk": "0.1.18",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.17"
+"@mentra/bluetooth-sdk": "0.1.18"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.17",
+        "@mentra/bluetooth-sdk": "0.1.18",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.17", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yWCrdmPCMYxosh64Zjz0oC+EuOJbOJ2ox5FsFk1V1mIsLD1KnEdHctU2kHv9Iuxj7BTIhVMDabOO1+SloHEwvA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.17",
+    "@mentra/bluetooth-sdk": "0.1.18",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -584,19 +584,19 @@ function PhotoDetailsCard({
     <>
       <Pressable onPress={onToggle} style={styles.detailsHeader}>
         <View style={{ flex: 1 }}>
-          <Text style={styles.eyebrow}>PHOTO DETAILS</Text>
-          <Text style={styles.detailsSummary}>{photoDetailsSummary(details)}</Text>
+          <Text selectable style={styles.eyebrow}>PHOTO DETAILS</Text>
+          <Text selectable style={styles.detailsSummary}>{photoDetailsSummary(details)}</Text>
         </View>
-        <Text style={styles.detailsChevron}>{expanded ? 'Hide' : 'Show'}</Text>
+        <Text selectable style={styles.detailsChevron}>{expanded ? 'Hide' : 'Show'}</Text>
       </Pressable>
       {expanded ? (
         <View style={styles.detailsBody}>
-          {rows.map((row) => (
-            <View key={row.label} style={styles.detailsRow}>
-              <Text style={[styles.detailsLabel, row.tone === 'warning' && styles.detailsLabelWarning]}>
+          {rows.map((row, index) => (
+            <View key={`${row.label}-${index}`} style={styles.detailsRow}>
+              <Text selectable style={[styles.detailsLabel, row.tone === 'warning' && styles.detailsLabelWarning]}>
                 {row.label}
               </Text>
-              <Text style={[styles.detailsValue, row.tone === 'warning' && styles.detailsValueWarning]}>
+              <Text selectable style={[styles.detailsValue, row.tone === 'warning' && styles.detailsValueWarning]}>
                 {row.value}
               </Text>
             </View>
@@ -844,17 +844,17 @@ function VideoDetailsCard({
     <View style={styles.videoDetailsPanel}>
       <Pressable onPress={onToggle} style={styles.detailsHeader}>
         <View style={{ flex: 1 }}>
-          <Text style={styles.eyebrow}>VIDEO DETAILS</Text>
-          <Text style={styles.detailsSummary}>{videoDetailsSummary(details)}</Text>
+          <Text selectable style={styles.eyebrow}>VIDEO DETAILS</Text>
+          <Text selectable style={styles.detailsSummary}>{videoDetailsSummary(details)}</Text>
         </View>
-        <Text style={styles.detailsChevron}>{expanded ? 'Hide' : 'Show'}</Text>
+        <Text selectable style={styles.detailsChevron}>{expanded ? 'Hide' : 'Show'}</Text>
       </Pressable>
       {expanded ? (
         <View style={styles.detailsBody}>
-          {rows.map((row) => (
-            <View key={row.label} style={styles.detailsRow}>
-              <Text style={styles.detailsLabel}>{row.label}</Text>
-              <Text style={styles.detailsValue}>{row.value}</Text>
+          {rows.map((row, index) => (
+            <View key={`${row.label}-${index}`} style={styles.detailsRow}>
+              <Text selectable style={styles.detailsLabel}>{row.label}</Text>
+              <Text selectable style={styles.detailsValue}>{row.value}</Text>
             </View>
           ))}
         </View>
@@ -1662,6 +1662,7 @@ function photoDetailsSummary(details: PhotoPreviewDetails | null) {
 
 type DetailRow = {label: string; value: string};
 type DetailRowTone = 'default' | 'warning';
+const GLASSES_TO_PHONE_CLOCK_OFFSET_MS = 0;
 
 function photoDetailsRows(details: PhotoPreviewDetails | null) {
   if (!details) {
@@ -1688,6 +1689,8 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
     rows.push({label: 'Bluetooth fallback', value: details.bleFallbackMessage, tone: 'warning'});
   }
   if (details.requestId) rows.push({label: 'Request ID', value: details.requestId});
+  addPhotoClockAdjustmentRow(rows, details.timeline);
+  addPhotoTimelineRows(rows, details.timeline);
   if (details.byteCount) rows.push({label: 'Size', value: formatBytes(details.byteCount)});
   if (details.width && details.height) rows.push({label: 'Dimensions', value: `${details.width} x ${details.height}`});
   if (details.estimatedFov) rows.push({label: 'Estimated FOV', value: formatFovEstimate(details.estimatedFov)});
@@ -1699,7 +1702,12 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
   if (details.contentType) rows.push({label: 'Content type', value: details.contentType});
   if (details.uploadUrl) rows.push({label: 'Upload URL', value: details.uploadUrl});
   if (details.previewUrl) rows.push({label: 'Preview URL', value: details.previewUrl});
-  if (details.timestamp) rows.push({label: 'SDK timestamp', value: new Date(details.timestamp).toLocaleTimeString()});
+  if (details.timestamp) {
+    rows.push({
+      label: 'SDK timestamp',
+      value: formatClockTimeWithMillis(details.timestamp),
+    });
+  }
   if (details.uploadedAt) rows.push({label: 'Uploaded at', value: details.uploadedAt});
   if (details.error) rows.push({label: 'Error', value: details.error});
   return rows;
@@ -1860,6 +1868,87 @@ function formatDurationMs(ms: number) {
   const minutes = Math.floor(seconds / 60);
   const remainder = Math.round(seconds % 60).toString().padStart(2, '0');
   return `${minutes}:${remainder}`;
+}
+
+function addPhotoTimelineRows(rows: DetailRow[], timeline: PhotoPreviewDetails['timeline']) {
+  if (!timeline?.length) {
+    return;
+  }
+  const startTimestamp = photoTimelineStart(timeline);
+  for (const event of timeline) {
+    rows.push({
+      label: photoTimelineLabel(event),
+      value: formatPhotoTimelineTimestamp(photoTimelineDisplayTimestamp(event), startTimestamp),
+    });
+  }
+}
+
+function addPhotoClockAdjustmentRow(rows: DetailRow[], timeline: PhotoPreviewDetails['timeline']) {
+  const hasDeviceTimestamp = timeline?.some((event) => event.deviceTimestamp != null);
+  if (!hasDeviceTimestamp) {
+    return;
+  }
+  rows.push({
+    label: 'Clock adjustment',
+    value: `Glasses timestamps +${formatOffsetSeconds(GLASSES_TO_PHONE_CLOCK_OFFSET_MS)} to phone clock`,
+  });
+}
+
+function photoTimelineStart(timeline: PhotoPreviewDetails['timeline']) {
+  const requestEvent = timeline?.find((event) => event.source === 'request');
+  if (requestEvent) {
+    return requestEvent.timestamp;
+  }
+  return timeline?.[0] ? photoTimelineDisplayTimestamp(timeline[0]) : undefined;
+}
+
+function photoTimelineDisplayTimestamp(event: NonNullable<PhotoPreviewDetails['timeline']>[number]) {
+  return event.deviceTimestamp != null
+    ? event.deviceTimestamp + GLASSES_TO_PHONE_CLOCK_OFFSET_MS
+    : event.timestamp;
+}
+
+function photoTimelineLabel(event: NonNullable<PhotoPreviewDetails['timeline']>[number]) {
+  switch (event.source) {
+    case 'request':
+      return 'Requested';
+    case 'photo_status':
+      return `Status ${event.status?.replace(/_/g, ' ') ?? 'received'}`;
+    case 'photo_response':
+      return 'Photo uploaded';
+    default:
+      return 'Photo event';
+  }
+}
+
+function formatPhotoTimelineTimestamp(timestamp: number, startTimestamp?: number) {
+  const formattedTime = formatClockTimeWithMillis(timestamp);
+  if (startTimestamp == null) {
+    return formattedTime;
+  }
+  return `${formattedTime} (${formatTimelineDelta(timestamp - startTimestamp)})`;
+}
+
+function formatClockTimeWithMillis(timestamp: number) {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+  const millis = date.getMilliseconds().toString().padStart(3, '0');
+  return `${hours}:${minutes}:${seconds}.${millis}`;
+}
+
+function formatTimelineDelta(deltaMs: number) {
+  const sign = deltaMs < 0 ? '-' : '+';
+  const absoluteMs = Math.abs(deltaMs);
+  if (absoluteMs < 1000) {
+    return `${sign}${Math.round(absoluteMs)}ms`;
+  }
+  return `${sign}${(absoluteMs / 1000).toFixed(3)}s`;
+}
+
+function formatOffsetSeconds(ms: number) {
+  return `${(Math.abs(ms) / 1000).toFixed(3)}s`;
 }
 
 function formatFovEstimate(fov: NonNullable<PhotoPreviewDetails['estimatedFov']>) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1767,6 +1767,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('LIVE', `ignoring stale phone photo ${payload.requestId}`);
       return;
     }
+    const deliveredAt = Date.now();
     clearPhotoUploadTimeout();
     activePhotoRequestIdRef.current = null;
     setPhonePhotoReceiverRunning(true);
@@ -1782,6 +1783,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       requestId: payload.requestId ?? activeRequestId ?? current?.requestId ?? null,
       source: 'Phone receiver',
       state: 'preview',
+      timestamp: deliveredAt,
+      timeline: appendPhotoResponseTimeline(current?.timeline, {timestamp: deliveredAt}),
     }));
     void updatePhotoPreviewMetadata(payload.fileUri);
     if (scanModeRef.current) {
@@ -2221,8 +2224,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       source: photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver',
       state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
       timestamp: responseDeviceTimestamp,
-      timeline: appendPhotoTimeline(current?.timeline, {
-        source: 'photo_response',
+      timeline: appendPhotoResponseTimeline(current?.timeline, {
         deviceTimestamp: response.timestamp,
         timestamp: responsePhoneTimestamp,
       }),
@@ -2263,6 +2265,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             uploadedAt?: string;
           };
           if (json.photoUrl) {
+            const deliveredAt = Date.now();
             setPhotoPreviewUrl(json.photoUrl);
             setPhotoStatus(null);
             setPhotoPreviewDetails((current) => ({
@@ -2276,6 +2279,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
               requestId: json.requestId ?? requestId,
               source: 'Cloud server',
               state: 'preview',
+              timestamp: deliveredAt,
+              timeline: appendPhotoResponseTimeline(current?.timeline, {timestamp: deliveredAt}),
               uploadedAt: json.uploadedAt ?? current?.uploadedAt,
             }));
             void updatePhotoPreviewMetadata(json.photoUrl);
@@ -4268,6 +4273,17 @@ function appendPhotoTimeline(
       (entry.deviceTimestamp ?? entry.timestamp) === (event.deviceTimestamp ?? event.timestamp),
   );
   return duplicate ? entries : [...entries, event];
+}
+
+function appendPhotoResponseTimeline(
+  timeline: PhotoTimelineEvent[] | undefined,
+  event: Pick<PhotoTimelineEvent, 'deviceTimestamp' | 'timestamp'>,
+) {
+  return appendPhotoTimeline(timeline, {
+    source: 'photo_response',
+    deviceTimestamp: event.deviceTimestamp,
+    timestamp: event.timestamp,
+  });
 }
 
 function videoStatusIsFailure(status: string) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -156,6 +156,12 @@ export type PhotoCaptureMetadataDetails = {
   totalLightProxy?: number;
   mfnrLikely?: boolean;
 };
+export type PhotoTimelineEvent = {
+  source: 'request' | 'photo_status' | 'photo_response';
+  status?: string;
+  deviceTimestamp?: number;
+  timestamp: number;
+};
 export type PhotoPreviewDetails = {
   bleFallbackMessage?: string;
   bleFallbackUsed?: boolean;
@@ -174,6 +180,7 @@ export type PhotoPreviewDetails = {
   source: 'Cloud server' | 'Phone receiver' | 'Action button' | 'Glasses gallery';
   state: 'acknowledged' | 'error' | 'preview';
   timestamp?: number;
+  timeline?: PhotoTimelineEvent[];
   uploadUrl?: string;
   uploadedAt?: string;
   width?: number;
@@ -1626,7 +1633,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Enter a valid http:// or https:// media upload URL.');
       }
 
-      const requestId = `photo-${Date.now()}`;
+      const requestedAt = Date.now();
+      const requestId = `photo-${requestedAt}`;
       statusUrl = photoStatusUrl(uploadUrlText, requestId);
       activePhotoRequestIdRef.current = requestId;
       pollGenerationRef.current += 1;
@@ -1634,7 +1642,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
       setPhotoPreviewUrl(null);
       setPhotoPreviewDetails(null);
-      markPhotoRequestStarted(requestId);
+      markPhotoRequestStarted(requestId, 'Cloud server', requestedAt);
       resetBarcodeScan();
       setCameraStatus(`Camera: webhook upload requested (${requestId})`);
       try {
@@ -1663,13 +1671,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   async function captureAndUploadToPhone() {
     const receiver = await ensurePhonePhotoReceiver('capture');
 
-    const requestId = `photo-${Date.now()}`;
+    const requestedAt = Date.now();
+    const requestId = `photo-${requestedAt}`;
     activePhotoRequestIdRef.current = requestId;
     pollGenerationRef.current += 1;
 
     setPhotoPreviewUrl(null);
     setPhotoPreviewDetails(null);
-    markPhotoRequestStarted(requestId);
+    markPhotoRequestStarted(requestId, 'Phone receiver', requestedAt);
     resetBarcodeScan();
     setCameraStatus(`Camera: phone upload requested (${requestId})`);
     startPhonePhotoUploadTimeout(requestId);
@@ -1834,12 +1843,23 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhonePhotoUploadUrl(null);
   }
 
-  function markPhotoRequestStarted(requestId: string) {
+  function markPhotoRequestStarted(
+    requestId: string,
+    source: PhotoPreviewDetails['source'],
+    requestedAt: number,
+  ) {
     setPhotoStatus({
       type: 'photo_status',
       requestId,
       status: 'accepted',
-      timestamp: Date.now(),
+      timestamp: requestedAt,
+    });
+    setPhotoPreviewDetails({
+      requestId,
+      source,
+      state: 'acknowledged',
+      timestamp: requestedAt,
+      timeline: [{source: 'request', timestamp: requestedAt}],
     });
   }
 
@@ -1848,14 +1868,28 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     errorCode: string,
     errorMessage: string,
   ) {
+    const failedAt = Date.now();
     setPhotoStatus({
       type: 'photo_status',
       requestId,
       status: 'failed',
-      timestamp: Date.now(),
+      timestamp: failedAt,
       errorCode,
       errorMessage,
     });
+    setPhotoPreviewDetails((current) => ({
+      ...current,
+      error: errorMessage || errorCode,
+      requestId,
+      source: current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
+      state: 'error',
+      timestamp: failedAt,
+      timeline: appendPhotoTimeline(current?.timeline, {
+        source: 'photo_status',
+        status: 'failed',
+        timestamp: failedAt,
+      }),
+    }));
   }
 
   function markPhotoRequestStillWaiting(
@@ -1863,11 +1897,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     source: PhotoPreviewDetails['source'],
     error: unknown,
   ) {
+    const waitingAt = Date.now();
     setPhotoStatus({
       type: 'photo_status',
       requestId,
       status: 'uploading',
-      timestamp: Date.now(),
+      timestamp: waitingAt,
     });
     setPhotoPreviewDetails((current) => ({
       ...current,
@@ -1875,7 +1910,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       requestId,
       source,
       state: current?.state === 'preview' ? 'preview' : 'acknowledged',
-      timestamp: Date.now(),
+      timestamp: waitingAt,
+      timeline: appendPhotoTimeline(current?.timeline, {
+        source: 'photo_status',
+        status: 'uploading',
+        timestamp: waitingAt,
+      }),
     }));
     setCameraStatus('Camera: still waiting for photo delivery');
     addEvent(
@@ -1932,54 +1972,60 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     const fallbackMessage = photoBleFallbackMessage(payload.status);
     const bleTransferStatus =
       payload.status === 'ready_for_transfer' || payload.status === 'transferring';
-    if (
-      payload.resolvedConfig ||
-      payloadWithExtras.requestedCaptureConfig ||
-      payloadWithExtras.meteredPreview ||
-      payloadWithExtras.captureMetadata ||
-      fallbackMessage ||
-      bleTransferStatus
-    ) {
-      setPhotoPreviewDetails((current) => {
-        const bleFallbackUsed =
-          current?.bleFallbackUsed || payload.status === 'ble_fallback_compression';
-        return {
-          ...current,
-          bleFallbackMessage:
-            fallbackMessage ??
-            (bleFallbackUsed
-              ? photoBleFallbackProgressMessage(payload.status, current?.bleFallbackMessage)
-              : current?.bleFallbackMessage),
-          bleFallbackUsed,
-          requestId: payload.requestId,
-          source:
-            isGalleryModeButtonPhoto
-              ? 'Glasses gallery'
-              : payload.resolvedConfig?.source === 'button'
-                ? 'Action button'
-              : current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
-          state: current?.state === 'preview' ? 'preview' : 'acknowledged',
-          timestamp: payload.timestamp,
-          resolvedConfig: payload.resolvedConfig ?? current?.resolvedConfig,
-          requestedCaptureConfig:
-            payloadWithExtras.requestedCaptureConfig ?? current?.requestedCaptureConfig,
-          meteredPreview: payloadWithExtras.meteredPreview ?? current?.meteredPreview,
-          captureMetadata: payloadWithExtras.captureMetadata ?? current?.captureMetadata,
-        };
-      });
-    }
+    const statusPhoneTimestamp = Date.now();
+    const statusDeviceTimestamp = payload.timestamp ?? statusPhoneTimestamp;
+    setPhotoPreviewDetails((current) => {
+      const bleFallbackUsed =
+        current?.bleFallbackUsed || payload.status === 'ble_fallback_compression';
+      return {
+        ...current,
+        bleFallbackMessage:
+          fallbackMessage ??
+          (bleFallbackUsed
+            ? photoBleFallbackProgressMessage(payload.status, current?.bleFallbackMessage)
+            : current?.bleFallbackMessage),
+        bleFallbackUsed,
+        requestId: payload.requestId,
+        source:
+          isGalleryModeButtonPhoto
+            ? 'Glasses gallery'
+            : payload.resolvedConfig?.source === 'button'
+              ? 'Action button'
+            : current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
+        state: current?.state === 'preview' ? 'preview' : 'acknowledged',
+        timestamp: statusDeviceTimestamp,
+        timeline: appendPhotoTimeline(current?.timeline, {
+          source: 'photo_status',
+          status: payload.status,
+          deviceTimestamp: payload.timestamp,
+          timestamp: statusPhoneTimestamp,
+        }),
+        resolvedConfig: payload.resolvedConfig ?? current?.resolvedConfig,
+        requestedCaptureConfig:
+          payloadWithExtras.requestedCaptureConfig ?? current?.requestedCaptureConfig,
+        meteredPreview: payloadWithExtras.meteredPreview ?? current?.meteredPreview,
+        captureMetadata: payloadWithExtras.captureMetadata ?? current?.captureMetadata,
+      };
+    });
 
     if (payload.status === 'failed') {
       galleryModePhotoRequestIdsRef.current.delete(payload.requestId);
       clearPhotoUploadTimeout();
       activePhotoRequestIdRef.current = null;
-      setPhotoPreviewDetails({
+      setPhotoPreviewDetails((current) => ({
+        ...current,
         error: payload.errorCode ?? payload.errorMessage,
         requestId: payload.requestId,
-        source: photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver',
+        source: current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
         state: 'error',
-        timestamp: payload.timestamp,
-      });
+        timestamp: statusDeviceTimestamp,
+        timeline: current?.timeline ?? [{
+          source: 'photo_status',
+          status: payload.status,
+          deviceTimestamp: payload.timestamp,
+          timestamp: statusPhoneTimestamp,
+        }],
+      }));
       resetBarcodeScan();
     }
 
@@ -2152,6 +2198,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       return;
     }
     const previewUrl = response.photoUrl;
+    const responsePhoneTimestamp = Date.now();
+    const responseDeviceTimestamp = response.timestamp ?? responsePhoneTimestamp;
     if (previewUrl) {
       setPhotoPreviewUrl(previewUrl);
       setPhotoStatus(null);
@@ -2172,7 +2220,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       requestId: response.requestId,
       source: photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver',
       state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
-      timestamp: response.timestamp,
+      timestamp: responseDeviceTimestamp,
+      timeline: appendPhotoTimeline(current?.timeline, {
+        source: 'photo_response',
+        deviceTimestamp: response.timestamp,
+        timestamp: responsePhoneTimestamp,
+      }),
       uploadUrl: response.uploadUrl,
     }));
     if (previewUrl) {
@@ -4201,6 +4254,20 @@ function photoBleFallbackProgressMessage(status: string, currentMessage?: string
 
 function photoStatusStartsNewCapture(status: string) {
   return status === 'accepted' || status === 'queued' || status === 'configuring';
+}
+
+function appendPhotoTimeline(
+  timeline: PhotoTimelineEvent[] | undefined,
+  event: PhotoTimelineEvent,
+) {
+  const entries = timeline ?? [];
+  const duplicate = entries.some(
+    (entry) =>
+      entry.source === event.source &&
+      entry.status === event.status &&
+      (entry.deviceTimestamp ?? entry.timestamp) === (event.deviceTimestamp ?? event.timestamp),
+  );
+  return duplicate ? entries : [...entries, event];
 }
 
 function videoStatusIsFailure(status: string) {


### PR DESCRIPTION
## Summary

- Updates all Starter Kit example app Bluetooth SDK pins from `0.1.17` to `0.1.18`.
- Refreshes the React Native and ElevenLabs React Native `bun.lock` files so the `@mentra/bluetooth-sdk@0.1.18` integrity hash is current.
- Keeps the existing photo detail timeline work on this branch, which records requested/status/response timing in the React Native camera detail card.

## Validation

- `bun install --lockfile-only` in `examples/react-native`
- `bun install --lockfile-only` in `examples/react-native-elevenlabs-audio`
- `xcodebuild -project MentraExample.xcodeproj -resolvePackageDependencies` in `examples/ios`
- `git grep -n "0\.1\.17" -- examples/android examples/ios examples/react-native examples/react-native-elevenlabs-audio` returned no tracked matches
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version pins and example-app diagnostics; no production auth or data-path changes.
> 
> **Overview**
> Bumps all Starter Kit example apps from **Bluetooth SDK `0.1.17` to `0.1.18`**: Android `gradle.properties`, iOS SPM/`project.pbxproj`/`project.yml`, and both React Native examples’ `package.json` plus refreshed `bun.lock` integrity for `@mentra/bluetooth-sdk`.
> 
> The React Native camera example also **adds a photo capture timeline** for debugging latency. `useBluetoothSdkExample` records request, `photo_status`, and delivery events (with optional glasses `deviceTimestamp`), and the Camera screen **photo details** panel shows millisecond timestamps, deltas from request, clock-adjustment note, and **selectable** detail text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657e3dc9aa3d63c18368cef0637e52d582db6510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->