### PR TITLE
Update example apps to Bluetooth SDK 0.1.19

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.18
+mentraSdkVersion=0.1.19
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.18
+mentraSdkVersion=0.1.19

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.18;
+				version = 0.1.19;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.18`:
+The Xcode project pins the public Swift package to `0.1.19`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.18
+    exactVersion: 0.1.19
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.18",
+        "@mentra/bluetooth-sdk": "0.1.19",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.18",
+    "@mentra/bluetooth-sdk": "0.1.19",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.18"
+"@mentra/bluetooth-sdk": "0.1.19"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.18",
+        "@mentra/bluetooth-sdk": "0.1.19",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -300,7 +300,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.18",
+    "@mentra/bluetooth-sdk": "0.1.19",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
## Summary

- Updates the native Android example to `com.mentraglass:bluetooth-sdk:0.1.19`.
- Updates the native iOS example SwiftPM exact-version pin to `0.1.19` in both `project.yml` and the checked-in Xcode project.
- Updates both React Native examples to `@mentra/bluetooth-sdk@0.1.19`.
- Updates their Bun lock entries and the README snippets that document the pinned release.

## Release dependency

This PR depends on Mentra-Community/MentraOS#3403. At the time this PR was opened, 0.1.19 had not yet been published to npm, Maven Central, or the public SwiftPM repository, so registry-backed builds cannot complete until that release workflow finishes.

The Bun lock integrity was derived from the 0.1.19 npm release candidate produced by the MentraOS release branch. Two independent `npm pack` runs produced the same tarball SHA and integrity:

- SHA-1: `9ea497eb0b4f4d6ce7ba8654e7ec9dd6a43f8df9`
- Integrity: `sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw==`

Once #3403 merges and publication completes, this PR should be refreshed against the actual registries and moved out of draft.

## Validation completed

- Confirmed all declared SDK pins across the Android, iOS, React Native, and React Native ElevenLabs examples now reference `0.1.19`.
- Parsed both React Native `package.json` files with `jq`.
- Confirmed the Xcode project and its XcodeGen source agree on exact version `0.1.19`.
- `git diff --check`.
- Verified the locally packed 0.1.19 npm release candidate injects the correct iOS SDK version and restores the source placeholder afterward.

## Publication-gated validation

After the release artifacts exist:

- Run `bun install --frozen-lockfile` and TypeScript checks in both React Native examples.
- Compile the Android example against Maven Central 0.1.19.
- Resolve and analyze the iOS example against SwiftPM tag 0.1.19.
- Confirm the published npm integrity matches the release-candidate lock entries.

## Risk

Low and isolated to example dependency pins. No example behavior or SDK implementation is changed here.