### PR TITLE
Publish bundled React Native release APKs

### DIFF
--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -263,13 +263,13 @@ jobs:
           chmod +x ./gradlew
           ./gradlew :app:compileDebugKotlin --no-daemon
 
-      - name: Build Android app
+      - name: Build release Android app
         working-directory: examples/react-native/android
         run: |
-          ./gradlew :app:assembleDebug --no-daemon
+          ./gradlew :app:assembleRelease --no-daemon
 
       - name: Collect APK
-        run: cp examples/react-native/android/app/build/outputs/apk/debug/app-debug.apk mentra-example-react-native.apk
+        run: cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk mentra-example-react-native.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
@@ -350,13 +350,13 @@ jobs:
           chmod +x ./gradlew
           ./gradlew :app:compileDebugKotlin --no-daemon
 
-      - name: Build Android app
+      - name: Build release Android app
         working-directory: examples/react-native-elevenlabs-audio/android
         run: |
-          ./gradlew :app:assembleDebug --no-daemon
+          ./gradlew :app:assembleRelease --no-daemon
 
       - name: Collect APK
-        run: cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/debug/app-debug.apk mentra-example-rn-elevenlabs-audio.apk
+        run: cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/release/app-release.apk mentra-example-rn-elevenlabs-audio.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Switch the React Native example APK artifact from the debug variant to the release variant.
- Do the same for the React Native ElevenLabs audio example, which had the same debug APK publishing path.

## Why
The workflow currently publishes `app-debug.apk` for the React Native examples. Expo/React Native debug builds are development clients: they intentionally skip embedding the JS bundle and launch to the Expo development server screen. That is why an installed artifact shows "Development Build" and asks for Metro.

The generated Expo Android Gradle config documents this behavior: `debug` is a debuggable variant, and debuggable variants skip JS/assets bundling. The release variant runs `createBundleReleaseJsAndAssets` and produces an APK containing `assets/index.android.bundle`.

## Verification
- `git diff --check`
- `./gradlew :app:assembleRelease --no-daemon` in `examples/react-native/android`
  - observed `:app:createBundleReleaseJsAndAssets`
  - verified release APK contains `assets/index.android.bundle`
- `./gradlew :app:assembleRelease --no-daemon` in `examples/react-native-elevenlabs-audio/android`
  - observed `:app:createBundleReleaseJsAndAssets`
  - verified release APK contains `assets/index.android.bundle`
- Confirmed existing debug APKs do not contain `assets/index.android.bundle`
