### PR TITLE
Display Mentra Live version details

### DIFF
--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, ScrollView, Pressable, StyleSheet, Image } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Circle, Line, Path, Rect } from 'react-native-svg';
+import { DeviceModels } from '@mentra/bluetooth-sdk';
 import { Header } from '../components/Header';
 import { OfflineNotice } from '../components/OfflineNotice';
 import { useScrollBottomPadding } from '../components/keyboardLayout';
@@ -197,6 +198,13 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           </View>} />
           <StatusRow label="TARGET" value={connectionTargetLabel(sdk)} mono />
           <StatusRow label="DEVICE" value={deviceLabel(sdk.glasses)} mono />
+          {shouldShowMentraLiveVersions(sdk) ? (
+            <>
+              <StatusRow label="ASG CLIENT" value={versionLabel(sdk.mentraLiveVersions.appVersion)} mono selectable />
+              <StatusRow label="MTK" value={versionLabel(sdk.mentraLiveVersions.mtkFirmwareVersion)} mono selectable />
+              <StatusRow label="BES" value={versionLabel(sdk.mentraLiveVersions.besFirmwareVersion)} mono selectable />
+            </>
+          ) : null}
           <StatusRow label="BATTERY" custom={<View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
             <Text style={[styles.statusValue, { fontWeight: '600' }]}>{batteryLabel(sdk.glasses)}</Text>
             {charging ? <View style={styles.chargingPill}>
@@ -243,6 +251,21 @@ function connectionTargetLabel(sdk: BluetoothSdkExampleModel) {
     return 'Choose a discovered device';
   }
   return sdk.defaultDevice?.name ?? 'Scan required';
+}
+
+function shouldShowMentraLiveVersions(sdk: BluetoothSdkExampleModel) {
+  if (!isGlassesConnected(sdk.glasses)) {
+    return false;
+  }
+  const model = [
+    sdk.glasses.device.deviceModel,
+    sdk.glasses.device.bluetoothName,
+  ].filter(Boolean).join(' ').toLowerCase();
+  return sdk.glasses.device.deviceModel === DeviceModels.MentraLive || model.includes('mentra live');
+}
+
+function versionLabel(version: string | null) {
+  return version ?? 'Unknown';
 }
 
 function glassesImageFor(status: BluetoothSdkExampleModel['glasses']) {

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -95,7 +95,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
 
           {/* Stat row */}
           <View style={styles.statRow}>
-            <StatCard label="FIRMWARE" value={firmwareLabel(sdk.glasses)} sub={firmwareSubLabel(sdk.glasses)} subColor={colors.greenAccent} />
+            <StatCard label="FIRMWARE" value={firmwareCardLabel(sdk)} sub={firmwareCardSubLabel(sdk)} subColor={colors.greenAccent} />
             <StatCard label="WI-FI" value={wifiLabel(sdk.glasses)} sub={wifiSubLabel(sdk.glasses)} subColor={colors.muted} bold />
             <StatCard label="RSSI" value={rssiLabel(sdk.glasses)} sub={rssiUpdatedLabel(sdk.glasses)} subColor={colors.greenAccent} bold />
           </View>
@@ -266,6 +266,20 @@ function shouldShowMentraLiveVersions(sdk: BluetoothSdkExampleModel) {
 
 function versionLabel(version: string | null) {
   return version ?? 'Unknown';
+}
+
+function firmwareCardLabel(sdk: BluetoothSdkExampleModel) {
+  if (shouldShowMentraLiveVersions(sdk) && sdk.mentraLiveVersions.appVersion) {
+    return sdk.mentraLiveVersions.appVersion;
+  }
+  return firmwareLabel(sdk.glasses);
+}
+
+function firmwareCardSubLabel(sdk: BluetoothSdkExampleModel) {
+  if (shouldShowMentraLiveVersions(sdk) && sdk.mentraLiveVersions.appVersion) {
+    return 'ASG client';
+  }
+  return firmwareSubLabel(sdk.glasses);
 }
 
 function glassesImageFor(status: BluetoothSdkExampleModel['glasses']) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -105,6 +105,36 @@ function otaVersionInfoSignature(event: VersionInfoEvent) {
   ].filter(Boolean).join('|') || 'version-unknown';
 }
 
+function versionValue(value: string | null | undefined) {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveMentraLiveVersions(
+  glasses: GlassesRuntimeState,
+  versionInfo: VersionInfoEvent | null,
+): MentraLiveVersions {
+  if (!glasses.connected) {
+    return {
+      appVersion: null,
+      besFirmwareVersion: null,
+      mtkFirmwareVersion: null,
+    };
+  }
+
+  return {
+    appVersion:
+      versionValue(versionInfo?.appVersion) ??
+      versionValue(glasses.device.appVersion) ??
+      versionValue(glasses.firmware.appVersion),
+    besFirmwareVersion:
+      versionValue(versionInfo?.besFirmwareVersion) ??
+      (glasses.firmware.source === 'bes' ? versionValue(glasses.firmware.version) : null),
+    mtkFirmwareVersion:
+      versionValue(versionInfo?.mtkFirmwareVersion) ??
+      (glasses.firmware.source === 'mtk' ? versionValue(glasses.firmware.version) : null),
+  };
+}
+
 export type StreamResolvedConfig = {
   transport?: 'rtmp' | 'srt' | 'whip';
   video?: {
@@ -336,6 +366,12 @@ export type SdkConsoleEvent = {
   time: string;
 };
 
+export type MentraLiveVersions = {
+  appVersion: string | null;
+  besFirmwareVersion: string | null;
+  mtkFirmwareVersion: string | null;
+};
+
 export type BluetoothSdkExampleState = {
   activeAction: string | null;
   barcodeScan: BarcodeScanDetails;
@@ -352,6 +388,7 @@ export type BluetoothSdkExampleState = {
   lastAction: string;
   lastMicBytes: number;
   lastMicDurationSeconds: number | null;
+  mentraLiveVersions: MentraLiveVersions;
   micAudioRouteStatus: string;
   ledColor: LedColor;
   ledMode: LedMode;
@@ -662,6 +699,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
+  const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoEvent | null>(null);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
 
   const bluetooth = useMentraBluetooth({
@@ -728,6 +766,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!glassesConnected) {
+      setLatestVersionInfo(null);
+    }
+  }, [glassesConnected]);
 
   useEffect(() => {
     if (didAutoConnectDefaultRef.current || glassesConnected) {
@@ -840,6 +884,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('LIVE', `stream status ${summarizeMap(payload)}`);
       }),
       BluetoothSdk.addListener('version_info', (payload: VersionInfoEvent) => {
+        setLatestVersionInfo(payload);
         setLatestVersionInfoSignature(otaVersionInfoSignature(payload));
       }),
       BluetoothSdk.addListener('ota_status', applyOtaStatus),
@@ -3487,6 +3532,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     lastAction,
     lastMicBytes,
     lastMicDurationSeconds,
+    mentraLiveVersions: resolveMentraLiveVersions(glasses, latestVersionInfo),
     ledColor,
     ledMode,
     micAudioRouteStatus,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -25,6 +25,7 @@ import BluetoothSdk, {
   type StreamStatusEvent,
   type TouchEvent,
   type VersionInfoEvent,
+  type VersionInfoResult,
   type VideoRecordingStatusEvent,
   type VoiceActivityDetectionStatusEvent,
 } from '@mentra/bluetooth-sdk';
@@ -95,7 +96,7 @@ function otaVersionSignature(glasses: GlassesRuntimeState) {
   ].filter(Boolean).join('|') || 'version-unknown';
 }
 
-function otaVersionInfoSignature(event: VersionInfoEvent) {
+function otaVersionInfoSignature(event: VersionInfoResult) {
   return [
     event.buildNumber,
     event.appVersion,
@@ -111,7 +112,7 @@ function versionValue(value: string | null | undefined) {
 
 function resolveMentraLiveVersions(
   glasses: GlassesRuntimeState,
-  versionInfo: VersionInfoEvent | null,
+  versionInfo: VersionInfoResult | null,
 ): MentraLiveVersions {
   if (!glasses.connected) {
     return {
@@ -133,6 +134,17 @@ function resolveMentraLiveVersions(
       versionValue(versionInfo?.mtkFirmwareVersion) ??
       (glasses.firmware.source === 'mtk' ? versionValue(glasses.firmware.version) : null),
   };
+}
+
+function isMentraLiveRuntime(glasses: GlassesRuntimeState) {
+  if (!glasses.connected) {
+    return false;
+  }
+  const model = [
+    glasses.device.deviceModel,
+    glasses.device.bluetoothName,
+  ].filter(Boolean).join(' ').toLowerCase();
+  return glasses.device.deviceModel === DeviceModels.MentraLive || model.includes('mentra live');
 }
 
 export type StreamResolvedConfig = {
@@ -699,7 +711,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
-  const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoEvent | null>(null);
+  const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoResult | null>(null);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
 
   const bluetooth = useMentraBluetooth({
@@ -767,11 +779,37 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     };
   }, []);
 
-  useEffect(() => {
-    if (!glassesConnected) {
-      setLatestVersionInfo(null);
+  function applyVersionInfo(payload: VersionInfoResult) {
+    if (!glassesConnectedRef.current) {
+      return;
     }
-  }, [glassesConnected]);
+    setLatestVersionInfo(payload);
+    setLatestVersionInfoSignature(otaVersionInfoSignature(payload));
+  }
+
+  useEffect(() => {
+    setLatestVersionInfo(null);
+    if (!glassesConnected || !isMentraLiveRuntime(glasses)) {
+      return;
+    }
+
+    let cancelled = false;
+    void BluetoothSdk.requestVersionInfo()
+      .then((payload) => {
+        if (!cancelled) {
+          applyVersionInfo(payload);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled && glassesConnectedRef.current) {
+          addEvent('LIVE', `version info refresh failed: ${formatError(error)}`);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connectedDeviceKey, glassesConnected]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (didAutoConnectDefaultRef.current || glassesConnected) {
@@ -884,8 +922,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('LIVE', `stream status ${summarizeMap(payload)}`);
       }),
       BluetoothSdk.addListener('version_info', (payload: VersionInfoEvent) => {
-        setLatestVersionInfo(payload);
-        setLatestVersionInfoSignature(otaVersionInfoSignature(payload));
+        applyVersionInfo(payload);
       }),
       BluetoothSdk.addListener('ota_status', applyOtaStatus),
       BluetoothSdk.addListener('mic_pcm', (payload: MicPcmEvent) => {


### PR DESCRIPTION
## Summary
- Store the latest Mentra Live `version_info` payload in the React Native example state.
- Show ASG client, MTK firmware, and BES firmware versions in the Device tab for connected Mentra Live glasses.
- Keep the rows hidden for non-Mentra Live devices and show `Unknown` until a version value is reported.

## Verification
- `bunx tsc --noEmit -p tsconfig.json` in `examples/react-native`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI and demo state only; no production SDK or auth changes.
> 
> **Overview**
> Adds **Mentra Live–specific version reporting** to the React Native Bluetooth SDK example.
> 
> On connect for Mentra Live devices, the hook **requests `version_info`**, keeps the latest **`VersionInfoResult`** in state, and exposes **`mentraLiveVersions`** (ASG app, MTK, BES) with fallbacks from existing glasses runtime fields when events are missing. **`version_info` listener** updates the same stored payload instead of only tracking an OTA signature.
> 
> The **Device** screen shows **ASG CLIENT**, **MTK**, and **BES** rows in live status (and uses ASG client for the firmware stat card) only when connected Mentra Live; missing values show **Unknown**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9525291a3bea6d2b8c9c4f97a427ea8c7853e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->