### PR TITLE
Preview glasses-stored photos over hotspot and update SDK to 0.1.19

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.18
+mentraSdkVersion=0.1.19
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
@@ -1,0 +1,89 @@
+package com.mentra.examples.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resumeWithException
+
+class GlassesHotspotConnector(context: Context) {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private var callback: ConnectivityManager.NetworkCallback? = null
+    private var pendingContinuation: CancellableContinuation<Unit>? = null
+
+    suspend fun connect(ssid: String, password: String) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            throw IOException("Automatic hotspot connection requires Android 10 or newer.")
+        }
+        disconnect()
+        withTimeout(35_000) {
+            suspendCancellableCoroutine { continuation ->
+                pendingContinuation = continuation
+                val completed = AtomicBoolean(false)
+                val specifier = WifiNetworkSpecifier.Builder()
+                    .setSsid(ssid)
+                    .setWpa2Passphrase(password)
+                    .build()
+                val request = NetworkRequest.Builder()
+                    .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                    .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .setNetworkSpecifier(specifier)
+                    .build()
+                val networkCallback = object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        if (!connectivityManager.bindProcessToNetwork(network)) {
+                            if (completed.compareAndSet(false, true)) {
+                                pendingContinuation = null
+                                continuation.resumeWithException(IOException("Could not route gallery traffic over the glasses hotspot."))
+                            }
+                            return
+                        }
+                        if (completed.compareAndSet(false, true)) {
+                            pendingContinuation = null
+                            continuation.resumeWith(Result.success(Unit))
+                        }
+                    }
+
+                    override fun onUnavailable() {
+                        if (completed.compareAndSet(false, true)) {
+                            pendingContinuation = null
+                            continuation.resumeWithException(IOException("The glasses hotspot connection was not approved or could not be found."))
+                        }
+                    }
+
+                    override fun onLost(network: Network) {
+                        connectivityManager.bindProcessToNetwork(null)
+                    }
+                }
+                callback = networkCallback
+                continuation.invokeOnCancellation { releaseNetwork() }
+                connectivityManager.requestNetwork(request, networkCallback)
+            }
+        }
+    }
+
+    fun disconnect() {
+        val continuation = pendingContinuation
+        pendingContinuation = null
+        releaseNetwork()
+        continuation?.cancel(CancellationException("Glasses hotspot connection cancelled."))
+    }
+
+    private fun releaseNetwork() {
+        connectivityManager.bindProcessToNetwork(null)
+        callback?.let { current ->
+            runCatching { connectivityManager.unregisterNetworkCallback(current) }
+        }
+        callback = null
+    }
+}

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MainActivity.kt
@@ -114,6 +114,7 @@ class MainActivity : ComponentActivity() {
             }
             if (Build.VERSION.SDK_INT >= 33) {
                 add(Manifest.permission.POST_NOTIFICATIONS)
+                add(Manifest.permission.NEARBY_WIFI_DEVICES)
             }
         }.toTypedArray()
         ActivityCompat.requestPermissions(this, permissions, 100)

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -93,6 +93,7 @@ import java.net.URI
 import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.URLDecoder
+import java.net.URLEncoder
 import java.net.UnknownHostException
 import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
@@ -114,6 +115,7 @@ fun streamProtocolLabel(protocol: String): String = if (protocol == "webrtc") "W
 enum class PhotoDestination {
     MACBOOK_SERVER,
     THIS_PHONE,
+    GLASSES_STORAGE,
 }
 
 data class ExampleEvent(
@@ -126,6 +128,7 @@ data class PhotoPreviewDetails(
     val byteCount: Int? = null,
     val contentType: String? = null,
     val error: String? = null,
+    val fileName: String? = null,
     val height: Int? = null,
     val previewUrl: String? = null,
     val requestId: String? = null,
@@ -173,6 +176,19 @@ private data class GalleryServerCheck(
     val eventText: String,
 )
 
+private data class GalleryPhoto(
+    val name: String,
+    val mimeType: String?,
+    val size: Int?,
+    val url: String?,
+)
+
+private data class PendingHotspotConnection(
+    val ssid: String,
+    val password: String,
+    val baseUrl: String,
+)
+
 private data class WebhookReachability(
     val healthUrl: String,
     val host: String,
@@ -199,6 +215,7 @@ const val CAMERA_FOV_DEFAULT = 102
 const val CAMERA_WARM_UP_DURATION_MS = 30_000
 const val CAMERA_WARM_UP_REFRESH_MS = 20_000L
 const val CAMERA_WARM_UP_DISCONNECTED_RETRY_MS = 2_000L
+const val GLASSES_PHOTO_POLL_ATTEMPTS = 120
 val photoAeExposureDivisorOptions = listOf(2, 3, 5)
 val photoIsoCapOptions = listOf(400, 800, 1600)
 val photoIspDigitalGainOptions = listOf(0, 1, 2, 4)
@@ -216,6 +233,7 @@ data class MentraExampleState(
     val galleryModeEnabled: Boolean = false,
     val galleryServerReachable: Boolean? = null,
     val galleryServerStatus: String = "Gallery server: enable hotspot to check",
+    val hotspotJoinPromptSsid: String? = null,
     val glassesStatus: GlassesRuntimeState? = null,
     val glassesMediaVolume: Int? = null,
     val glassesVolumeStatus: String = "Glasses volume: not checked",
@@ -301,6 +319,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private val cloudUrlPrefs =
         appContext.getSharedPreferences("mentra_example_cloud_urls", Context.MODE_PRIVATE)
     private val mentraBluetoothSdk = MentraBluetoothSdk.create(appContext, this)
+    private val glassesHotspotConnector = GlassesHotspotConnector(appContext)
     private val controllerJob = Job()
     private val scope = CoroutineScope(Dispatchers.Main + controllerJob)
     private val photoUploadServer = LocalPhotoUploadServer(
@@ -312,6 +331,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var activeVideoRequestId: String? = null
     private var activeStreamId: String? = null
     private var pollGeneration = 0
+    private var galleryConnectionGeneration = 0
+    private var pendingHotspotConnection: PendingHotspotConnection? = null
+    private var hotspotJoinExplanationShown = false
     private var videoPollGeneration = 0
     private var directPhotoTimeoutJob: Job? = null
     private var gStreamerWhipReceiver: GStreamerWhipReceiver? = null
@@ -541,13 +563,145 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (state.photoDestination == destination) {
             return
         }
-        if (destination == PhotoDestination.MACBOOK_SERVER) {
-            stopPhonePhotoServer()
-            state = state.copy(cameraStatus = "Camera: enter a media upload URL")
-        } else {
-            state = state.copy(cameraStatus = "Camera: phone receiver will start before capture")
+        val wasGlassesStorage = state.photoDestination == PhotoDestination.GLASSES_STORAGE
+        stopPhonePhotoServer()
+        state = state.copy(
+            cameraStatus = when (destination) {
+                PhotoDestination.MACBOOK_SERVER -> "Camera: enter a media upload URL"
+                PhotoDestination.THIS_PHONE -> "Camera: phone receiver will start before capture"
+                PhotoDestination.GLASSES_STORAGE -> "Camera: preparing glasses hotspot"
+            },
+            photoDestination = destination,
+        )
+        if (destination == PhotoDestination.GLASSES_STORAGE) {
+            if (isGlassesConnected()) {
+                prepareGlassesPhotoPreview()
+            }
+            return
         }
-        state = state.copy(photoDestination = destination)
+        if (!wasGlassesStorage) {
+            return
+        }
+        galleryConnectionGeneration += 1
+        pendingHotspotConnection = null
+        state = state.copy(
+            galleryServerReachable = null,
+            galleryServerStatus = "Gallery server: hotspot off",
+            hotspotJoinPromptSsid = null,
+        )
+        runAction("Disable glasses photo hotspot") {
+            glassesHotspotConnector.disconnect()
+            if (state.hotspotEnabled && isGlassesConnected()) {
+                withContext(Dispatchers.IO) { mentraBluetoothSdk.setHotspotState(false) }
+            }
+        }
+    }
+
+    fun prepareGlassesPhotoPreview() = runAction("Connect to glasses hotspot") {
+        prepareGlassesPhotoPreviewConnection()
+    }
+
+    fun confirmHotspotJoin() {
+        hotspotJoinExplanationShown = true
+        state = state.copy(hotspotJoinPromptSsid = null)
+        runAction("Join glasses hotspot") {
+            connectPendingGlassesHotspot()
+        }
+    }
+
+    fun dismissHotspotJoin() {
+        state = state.copy(
+            galleryServerReachable = false,
+            galleryServerStatus = "Gallery server: connection required",
+            hotspotJoinPromptSsid = null,
+            cameraStatus = "Camera: connect to the glasses hotspot to enable capture",
+        )
+    }
+
+    private suspend fun prepareGlassesPhotoPreviewConnection() {
+        requireConnected("prepare saved-photo previews")
+        val generation = ++galleryConnectionGeneration
+        state = state.copy(
+            cameraStatus = "Camera: preparing glasses hotspot",
+            galleryServerReachable = null,
+            galleryServerStatus = "Gallery server: starting glasses hotspot",
+            hotspotJoinPromptSsid = null,
+        )
+        val existing = enabledHotspotStatus(state.glassesStatus)
+        val hotspot = existing ?: withContext(Dispatchers.IO) {
+            mentraBluetoothSdk.setHotspotState(true).status as? HotspotStatus.Enabled
+        } ?: throw IllegalStateException("The glasses hotspot did not turn on.")
+        if (generation != galleryConnectionGeneration) return
+
+        val pending = PendingHotspotConnection(
+            ssid = hotspot.ssid,
+            password = hotspot.password,
+            baseUrl = "http://${hotspot.localIp}:8089",
+        )
+        pendingHotspotConnection = pending
+        if (waitForGalleryServer(pending.baseUrl, attempts = 3, delayMs = 400)) {
+            markGalleryServerReady(pending.baseUrl)
+            return
+        }
+        if (!hotspotJoinExplanationShown) {
+            state = state.copy(
+                cameraStatus = "Camera: approve the glasses hotspot connection",
+                galleryServerReachable = false,
+                galleryServerStatus = "Gallery server: approval required for ${pending.ssid}",
+                hotspotJoinPromptSsid = pending.ssid,
+            )
+            return
+        }
+        connectPendingGlassesHotspot()
+    }
+
+    private suspend fun connectPendingGlassesHotspot() {
+        val pending = pendingHotspotConnection ?: run {
+            prepareGlassesPhotoPreviewConnection()
+            return
+        }
+        val generation = galleryConnectionGeneration
+        state = state.copy(
+            cameraStatus = "Camera: connecting to ${pending.ssid}",
+            galleryServerReachable = null,
+            galleryServerStatus = "Gallery server: connecting to ${pending.ssid}",
+        )
+        try {
+            withContext(Dispatchers.IO) {
+                glassesHotspotConnector.connect(pending.ssid, pending.password)
+            }
+            if (generation != galleryConnectionGeneration) return
+            if (!waitForGalleryServer(pending.baseUrl, attempts = 20, delayMs = 500)) {
+                throw IOException("Could not reach the glasses gallery after connecting.")
+            }
+            markGalleryServerReady(pending.baseUrl)
+        } catch (error: Throwable) {
+            if (generation != galleryConnectionGeneration) return
+            state = state.copy(
+                cameraStatus = "Camera: connect to the glasses hotspot to enable capture",
+                galleryServerReachable = false,
+                galleryServerStatus = "Gallery server: ${error.message ?: "connection failed"}",
+            )
+            throw error
+        }
+    }
+
+    private suspend fun waitForGalleryServer(baseUrl: String, attempts: Int, delayMs: Long): Boolean {
+        repeat(attempts) { attempt ->
+            if (checkGalleryServerReachability(baseUrl).reachable) return true
+            if (attempt < attempts - 1) delay(delayMs)
+        }
+        return false
+    }
+
+    private fun markGalleryServerReady(baseUrl: String) {
+        state = state.copy(
+            cameraStatus = "Camera: ready to save and preview from glasses",
+            galleryServerReachable = true,
+            galleryServerStatus = "Gallery server: ready at $baseUrl",
+            hotspotJoinPromptSsid = null,
+        )
+        addEvent("LIVE", "gallery server ready $baseUrl")
     }
 
     fun setPhotoSize(size: String) {
@@ -776,6 +930,13 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     fun captureAndUpload() = runAction(if (state.scanMode) "Capture scan photo" else "Capture & upload") {
         requireConnected("capture photos")
+        if (state.photoDestination == PhotoDestination.GLASSES_STORAGE) {
+            if (state.galleryServerReachable != true) {
+                throw IllegalStateException("Connect to the glasses hotspot before capturing.")
+            }
+            captureToGlassesStorage()
+            return@runAction
+        }
         requireGlassesWifi("capture photos")
         if (state.photoDestination == PhotoDestination.THIS_PHONE) {
             captureAndUploadToPhone()
@@ -860,12 +1021,64 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("TX", "requestPhoto requestId=$requestId webhookUrl=$uploadUrl")
     }
 
-    private fun buildPhotoRequest(requestId: String, webhookUrl: String): PhotoRequest {
+    private suspend fun captureToGlassesStorage() {
+        val requestId = "photo-${System.currentTimeMillis()}"
+        activePhotoRequestId = requestId
+        pollGeneration += 1
+        val generation = pollGeneration
+        state = state.copy(
+            cameraStatus = "Camera: saving photo on glasses ($requestId)",
+            photoPreviewDetails = PhotoPreviewDetails(
+                requestId = requestId,
+                source = "Glasses gallery",
+                state = "acknowledged",
+            ),
+            photoPreviewUrl = null,
+        )
+        val responseEvent = try {
+            withContext(Dispatchers.IO) {
+                mentraBluetoothSdk.requestPhoto(
+                    buildPhotoRequest(requestId = requestId, webhookUrl = "", save = true)
+                )
+            }
+        } catch (error: Throwable) {
+            activePhotoRequestId = null
+            throw error
+        }
+        handlePhotoResponse(responseEvent)
+        state = state.copy(
+            cameraStatus = "Camera: photo saved on glasses; loading preview",
+            photoPreviewDetails = state.photoPreviewDetails?.copy(state = "saved"),
+        )
+        scope.launch {
+            try {
+                downloadGlassesPhotoPreview(requestId, generation)
+            } catch (error: Throwable) {
+                if (activePhotoRequestId != requestId || pollGeneration != generation) return@launch
+                activePhotoRequestId = null
+                val message = error.message ?: "Saved photo preview download failed."
+                state = state.copy(
+                    cameraStatus = "Camera: $message",
+                    photoPreviewDetails = state.photoPreviewDetails?.copy(
+                        error = message,
+                        state = "saved",
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun buildPhotoRequest(
+        requestId: String,
+        webhookUrl: String,
+        save: Boolean = false,
+    ): PhotoRequest {
         return PhotoRequest(
             requestId = requestId,
             size = photoSizeToSdk(state.photoSize),
             webhookUrl = webhookUrl,
             compress = PhotoCompression.fromValue(state.photoCompression),
+            save = save,
             sound = true,
             exposureTimeNs = if (state.photoExposureManual) state.photoExposureTimeNs.toDouble() else null,
             iso = if (state.photoExposureManual) state.photoIso else null,
@@ -878,6 +1091,130 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             ispDigitalGain = state.photoIspDigitalGain,
             ispAnalogGain = state.photoIspAnalogGain,
         )
+    }
+
+    private suspend fun downloadGlassesPhotoPreview(
+        requestId: String,
+        generation: Int,
+    ) {
+        val baseUrl = pendingHotspotConnection?.baseUrl
+            ?: galleryServerUrl(state.glassesStatus, state.hotspotEnabled)
+            ?: throw IllegalStateException("The glasses hotspot is not ready for preview downloads.")
+        if (state.galleryServerReachable != true) {
+            throw IllegalStateException("The glasses hotspot is not ready for preview downloads.")
+        }
+
+        val localFile = File(appContext.cacheDir, "mentra-gallery-$requestId.jpg")
+        state = state.copy(galleryServerStatus = "Gallery server: finding $requestId")
+
+        repeat(GLASSES_PHOTO_POLL_ATTEMPTS) { attempt ->
+            if (activePhotoRequestId != requestId || pollGeneration != generation) {
+                return
+            }
+            try {
+                val photo = withContext(Dispatchers.IO) {
+                    findGalleryPhoto(baseUrl, requestId)
+                }
+                state = state.copy(
+                    galleryServerReachable = true,
+                    galleryServerStatus = "Gallery server: connected; finding $requestId",
+                )
+                if (photo == null) {
+                    delay(1_000)
+                    return@repeat
+                }
+                val encodedFileName = URLEncoder.encode(photo.name, StandardCharsets.UTF_8.name())
+                val remoteUrl = photo.url?.let {
+                    if (it.startsWith("http://") || it.startsWith("https://")) it else "$baseUrl$it"
+                } ?: "$baseUrl/api/photo?file=$encodedFileName"
+                val contentType = withContext(Dispatchers.IO) {
+                    downloadGalleryFile(remoteUrl, localFile)
+                }
+                val dimensions = imageDimensions(localFile)
+                val previewUri = Uri.fromFile(localFile).toString()
+                activePhotoRequestId = null
+                state = state.copy(
+                    cameraStatus = "Camera: loaded photo preview from glasses",
+                    galleryServerReachable = true,
+                    galleryServerStatus = "Gallery server: downloaded ${photo.name}",
+                    photoPreviewDetails = state.photoPreviewDetails.copyForUpload(
+                        byteCount = photo.size ?: localFile.length().toInt(),
+                        contentType = photo.mimeType ?: contentType,
+                        fileName = photo.name,
+                        height = dimensions?.second,
+                        previewUrl = remoteUrl,
+                        requestId = requestId,
+                        source = "Glasses gallery",
+                        width = dimensions?.first,
+                    ),
+                    photoPreviewUrl = previewUri,
+                )
+                addEvent("LIVE", "glasses photo downloaded ${photo.name}")
+                return
+            } catch (error: Throwable) {
+                if (attempt == 0 || attempt % 10 == 9) {
+                    state = state.copy(
+                        cameraStatus = "Camera: join ${galleryHotspotSsidLabel(state.glassesStatus)} to load the saved photo",
+                        galleryServerReachable = false,
+                        galleryServerStatus = "Gallery server: not reachable. Join ${galleryHotspotSsidLabel(state.glassesStatus)}.",
+                    )
+                    addEvent("LIVE", "waiting for glasses photo $requestId: ${error.message}")
+                }
+            }
+            delay(1_000)
+        }
+        throw IOException(
+            "Photo was saved on the glasses, but the preview could not be downloaded from $baseUrl."
+        )
+    }
+
+    private fun downloadGalleryFile(remoteUrl: String, destination: File): String {
+        val connection = URL(remoteUrl).openConnection() as HttpURLConnection
+        connection.connectTimeout = 2_000
+        connection.readTimeout = 30_000
+        connection.useCaches = false
+        connection.setRequestProperty("Cache-Control", "no-cache")
+        try {
+            val code = connection.responseCode
+            if (code !in 200..299) {
+                throw IOException("Gallery server returned HTTP $code.")
+            }
+            destination.outputStream().buffered().use { output ->
+                connection.inputStream.buffered().use { input -> input.copyTo(output) }
+            }
+            return connection.contentType?.substringBefore(';') ?: "image/jpeg"
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun findGalleryPhoto(baseUrl: String, requestId: String): GalleryPhoto? {
+        val connection = URL("$baseUrl/api/gallery?limit=100&poll=${System.currentTimeMillis()}")
+            .openConnection() as HttpURLConnection
+        connection.connectTimeout = 2_000
+        connection.readTimeout = 5_000
+        connection.useCaches = false
+        return try {
+            if (connection.responseCode !in 200..299) {
+                throw IOException("Gallery server returned HTTP ${connection.responseCode}.")
+            }
+            val body = connection.inputStream.bufferedReader().use { it.readText() }
+            val photos = JSONObject(body).optJSONObject("data")?.optJSONArray("photos") ?: return null
+            for (index in 0 until photos.length()) {
+                val photo = photos.optJSONObject(index) ?: continue
+                if (photo.optString("request_id") != requestId) continue
+                val name = photo.optString("name").takeIf { it.isNotBlank() } ?: continue
+                return GalleryPhoto(
+                    name = name,
+                    mimeType = photo.optString("mime_type").takeIf { it.isNotBlank() },
+                    size = photo.optInt("size", -1).takeIf { it >= 0 },
+                    url = photo.optString("url").takeIf { it.isNotBlank() },
+                )
+            }
+            null
+        } finally {
+            connection.disconnect()
+        }
     }
 
     fun toggleVideoRecording() {
@@ -1771,6 +2108,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             if (state.scanMode) {
                 pushScanButtonPreset()
             }
+            if (state.photoDestination == PhotoDestination.GLASSES_STORAGE) {
+                prepareGlassesPhotoPreview()
+            }
         }
         maybeAutoCheckOta()
         addEvent("STORE", summarize(glasses))
@@ -1843,8 +2183,16 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         val nextGlassesStatus = (state.glassesStatus as? GlassesRuntimeState.Connected)?.copy(hotspot = status)
         state = state.copy(
             hotspotEnabled = enabled,
-            galleryServerReachable = null,
-            galleryServerStatus = if (enabled) {
+            galleryServerReachable = if (enabled) {
+                state.galleryServerReachable
+            } else if (state.photoDestination == PhotoDestination.GLASSES_STORAGE) {
+                false
+            } else {
+                null
+            },
+            galleryServerStatus = if (enabled && state.galleryServerReachable == true) {
+                state.galleryServerStatus
+            } else if (enabled) {
                 "Gallery server: ${galleryServerUrl(nextGlassesStatus, enabled)}"
             } else {
                 "Gallery server: hotspot off"
@@ -1872,18 +2220,27 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             addEvent("LIVE", "ignoring stale photo $requestId")
             return
         }
-        val uploadTarget = if (state.photoDestination == PhotoDestination.THIS_PHONE) "phone receiver" else "cloud webhook"
+        val uploadTarget = when (state.photoDestination) {
+            PhotoDestination.THIS_PHONE -> "phone receiver"
+            PhotoDestination.MACBOOK_SERVER -> "cloud webhook"
+            PhotoDestination.GLASSES_STORAGE -> "glasses storage"
+        }
+        val source = when (state.photoDestination) {
+            PhotoDestination.THIS_PHONE -> "Phone receiver"
+            PhotoDestination.MACBOOK_SERVER -> "Cloud server"
+            PhotoDestination.GLASSES_STORAGE -> "Glasses gallery"
+        }
         val nextDetails = when (response) {
             is PhotoResponse.Error -> PhotoPreviewDetails(
                 error = response.errorCode ?: response.errorMessage,
                 requestId = requestId,
-                source = if (state.photoDestination == PhotoDestination.THIS_PHONE) "Phone receiver" else "Cloud server",
+                source = source,
                 state = "error",
                 timestamp = response.timestamp,
             )
             is PhotoResponse.Success -> state.photoPreviewDetails.copyForAck(
                 requestId = requestId,
-                source = if (state.photoDestination == PhotoDestination.THIS_PHONE) "Phone receiver" else "Cloud server",
+                source = source,
                 timestamp = response.timestamp,
                 uploadUrl = response.uploadUrl,
             )
@@ -2275,6 +2632,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         stopMicElapsedTimer()
         stopMicPlayback()
         unregisterAudioStateObservers()
+        glassesHotspotConnector.disconnect()
         volumeRefreshJob?.cancel()
         controllerJob.cancel()
         mentraBluetoothSdk.close()
@@ -2606,6 +2964,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         directPhotoTimeoutJob?.cancel()
         directPhotoTimeoutJob = null
         photoUploadServer.stop()
+        galleryConnectionGeneration += 1
+        pendingHotspotConnection = null
+        glassesHotspotConnector.disconnect()
         resetOtaDisplayProgress()
         if (hadPhotoRequest) {
             pollGeneration += 1
@@ -2619,6 +2980,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             glassesVolumeStatus = "Glasses volume: not connected",
             galleryServerReachable = null,
             galleryServerStatus = "Gallery server: connect glasses first",
+            hotspotJoinPromptSsid = null,
             streamRequested = false,
             streamPreviewReady = false,
             streamStartedAt = null,
@@ -3195,6 +3557,7 @@ fun cameraSdkCall(
     mode: String,
     size: String,
     compression: String,
+    photoDestination: PhotoDestination,
     aeExposureDivisor: Int?,
     isoCap: Int?,
     noiseReduction: Boolean?,
@@ -3246,12 +3609,14 @@ println("Video stopped: ${'$'}{stopped.status}")
         ispAnalogGain?.let { "      ispAnalogGain = \"$it\"," },
     ).joinToString("\n")
     val optionalTuningLines = if (tuningLines.isBlank()) "" else "\n$tuningLines"
+    val webhookLine = if (photoDestination == PhotoDestination.GLASSES_STORAGE) "\"\"" else "uploadUrl"
+    val saveLine = if (photoDestination == PhotoDestination.GLASSES_STORAGE) "\n      save = true," else ""
     return """
 $prefix
 val photo = mentraBluetoothSdk.requestPhoto(
     PhotoRequest(
       size = PhotoSize.${when(size) { "low" -> "LOW"; "high" -> "HIGH"; "max" -> "MAX"; else -> "MEDIUM" }},
-      webhookUrl = uploadUrl,
+      webhookUrl = $webhookLine,$saveLine
       compress = PhotoCompression.${compression.uppercase(Locale.US)},
       sound = true,
       exposureTimeNs = ${if (exposureManual) exposureTimeNs else "null"},
@@ -3756,6 +4121,7 @@ private fun PhotoPreviewDetails?.copyForAck(
 private fun PhotoPreviewDetails?.copyForUpload(
     byteCount: Int? = null,
     contentType: String? = null,
+    fileName: String? = null,
     height: Int? = null,
     previewUrl: String,
     requestId: String?,
@@ -3766,6 +4132,7 @@ private fun PhotoPreviewDetails?.copyForUpload(
     (this ?: PhotoPreviewDetails(source = source, state = "preview")).copy(
         byteCount = byteCount ?: this?.byteCount,
         contentType = contentType ?: this?.contentType,
+        fileName = fileName ?: this?.fileName,
         height = height ?: this?.height,
         previewUrl = previewUrl,
         requestId = requestId ?: this?.requestId,

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -18,9 +18,11 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Icon
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -63,6 +65,8 @@ import com.mentra.examples.android.PhotoDestination
 import com.mentra.examples.android.VideoPreviewDetails
 import com.mentra.examples.android.cameraRoiPositions
 import com.mentra.examples.android.cameraSdkCall
+import com.mentra.examples.android.galleryHotspotPasswordLabel
+import com.mentra.examples.android.galleryHotspotSsidLabel
 import com.mentra.examples.android.isGlassesConnected
 import com.mentra.examples.android.isGlassesWifiConnected
 import com.mentra.examples.android.photoAeExposureDivisorOptions
@@ -93,9 +97,19 @@ fun CameraScreen(controller: MentraExampleController) {
     val state = controller.state
     val connected = isGlassesConnected(state.glassesStatus)
     val glassesWifiConnected = isGlassesWifiConnected(state.glassesStatus)
-    val wifiRequired = connected && !glassesWifiConnected
     val cloudServerEnabled = state.photoDestination == PhotoDestination.MACBOOK_SERVER
-    val directPhone = !cloudServerEnabled
+    val glassesStorageEnabled = state.photoDestination == PhotoDestination.GLASSES_STORAGE
+    val directPhone = state.photoDestination == PhotoDestination.THIS_PHONE
+    val waitingForGlassesPreview = glassesStorageEnabled &&
+        state.photoPreviewUrl == null &&
+        state.photoPreviewDetails?.state == "saved"
+    val needsGlassesHotspotSetup = connected && glassesStorageEnabled && state.galleryServerReachable != true
+    val photoControlsEnabled = connected &&
+        (glassesStorageEnabled || glassesWifiConnected) &&
+        !needsGlassesHotspotSetup &&
+        state.activeAction != "Capture & upload" &&
+        state.activeAction != "Capture scan photo"
+    val wifiRequired = connected && !glassesWifiConnected && !glassesStorageEnabled
     val videoActionBusy = state.activeAction == "Start video recording" || state.activeAction == "Stop & upload video"
     val videoControlsEnabled = connected &&
         glassesWifiConnected &&
@@ -108,6 +122,7 @@ fun CameraScreen(controller: MentraExampleController) {
         if (videoMode) "video" else "photo",
         state.photoSize,
         state.photoCompression,
+        state.photoDestination,
         state.photoAeExposureDivisor,
         state.photoIsoCap,
         state.photoNoiseReduction,
@@ -134,6 +149,18 @@ fun CameraScreen(controller: MentraExampleController) {
             state.activeAction == "Capture & upload" ||
                 state.activeAction == "Capture scan photo" -> captureMode = CameraCaptureMode.PHOTO
         }
+    }
+    state.hotspotJoinPromptSsid?.let { ssid ->
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Connect to Glasses") },
+            text = { Text("When prompted, tap Connect to connect to \"$ssid\".") },
+            confirmButton = {
+                TextButton(onClick = controller::confirmHotspotJoin) {
+                    Text("OK")
+                }
+            },
+        )
     }
     Column(modifier = Modifier.fillMaxSize().background(AppColor.bg).verticalScroll(rememberScrollState())) {
         PageHeader("Camera")
@@ -168,7 +195,7 @@ fun CameraScreen(controller: MentraExampleController) {
                         Text(
                             if (!connected) {
                                 "Connect glasses first"
-                            } else if (!glassesWifiConnected) {
+                            } else if (!glassesWifiConnected && !glassesStorageEnabled) {
                                 "Connect glasses to Wi-Fi"
                             } else if (state.activeAction == "Capture & upload" || state.activeAction == "Capture scan photo") {
                                 "Capturing..."
@@ -181,7 +208,10 @@ fun CameraScreen(controller: MentraExampleController) {
                             fontSize = 15.sp,
                             fontWeight = FontWeight.SemiBold
                         )
-                        if (state.photoPreviewUrl != null || state.photoPreviewDetails?.state == "error" || state.photoPreviewDetails?.state == "acknowledged") {
+                        if (
+                            state.photoPreviewUrl != null ||
+                            state.photoPreviewDetails?.state in setOf("error", "acknowledged", "saved")
+                        ) {
                             Text(
                                 photoStateLabel(state.photoPreviewUrl, state.photoPreviewDetails),
                                 color = AppColor.greenAccent,
@@ -204,6 +234,31 @@ fun CameraScreen(controller: MentraExampleController) {
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize()
                         )
+                    } else if (waitingForGlassesPreview) {
+                        Column(
+                            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(42.dp)
+                                    .clip(CircleShape)
+                                    .background(Color.White.copy(alpha = 0.18f))
+                                    .border(1.dp, Color.White.copy(alpha = 0.28f), CircleShape),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(Icons.Filled.Check, null, tint = Color.White, modifier = Modifier.size(22.dp))
+                            }
+                            Text("Photo saved on glasses", color = Color.White, fontSize = 15.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 10.dp))
+                            Text(
+                                "Downloading the saved photo preview.",
+                                color = Color.White.copy(alpha = 0.82f),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 3.dp),
+                            )
+                        }
                     } else {
                         Box(modifier = Modifier.align(Alignment.TopEnd).offset(x = (-50).dp, y = 30.dp).size(80.dp).clip(CircleShape).background(Color.White.copy(alpha = 0.55f)))
                         Row(modifier = Modifier.align(Alignment.BottomStart).padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
@@ -223,12 +278,15 @@ fun CameraScreen(controller: MentraExampleController) {
                         Text("ready", color = Color.White.copy(alpha = 0.85f), fontSize = 10.sp, fontWeight = FontWeight.Medium, modifier = Modifier.align(Alignment.BottomEnd).padding(14.dp))
                     }
                 }
+                if (needsGlassesHotspotSetup) {
+                    SavedPhotoHotspotPanel(controller)
+                }
                 Spacer(Modifier.height(14.dp))
                 Box(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp)
                         .clip(RoundedCornerShape(18.dp))
                         .background(Brush.verticalGradient(listOf(Color(0xFF26473A), Color(0xFF1F3A2A))))
-                        .clickable(enabled = connected && glassesWifiConnected) { controller.captureAndUpload() }
+                        .clickable(enabled = photoControlsEnabled) { controller.captureAndUpload() }
                         .padding(vertical = 16.dp),
                     contentAlignment = Alignment.Center
                 ) {
@@ -237,8 +295,10 @@ fun CameraScreen(controller: MentraExampleController) {
                         Text(
                             if (!connected) {
                                 "Connect glasses first"
-                            } else if (!glassesWifiConnected) {
+                            } else if (!glassesWifiConnected && !glassesStorageEnabled) {
                                 "Connect glasses to Wi-Fi"
+                            } else if (needsGlassesHotspotSetup) {
+                                if (state.galleryServerReachable == null) "Preparing hotspot..." else "Connect glasses hotspot"
                             } else if (state.activeAction == "Capture & upload" || state.activeAction == "Capture scan photo") {
                                 "Capturing..."
                             } else if (state.scanMode) {
@@ -413,7 +473,9 @@ fun CameraScreen(controller: MentraExampleController) {
                         } else {
                             when {
                             state.photoPreviewUrl != null && directPhone -> "Photo preview loaded from phone receiver"
+                            state.photoPreviewUrl != null && glassesStorageEnabled -> "Photo preview downloaded from glasses"
                             state.photoPreviewUrl != null -> "Photo preview loaded from cloud server"
+                            glassesStorageEnabled -> "Photo will be saved on glasses"
                             directPhone && state.phonePhotoServerRunning -> "Phone receiver ready"
                             directPhone -> "Phone receiver starts on capture"
                             else -> "Waiting for media upload"
@@ -434,7 +496,7 @@ fun CameraScreen(controller: MentraExampleController) {
             padding = PaddingValues(horizontal = 18.dp, vertical = 16.dp)
         ) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Eyebrow("UPLOAD TO")
+                Eyebrow(if (videoMode) "UPLOAD TO" else "PHOTO DESTINATION")
                 if (videoMode || cloudServerEnabled) {
                     Text(
                         "test webhook",
@@ -480,10 +542,19 @@ fun CameraScreen(controller: MentraExampleController) {
                 }
                 Spacer(Modifier.height(12.dp))
             } else {
-                CloudServerToggle(
+                PhotoDestinationToggle(
+                    label = "Use media cloud server",
                     enabled = cloudServerEnabled,
                     onEnabledChange = { enabled ->
                         controller.setPhotoDestination(if (enabled) PhotoDestination.MACBOOK_SERVER else PhotoDestination.THIS_PHONE)
+                    },
+                )
+                Spacer(Modifier.height(12.dp))
+                PhotoDestinationToggle(
+                    label = "Save and preview from glasses",
+                    enabled = glassesStorageEnabled,
+                    onEnabledChange = { enabled ->
+                        controller.setPhotoDestination(if (enabled) PhotoDestination.GLASSES_STORAGE else PhotoDestination.THIS_PHONE)
                     },
                 )
                 Spacer(Modifier.height(12.dp))
@@ -517,6 +588,15 @@ fun CameraScreen(controller: MentraExampleController) {
                             }
                         )
                     }
+                    Spacer(Modifier.height(12.dp))
+                } else if (glassesStorageEnabled) {
+                    Text(
+                        "Photos stay on the glasses. Capture unlocks when the gallery connection is ready.",
+                        color = AppColor.muted,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                     Spacer(Modifier.height(12.dp))
                 } else {
                     Row(
@@ -575,6 +655,74 @@ fun CameraScreen(controller: MentraExampleController) {
         }
 
         Spacer(Modifier.height(scrollBottomPadding()))
+    }
+}
+
+@Composable
+private fun SavedPhotoHotspotPanel(controller: MentraExampleController) {
+    val state = controller.state
+    val statusColor = when (state.galleryServerReachable) {
+        true -> AppColor.greenAccent
+        false -> AppColor.red
+        null -> AppColor.muted
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 6.dp, vertical = 10.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(AppColor.ink.copy(alpha = 0.04f))
+            .border(1.dp, AppColor.ink.copy(alpha = 0.08f), RoundedCornerShape(14.dp))
+            .padding(horizontal = 12.dp, vertical = 11.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                Text("Glasses hotspot", color = AppColor.ink, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                Text(
+                    "Join ${galleryHotspotSsidLabel(state.glassesStatus)}",
+                    color = AppColor.muted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "Password ${galleryHotspotPasswordLabel(state.glassesStatus)}",
+                    color = AppColor.muted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                SavedPhotoActionChip("Retry", controller::prepareGlassesPhotoPreview)
+                SavedPhotoActionChip("Wi-Fi settings", controller::openWifiSettings)
+                SavedPhotoActionChip("Copy password", controller::copyGalleryHotspotPassword)
+            }
+        }
+        Text(
+            state.galleryServerStatus,
+            color = statusColor,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+        )
+    }
+}
+
+@Composable
+private fun SavedPhotoActionChip(label: String, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(AppColor.greenAccent.copy(alpha = 0.14f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 7.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(label, color = AppColor.greenDeep, fontSize = 11.sp, fontWeight = FontWeight.Bold)
     }
 }
 
@@ -985,6 +1133,7 @@ private fun photoStateLabel(previewUrl: String?, details: PhotoPreviewDetails?):
     when {
         previewUrl != null -> "PREVIEW READY"
         details?.state == "error" -> "ERROR"
+        details?.state == "saved" -> "SAVED"
         details?.state == "acknowledged" -> "ACKNOWLEDGED"
         else -> "READY"
     }
@@ -1078,7 +1227,11 @@ private fun photoDetailsSummary(details: PhotoPreviewDetails?): String {
         details.source,
         details.byteCount?.let(::formatBytes),
         if (details.width != null && details.height != null) "${details.width} x ${details.height}" else null,
-        if (details.state == "acknowledged") "acknowledged" else "preview ready",
+        when (details.state) {
+            "acknowledged" -> "acknowledged"
+            "saved" -> "saved on glasses"
+            else -> "preview ready"
+        },
     ).joinToString(" · ")
 }
 
@@ -1116,8 +1269,9 @@ private fun photoDetailsRows(details: PhotoPreviewDetails?): List<Pair<String, S
     if (details == null) return listOf("Status" to "No photo metadata received yet")
     return buildList {
         add("Source" to details.source)
-        add("State" to details.state)
+        add("State" to if (details.state == "saved") "saved on glasses" else details.state)
         details.requestId?.let { add("Request ID" to it) }
+        details.fileName?.let { add("Glasses filename" to it) }
         details.byteCount?.let { add("Size" to formatBytes(it)) }
         if (details.width != null && details.height != null) add("Dimensions" to "${details.width} x ${details.height}")
         details.contentType?.let { add("Content type" to it) }
@@ -1227,7 +1381,11 @@ private fun FixedMediaServerRow() {
 }
 
 @Composable
-private fun CloudServerToggle(enabled: Boolean, onEnabledChange: (Boolean) -> Unit) {
+private fun PhotoDestinationToggle(
+    label: String,
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -1239,7 +1397,7 @@ private fun CloudServerToggle(enabled: Boolean, onEnabledChange: (Boolean) -> Un
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            "Use media cloud server",
+            label,
             color = AppColor.ink,
             fontSize = 14.sp,
             fontWeight = FontWeight.SemiBold,

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.18
+mentraSdkVersion=0.1.19

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		47B517CEA51967B475B5D044 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = MentraExample/MentraExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -254,6 +255,7 @@
 		872949F6CD2BE38E19A2FCD4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = MentraExample/MentraExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.18;
+				version = 0.1.19;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 import MentraBluetoothSDK
+import NetworkExtension
 import UIKit
 
 struct ExampleEvent: Identifiable {
@@ -27,6 +28,45 @@ private struct GalleryServerCheck {
 private struct WebhookReachability {
     let healthUrl: URL
     let host: String
+}
+
+private struct GalleryPhoto {
+    let name: String
+    let mimeType: String?
+    let size: Int?
+    let url: String?
+}
+
+private struct PendingHotspotConnection {
+    let ssid: String
+    let password: String
+    let baseUrl: String
+}
+
+private final class GlassesHotspotConnector {
+    func connect(ssid: String, password: String) async throws {
+        let configuration = NEHotspotConfiguration(ssid: ssid, passphrase: password, isWEP: false)
+        configuration.joinOnce = false
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            NEHotspotConfigurationManager.shared.apply(configuration) { error in
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == NEHotspotConfigurationErrorDomain,
+                       nsError.code == NEHotspotConfigurationError.alreadyAssociated.rawValue {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                    return
+                }
+                continuation.resume()
+            }
+        }
+    }
+
+    func disconnect(ssid: String) {
+        NEHotspotConfigurationManager.shared.removeConfiguration(forSSID: ssid)
+    }
 }
 
 private struct PersistedCloudUrls {
@@ -71,17 +111,20 @@ let photoAeExposureDivisorOptions = [2, 3, 5]
 let photoIsoCapOptions = [400, 800, 1600]
 let photoIspDigitalGainOptions = [0, 1, 2, 4]
 let photoIspAnalogGainOptions = ["low"]
+let glassesPhotoPollAttempts = 120
 let cameraRoiPositions: [(label: String, value: Int)] = [("Center", 0), ("Bottom", 1), ("Top", 2)]
 
 enum PhotoDestination {
     case macBookServer
     case thisPhone
+    case glassesStorage
 }
 
 struct PhotoPreviewDetails {
     let byteCount: Int?
     let contentType: String?
     let error: String?
+    let fileName: String?
     let height: Int?
     let previewUrl: String?
     let requestId: String?
@@ -92,11 +135,36 @@ struct PhotoPreviewDetails {
     let uploadedAt: String?
     let width: Int?
 
-    func acknowledged(requestId: String, source: String, timestamp: Int, uploadUrl: String) -> PhotoPreviewDetails {
+    func withState(_ nextState: String) -> PhotoPreviewDetails {
         PhotoPreviewDetails(
             byteCount: byteCount,
             contentType: contentType,
             error: error,
+            fileName: fileName,
+            height: height,
+            previewUrl: previewUrl,
+            requestId: requestId,
+            source: source,
+            state: nextState,
+            timestamp: timestamp,
+            uploadUrl: uploadUrl,
+            uploadedAt: uploadedAt,
+            width: width
+        )
+    }
+
+    func acknowledged(
+        requestId: String,
+        source: String,
+        timestamp: Int,
+        uploadUrl: String,
+        fileName: String? = nil
+    ) -> PhotoPreviewDetails {
+        PhotoPreviewDetails(
+            byteCount: byteCount,
+            contentType: contentType,
+            error: error,
+            fileName: fileName ?? self.fileName,
             height: height,
             previewUrl: previewUrl,
             requestId: requestId,
@@ -112,6 +180,7 @@ struct PhotoPreviewDetails {
     func uploaded(
         byteCount: Int?,
         contentType: String? = nil,
+        fileName: String? = nil,
         height: Int? = nil,
         previewUrl: String,
         requestId: String?,
@@ -123,6 +192,7 @@ struct PhotoPreviewDetails {
             byteCount: byteCount ?? self.byteCount,
             contentType: contentType ?? self.contentType,
             error: error,
+            fileName: fileName ?? self.fileName,
             height: height ?? self.height,
             previewUrl: previewUrl,
             requestId: requestId ?? self.requestId,
@@ -136,11 +206,11 @@ struct PhotoPreviewDetails {
     }
 
     static func waiting(source: String) -> PhotoPreviewDetails {
-        PhotoPreviewDetails(byteCount: nil, contentType: nil, error: nil, height: nil, previewUrl: nil, requestId: nil, source: source, state: "acknowledged", timestamp: nil, uploadUrl: nil, uploadedAt: nil, width: nil)
+        PhotoPreviewDetails(byteCount: nil, contentType: nil, error: nil, fileName: nil, height: nil, previewUrl: nil, requestId: nil, source: source, state: "acknowledged", timestamp: nil, uploadUrl: nil, uploadedAt: nil, width: nil)
     }
 
     static func failed(requestId: String, source: String, error: String, timestamp: Int) -> PhotoPreviewDetails {
-        PhotoPreviewDetails(byteCount: nil, contentType: nil, error: error, height: nil, previewUrl: nil, requestId: requestId, source: source, state: "error", timestamp: timestamp, uploadUrl: nil, uploadedAt: nil, width: nil)
+        PhotoPreviewDetails(byteCount: nil, contentType: nil, error: error, fileName: nil, height: nil, previewUrl: nil, requestId: requestId, source: source, state: "error", timestamp: timestamp, uploadUrl: nil, uploadedAt: nil, width: nil)
     }
 }
 
@@ -276,6 +346,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var actionSequence = 0
     private var activeActions: [Int: String] = [:]
     private var activeActionOrder: [Int] = []
+    private let glassesHotspotConnector = GlassesHotspotConnector()
+    private var galleryConnectionGeneration = 0
+    private var pendingHotspotConnection: PendingHotspotConnection?
+    private var hotspotJoinExplanationShown = false
     private var streamConfigurationChangeInProgress = false
     private var photoCaptureDefaultsSyncGeneration = 0
     private var photoCaptureDefaultsSyncTask: Task<Void, Never>?
@@ -341,6 +415,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var hotspotEnabled = false
     @Published private(set) var galleryServerReachable: Bool?
     @Published private(set) var galleryServerStatus = "Gallery server: enable hotspot to check"
+    @Published private(set) var hotspotJoinPromptSsid: String?
     @Published private(set) var micRecording = false
     @Published private(set) var micPlaying = false
     @Published private(set) var micElapsedSeconds = 0
@@ -642,13 +717,133 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     func setPhotoDestination(_ destination: PhotoDestination) {
         guard photoDestination != destination else { return }
-        if destination == .macBookServer {
-            stopPhonePhotoServer()
-            cameraStatus = "Camera: enter a media upload URL"
-        } else {
-            cameraStatus = "Camera: phone receiver will start before capture"
-        }
+        let wasGlassesStorage = photoDestination == .glassesStorage
+        stopPhonePhotoServer()
         photoDestination = destination
+        switch destination {
+        case .macBookServer:
+            cameraStatus = "Camera: enter a media upload URL"
+        case .thisPhone:
+            cameraStatus = "Camera: phone receiver will start before capture"
+        case .glassesStorage:
+            cameraStatus = "Camera: preparing glasses hotspot"
+            if glassesConnected {
+                prepareGlassesPhotoPreview()
+            }
+            return
+        }
+        guard wasGlassesStorage else { return }
+        galleryConnectionGeneration += 1
+        pendingHotspotConnection = nil
+        galleryServerReachable = nil
+        galleryServerStatus = "Gallery server: hotspot off"
+        hotspotJoinPromptSsid = nil
+        runAsyncAction("Disable glasses photo hotspot") { [self] in
+            glassesHotspotConnector.disconnect(ssid: galleryHotspotSsidLabel(glassesValues))
+            if hotspotEnabled && glassesConnected {
+                _ = try await mentraBluetoothSdk.setHotspotState(enabled: false)
+            }
+        }
+    }
+
+    func prepareGlassesPhotoPreview() {
+        runAsyncAction("Connect to glasses hotspot") { [self] in
+            try await prepareGlassesPhotoPreviewConnection()
+        }
+    }
+
+    func confirmHotspotJoin() {
+        hotspotJoinExplanationShown = true
+        hotspotJoinPromptSsid = nil
+        runAsyncAction("Join glasses hotspot") { [self] in
+            try await connectPendingGlassesHotspot()
+        }
+    }
+
+    private func prepareGlassesPhotoPreviewConnection() async throws {
+        try requireConnected("prepare saved-photo previews")
+        galleryConnectionGeneration += 1
+        let generation = galleryConnectionGeneration
+        cameraStatus = "Camera: preparing glasses hotspot"
+        galleryServerReachable = nil
+        galleryServerStatus = "Gallery server: starting glasses hotspot"
+        hotspotJoinPromptSsid = nil
+
+        let hotspot: (ssid: String, password: String, localIp: String)
+        if let current = enabledHotspotStatus(glassesValues) {
+            hotspot = current
+        } else {
+            let status = try await mentraBluetoothSdk.setHotspotState(enabled: true)
+            guard case let .enabled(ssid, password, localIp) = status.status else {
+                throw ExampleActionError(message: "The glasses hotspot did not turn on.")
+            }
+            hotspot = (ssid, password, localIp)
+        }
+        guard generation == galleryConnectionGeneration else { return }
+
+        let pending = PendingHotspotConnection(
+            ssid: hotspot.ssid,
+            password: hotspot.password,
+            baseUrl: "http://\(hotspot.localIp):8089"
+        )
+        pendingHotspotConnection = pending
+        if await waitForGalleryServer(pending.baseUrl, attempts: 3, delayMs: 400) {
+            markGalleryServerReady(pending.baseUrl)
+            return
+        }
+        if !hotspotJoinExplanationShown {
+            cameraStatus = "Camera: approve the glasses hotspot connection"
+            galleryServerReachable = false
+            galleryServerStatus = "Gallery server: approval required for \(pending.ssid)"
+            hotspotJoinPromptSsid = pending.ssid
+            return
+        }
+        try await connectPendingGlassesHotspot()
+    }
+
+    private func connectPendingGlassesHotspot() async throws {
+        guard let pending = pendingHotspotConnection else {
+            try await prepareGlassesPhotoPreviewConnection()
+            return
+        }
+        let generation = galleryConnectionGeneration
+        cameraStatus = "Camera: connecting to \(pending.ssid)"
+        galleryServerReachable = nil
+        galleryServerStatus = "Gallery server: connecting to \(pending.ssid)"
+        do {
+            try await glassesHotspotConnector.connect(ssid: pending.ssid, password: pending.password)
+            guard generation == galleryConnectionGeneration else { return }
+            guard await waitForGalleryServer(pending.baseUrl, attempts: 20, delayMs: 500) else {
+                throw ExampleActionError(message: "Could not reach the glasses gallery after connecting.")
+            }
+            markGalleryServerReady(pending.baseUrl)
+        } catch {
+            guard generation == galleryConnectionGeneration else { return }
+            cameraStatus = "Camera: connect to the glasses hotspot to enable capture"
+            galleryServerReachable = false
+            galleryServerStatus = "Gallery server: \(error.localizedDescription)"
+            throw error
+        }
+    }
+
+    private func waitForGalleryServer(_ baseUrl: String, attempts: Int, delayMs: UInt64) async -> Bool {
+        for attempt in 0 ..< attempts {
+            if await checkGalleryServerReachability(baseUrl).reachable {
+                return true
+            }
+            if attempt < attempts - 1 {
+                try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            }
+        }
+        return false
+    }
+
+    private func markGalleryServerReady(_ baseUrl: String) {
+        cameraStatus = "Camera: ready to save and preview from glasses"
+        galleryServerReachable = true
+        galleryServerStatus = "Gallery server: ready at \(baseUrl)"
+        hotspotJoinPromptSsid = nil
+        append(tag: "LIVE", text: "gallery server ready \(baseUrl)")
     }
 
     func setPhotoSize(_ size: PhotoSize) {
@@ -871,6 +1066,13 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     func captureAndUpload() {
         runAsyncAction(scanMode ? "Capture scan photo" : "Capture & upload") { [self] in
             try requireConnected("capture photos")
+            if photoDestination == .glassesStorage {
+                guard galleryServerReachable == true else {
+                    throw ExampleActionError(message: "Connect to the glasses hotspot before capturing.")
+                }
+                try await captureToGlassesStorage()
+                return
+            }
             try requireGlassesWifi("capture photos")
             if photoDestination == .thisPhone {
                 try await captureAndUploadToPhone()
@@ -905,7 +1107,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 }
                 throw error
             }
-            handlePhotoResponse(responseEvent.response)
+            handlePhotoResponse(responseEvent)
             pollPhotoPreview(requestId: requestId, statusUrl: statusUrl.deletingLastPathComponent().appendingPathComponent("\(requestId).json"), generation: generation)
         }
     }
@@ -942,16 +1144,76 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             }
             throw error
         }
-        handlePhotoResponse(responseEvent.response)
+        handlePhotoResponse(responseEvent)
         append(tag: "TX", text: "requestPhoto requestId=\(requestId) webhookUrl=\(uploadUrl)")
     }
 
-    private func buildPhotoRequest(requestId: String, webhookUrl: String) -> PhotoRequest {
+    private func captureToGlassesStorage() async throws {
+        let requestId = "photo-\(Int(Date().timeIntervalSince1970 * 1000))"
+        activePhotoRequestId = requestId
+        pollGeneration += 1
+        let generation = pollGeneration
+        photoPreviewDetails = .waiting(source: "Glasses gallery")
+        photoPreviewUrl = nil
+        photoPreviewImage = nil
+        cameraStatus = "Camera: saving photo on glasses (\(requestId))"
+
+        let responseEvent: PhotoResponseEvent
+        do {
+            responseEvent = try await mentraBluetoothSdk.requestPhoto(
+                buildPhotoRequest(requestId: requestId, webhookUrl: nil, save: true)
+            )
+        } catch {
+            activePhotoRequestId = nil
+            throw error
+        }
+        handlePhotoResponse(responseEvent)
+        cameraStatus = "Camera: photo saved on glasses; loading preview"
+        photoPreviewDetails = photoPreviewDetails.map { $0.withState("saved") }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await downloadGlassesPhotoPreview(
+                    requestId: requestId,
+                    generation: generation
+                )
+            } catch {
+                guard activePhotoRequestId == requestId, pollGeneration == generation else { return }
+                activePhotoRequestId = nil
+                let message = error.localizedDescription
+                cameraStatus = "Camera: \(message)"
+                photoPreviewDetails = photoPreviewDetails.map {
+                    PhotoPreviewDetails(
+                        byteCount: $0.byteCount,
+                        contentType: $0.contentType,
+                        error: message,
+                        fileName: $0.fileName,
+                        height: $0.height,
+                        previewUrl: $0.previewUrl,
+                        requestId: requestId,
+                        source: "Glasses gallery",
+                        state: "saved",
+                        timestamp: $0.timestamp,
+                        uploadUrl: $0.uploadUrl,
+                        uploadedAt: $0.uploadedAt,
+                        width: $0.width
+                    )
+                }
+            }
+        }
+    }
+
+    private func buildPhotoRequest(
+        requestId: String,
+        webhookUrl: String?,
+        save: Bool = false
+    ) -> PhotoRequest {
         return PhotoRequest(
             requestId: requestId,
             size: photoSize,
             webhookUrl: webhookUrl,
             compress: photoCompression,
+            save: save,
             sound: true,
             exposureTimeNs: photoExposureManual ? Double(photoExposureTimeNs) : nil,
             iso: photoExposureManual ? photoIso : nil,
@@ -963,6 +1225,116 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             zsl: photoZsl,
             ispDigitalGain: photoIspDigitalGain,
             ispAnalogGain: photoIspAnalogGain
+        )
+    }
+
+    private func downloadGlassesPhotoPreview(
+        requestId: String,
+        generation: Int
+    ) async throws {
+        guard let baseUrl = pendingHotspotConnection?.baseUrl
+                ?? galleryServerUrl(glassesValues, fallbackEnabled: hotspotEnabled),
+              galleryServerReachable == true else {
+            throw ExampleActionError(message: "The glasses hotspot is not ready for preview downloads.")
+        }
+
+        galleryServerStatus = "Gallery server: finding \(requestId)"
+        for attempt in 0 ..< glassesPhotoPollAttempts {
+            guard activePhotoRequestId == requestId, pollGeneration == generation else { return }
+            do {
+                let photo = try await findGalleryPhoto(baseUrl: baseUrl, requestId: requestId)
+                galleryServerReachable = true
+                galleryServerStatus = "Gallery server: connected; finding \(requestId)"
+                guard let photo else {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    continue
+                }
+                let remoteUrl: URL
+                if let path = photo.url, let url = URL(string: path, relativeTo: URL(string: baseUrl)) {
+                    remoteUrl = url.absoluteURL
+                } else {
+                    var components = URLComponents(string: "\(baseUrl)/api/photo")!
+                    components.queryItems = [URLQueryItem(name: "file", value: photo.name)]
+                    guard let url = components.url else {
+                        throw ExampleActionError(message: "The glasses photo URL is invalid.")
+                    }
+                    remoteUrl = url
+                }
+                var request = URLRequest(url: remoteUrl)
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+                request.timeoutInterval = 30
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+                    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                    throw ExampleActionError(message: "Gallery server returned HTTP \(statusCode).")
+                }
+                guard let image = UIImage(data: data) else {
+                    throw ExampleActionError(message: "The downloaded glasses photo is not a JPEG image.")
+                }
+                let localUrl = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("mentra-gallery-\(requestId).jpg")
+                try data.write(to: localUrl, options: .atomic)
+                activePhotoRequestId = nil
+                photoPreviewUrl = localUrl
+                photoPreviewImage = image
+                photoPreviewDetails = (photoPreviewDetails ?? .waiting(source: "Glasses gallery")).uploaded(
+                    byteCount: photo.size ?? data.count,
+                    contentType: photo.mimeType ?? http.value(forHTTPHeaderField: "Content-Type") ?? "image/jpeg",
+                    fileName: photo.name,
+                    height: Int(image.size.height * image.scale),
+                    previewUrl: remoteUrl.absoluteString,
+                    requestId: requestId,
+                    source: "Glasses gallery",
+                    width: Int(image.size.width * image.scale)
+                )
+                galleryServerReachable = true
+                galleryServerStatus = "Gallery server: downloaded \(photo.name)"
+                cameraStatus = "Camera: loaded photo preview from glasses"
+                append(tag: "LIVE", text: "glasses photo downloaded \(photo.name)")
+                return
+            } catch {
+                if attempt == 0 || attempt % 10 == 9 {
+                    galleryServerReachable = false
+                    galleryServerStatus = "Gallery server: not reachable. Join \(galleryHotspotSsidLabel(glassesValues))."
+                    cameraStatus = "Camera: join \(galleryHotspotSsidLabel(glassesValues)) to load the saved photo"
+                    append(tag: "LIVE", text: "waiting for glasses photo \(requestId): \(error.localizedDescription)")
+                }
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        throw ExampleActionError(
+            message: "Photo was saved on the glasses, but the preview could not be downloaded from \(baseUrl)."
+        )
+    }
+
+    private func findGalleryPhoto(baseUrl: String, requestId: String) async throws -> GalleryPhoto? {
+        guard var components = URLComponents(string: "\(baseUrl)/api/gallery") else { return nil }
+        components.queryItems = [
+            URLQueryItem(name: "limit", value: "100"),
+            URLQueryItem(name: "poll", value: String(Int(Date().timeIntervalSince1970 * 1000))),
+        ]
+        guard let url = components.url else { return nil }
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 5
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw ExampleActionError(message: "Gallery server returned HTTP \(statusCode).")
+        }
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = root["data"] as? [String: Any],
+              let photos = payload["photos"] as? [[String: Any]],
+              let photo = photos.first(where: { stringValue($0, "request_id") == requestId }),
+              let name = stringValue(photo, "name")
+        else {
+            return nil
+        }
+        return GalleryPhoto(
+            name: name,
+            mimeType: stringValue(photo, "mime_type"),
+            size: intValue(photo, "size"),
+            url: stringValue(photo, "url")
         )
     }
 
@@ -1642,7 +2014,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             let ssid = galleryHotspotSsidLabel(glassesValues)
             let password = galleryHotspotPasswordLabel(glassesValues)
             UIPasteboard.general.string = password
-            let message = "Password copied. Open iOS Settings > Wi-Fi, join \(ssid) with password \(password), then return and tap Open."
+            let message = "Password copied. Open iOS Settings > Wi-Fi, join \(ssid) with password \(password), then return and tap Retry."
             galleryServerStatus = message
             append(tag: "LIVE", text: message)
         }
@@ -1740,6 +2112,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             // Re-apply scan preset on reconnect so button captures stay in sync.
             if scanMode {
                 pushScanButtonPreset()
+            }
+            if photoDestination == .glassesStorage {
+                prepareGlassesPhotoPreview()
             }
         }
         refreshGalleryServerStatusForCurrentHotspot(defaultStatus: hotspotEnabled ? galleryServerStatus : "Gallery server: hotspot off")
@@ -2111,7 +2486,11 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     private func refreshGalleryServerStatusForCurrentHotspot(defaultStatus: String) {
-        galleryServerReachable = nil
+        if galleryServerReachable == true,
+           galleryServerUrl(glassesValues, fallbackEnabled: hotspotEnabled) != nil {
+            return
+        }
+        galleryServerReachable = !hotspotEnabled && photoDestination == .glassesStorage ? false : nil
         if let baseUrl = galleryServerUrl(glassesValues, fallbackEnabled: hotspotEnabled) {
             galleryServerStatus = "Gallery server: \(baseUrl)"
         } else {
@@ -2296,8 +2675,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         stopMicElapsedTimer()
         stopMicPlayback()
         hotspotEnabled = false
+        galleryConnectionGeneration += 1
+        if let pendingHotspotConnection {
+            glassesHotspotConnector.disconnect(ssid: pendingHotspotConnection.ssid)
+        }
+        pendingHotspotConnection = nil
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
+        hotspotJoinPromptSsid = nil
         resetOtaDisplayProgress()
         otaStatus = nil
         otaDisplayPercent = nil
@@ -2582,14 +2967,26 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         append(tag: "LIVE", text: "stream \(summary)")
     }
 
-    private func handlePhotoResponse(_ response: PhotoResponse) {
+    private func handlePhotoResponse(_ event: PhotoResponseEvent) {
+        let response = event.response
         let requestId = response.requestId
         if let activePhotoRequestId, requestId != activePhotoRequestId {
             append(tag: "LIVE", text: "ignoring stale photo \(requestId)")
             return
         }
-        let uploadTarget = photoDestination == .thisPhone ? "phone receiver" : "cloud webhook"
-        let source = photoDestination == .thisPhone ? "Phone receiver" : "Cloud server"
+        let uploadTarget: String
+        let source: String
+        switch photoDestination {
+        case .thisPhone:
+            uploadTarget = "phone receiver"
+            source = "Phone receiver"
+        case .macBookServer:
+            uploadTarget = "cloud webhook"
+            source = "Cloud server"
+        case .glassesStorage:
+            uploadTarget = "glasses storage"
+            source = "Glasses gallery"
+        }
         switch response {
         case let .success(requestId, uploadUrl, _, _, _, _, timestamp):
             photoPreviewDetails = (photoPreviewDetails ?? .waiting(source: source)).acknowledged(

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -23,6 +23,7 @@ private func cameraSdkCall(
     mode: CameraCaptureMode,
     size: String,
     compression: String,
+    photoDestination: PhotoDestination,
     aeExposureDivisor: Int?,
     isoCap: Int?,
     noiseReduction: Bool?,
@@ -81,12 +82,14 @@ private func cameraSdkCall(
         print("Video stopped: \\(stopped.status)")
         """
     }
+    let webhookUrl = photoDestination == .glassesStorage ? "nil" : "uploadUrl"
+    let saveLine = photoDestination == .glassesStorage ? "\n          save: true," : ""
     return """
     \(prefix)
     let photo = try await mentraBluetoothSdk.requestPhoto(
         PhotoRequest(
           size: .\(size),
-          webhookUrl: uploadUrl,
+          webhookUrl: \(webhookUrl),\(saveLine)
           compress: .\(compression),
           sound: true,
     \(exposureLine)
@@ -108,12 +111,16 @@ struct CameraScreen: View {
         model.photoDestination == .macBookServer
     }
 
+    private var glassesStorageEnabled: Bool {
+        model.photoDestination == .glassesStorage
+    }
+
     private var directPhone: Bool {
-        !cloudServerEnabled
+        model.photoDestination == .thisPhone
     }
 
     private var wifiRequired: Bool {
-        model.glassesConnected && !model.glassesWifiConnected
+        model.glassesConnected && !model.glassesWifiConnected && !glassesStorageEnabled
     }
 
     private var cameraStatusFailed: Bool {
@@ -128,8 +135,27 @@ struct CameraScreen: View {
         model.glassesConnected && model.glassesWifiConnected && !videoActionBusy
     }
 
+    private var waitingForGlassesPreview: Bool {
+        glassesStorageEnabled &&
+            model.photoPreviewUrl == nil &&
+            model.photoPreviewImage == nil &&
+            model.photoPreviewDetails?.state == "saved"
+    }
+
+    private var needsGlassesHotspotSetup: Bool {
+        model.glassesConnected && glassesStorageEnabled && model.galleryServerReachable != true
+    }
+
+    private var photoControlsEnabled: Bool {
+        model.glassesConnected &&
+            (glassesStorageEnabled || model.glassesWifiConnected) &&
+            !needsGlassesHotspotSetup &&
+            model.activeAction != "Capture & upload" &&
+            model.activeAction != "Capture scan photo"
+    }
+
     private var setupHint: String? {
-        guard captureMode == .video || !directPhone else { return nil }
+        guard captureMode == .video || cloudServerEnabled else { return nil }
         return localCameraSetupHint(webhookUrl: model.webhookUrl, status: model.cameraStatus)
     }
 
@@ -164,6 +190,17 @@ struct CameraScreen: View {
         }
         .background(AppColor.bg)
         .scrollDismissesKeyboard(.interactively)
+        .alert(
+            "Connect to Glasses",
+            isPresented: Binding(
+                get: { model.hotspotJoinPromptSsid != nil },
+                set: { _ in }
+            )
+        ) {
+            Button("OK", action: model.confirmHotspotJoin)
+        } message: {
+            Text("When prompted, tap Join to connect to \"\(model.hotspotJoinPromptSsid ?? "the glasses hotspot")\".")
+        }
         .onChange(of: model.activeAction) { action in
             if action == "Capture & upload" || action == "Capture scan photo" {
                 captureMode = .photo
@@ -213,7 +250,27 @@ struct CameraScreen: View {
                     .frame(height: 160)
                     .clipShape(RoundedRectangle(cornerRadius: 22))
                 }
-                if model.photoPreviewUrl == nil && model.photoPreviewImage == nil {
+                if waitingForGlassesPreview {
+                    VStack(spacing: 3) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 20, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(width: 42, height: 42)
+                            .background(Color.white.opacity(0.18))
+                            .overlay(Circle().stroke(Color.white.opacity(0.28), lineWidth: 1))
+                            .clipShape(Circle())
+                        Text("Photo saved on glasses")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundColor(.white)
+                            .padding(.top, 7)
+                        Text("Downloading the saved photo preview.")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(Color.white.opacity(0.82))
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.horizontal, 24)
+                    .frame(maxWidth: .infinity, minHeight: 160)
+                } else if model.photoPreviewUrl == nil && model.photoPreviewImage == nil {
                     Circle().fill(Color.white.opacity(0.55)).frame(width: 80, height: 80).blur(radius: 6).offset(x: 200, y: -30)
                     LinearGradient(colors: [.clear, .black.opacity(0.3)], startPoint: .top, endPoint: .bottom)
                         .frame(height: 90).clipShape(RoundedRectangle(cornerRadius: 22)).offset(y: 70)
@@ -234,19 +291,25 @@ struct CameraScreen: View {
                 }
             }
 
+            if needsGlassesHotspotSetup {
+                savedPhotoHotspotPanel
+                    .padding(.horizontal, 6)
+                    .padding(.top, 10)
+            }
+
             Button {
                 model.captureAndUpload()
             } label: {
                 HStack(spacing: 10) {
                     Image(systemName: "camera").foregroundColor(.white).font(.system(size: 15, weight: .bold))
-                    Text(!model.glassesConnected ? "Connect glasses first" : !model.glassesWifiConnected ? "Connect glasses to Wi-Fi" : (model.activeAction == "Capture & upload" || model.activeAction == "Capture scan photo") ? "Capturing..." : model.scanMode ? "Capture scan photo" : "Capture photo").foregroundColor(.white).font(.system(size: 15, weight: .semibold))
+                    Text(captureButtonTitle).foregroundColor(.white).font(.system(size: 15, weight: .semibold))
                 }
                 .frame(maxWidth: .infinity).padding(.vertical, 16)
                 .background(LinearGradient(colors: [Color(hex: 0x26473A), Color(hex: 0x1F3A2A)], startPoint: .top, endPoint: .bottom))
                 .clipShape(RoundedRectangle(cornerRadius: 18))
             }
-            .disabled(!model.glassesConnected || !model.glassesWifiConnected)
-            .opacity(model.glassesConnected && model.glassesWifiConnected ? 1 : 0.55)
+            .disabled(!photoControlsEnabled)
+            .opacity(photoControlsEnabled ? 1 : 0.55)
             .padding(.horizontal, 6).padding(.top, 14)
 
             ScanModeSettingsCard(model: model)
@@ -254,6 +317,56 @@ struct CameraScreen: View {
                 .padding(.horizontal, 6)
                 .padding(.top, 12)
         }
+    }
+
+    private var savedPhotoHotspotPanel: some View {
+        let password = galleryHotspotPasswordLabel(model.glassesValues)
+        let statusColor = model.galleryServerReachable == true
+            ? AppColor.greenAccent
+            : model.galleryServerReachable == false ? AppColor.red : AppColor.muted
+
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Glasses hotspot")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(AppColor.ink)
+                    Text("Join \(galleryHotspotSsidLabel(model.glassesValues))")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(AppColor.muted)
+                    Text("Password \(password)")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(AppColor.muted)
+                }
+                Spacer(minLength: 6)
+                VStack(alignment: .trailing, spacing: 5) {
+                    HotspotActionChip(title: "Retry", enabled: true, action: model.prepareGlassesPhotoPreview)
+                    HotspotActionChip(title: "Manual setup", enabled: true, action: model.openWifiSettings)
+                    HotspotActionChip(title: "Copy password", enabled: true, action: model.copyGalleryHotspotPassword)
+                }
+            }
+            Text(model.galleryServerStatus)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(statusColor)
+                .lineLimit(2)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .background(AppColor.ink.opacity(0.04))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(AppColor.ink.opacity(0.08), lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var captureButtonTitle: String {
+        if !model.glassesConnected { return "Connect glasses first" }
+        if !model.glassesWifiConnected && !glassesStorageEnabled { return "Connect glasses to Wi-Fi" }
+        if needsGlassesHotspotSetup {
+            return model.galleryServerReachable == nil ? "Preparing hotspot..." : "Connect glasses hotspot"
+        }
+        if model.activeAction == "Capture & upload" || model.activeAction == "Capture scan photo" {
+            return "Capturing..."
+        }
+        return model.scanMode ? "Capture scan photo" : "Capture photo"
     }
 
     private var videoCard: some View {
@@ -393,6 +506,7 @@ struct CameraScreen: View {
             mode: captureMode,
             size: model.photoSize.rawValue,
             compression: model.photoCompression.rawValue,
+            photoDestination: model.photoDestination,
             aeExposureDivisor: model.photoAeExposureDivisor,
             isoCap: model.photoIsoCap,
             noiseReduction: model.photoNoiseReduction,
@@ -457,7 +571,8 @@ struct CameraScreen: View {
     private var uploadCard: some View {
         GlassCard(corner: 22, padding: EdgeInsets(top: 16, leading: 18, bottom: 16, trailing: 18)) {
             HStack {
-                Text("UPLOAD TO").font(.system(size: 10, weight: .semibold)).tracking(1.2).foregroundColor(AppColor.muted)
+                Text(captureMode == .photo ? "PHOTO DESTINATION" : "UPLOAD TO")
+                    .font(.system(size: 10, weight: .semibold)).tracking(1.2).foregroundColor(AppColor.muted)
                 Spacer()
                 if captureMode == .video || cloudServerEnabled {
                     Button {
@@ -511,6 +626,22 @@ struct CameraScreen: View {
                 .background(AppColor.ink.opacity(0.04)).clipShape(RoundedRectangle(cornerRadius: 12))
                 .padding(.bottom, 12)
 
+                Toggle(isOn: Binding(
+                    get: { glassesStorageEnabled },
+                    set: { enabled in
+                        model.setPhotoDestination(enabled ? .glassesStorage : .thisPhone)
+                    }
+                )) {
+                    Text("Save and preview from glasses")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(AppColor.ink)
+                }
+                .toggleStyle(SwitchToggleStyle(tint: AppColor.greenAccent))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(AppColor.ink.opacity(0.04)).clipShape(RoundedRectangle(cornerRadius: 12))
+                .padding(.bottom, 12)
+
                 if cloudServerEnabled {
                     Text("Cloud server receives photo uploads.")
                         .font(.system(size: 12, weight: .medium))
@@ -533,6 +664,12 @@ struct CameraScreen: View {
                     .padding(.horizontal, 14).padding(.vertical, 12)
                     .background(AppColor.ink.opacity(0.04)).clipShape(RoundedRectangle(cornerRadius: 12))
                     .padding(.bottom, 12)
+                } else if glassesStorageEnabled {
+                    Text("Photos stay on the glasses. Capture unlocks when the gallery connection is ready.")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(AppColor.muted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 12)
                 } else {
                     HStack(spacing: 10) {
                         Circle()
@@ -659,6 +796,7 @@ struct CameraScreen: View {
     private var photoStateLabel: String {
         if model.photoPreviewUrl != nil || model.photoPreviewImage != nil { return "preview ready" }
         if model.photoPreviewDetails?.state == "error" { return "error" }
+        if model.photoPreviewDetails?.state == "saved" { return "saved" }
         if model.photoPreviewDetails?.state == "acknowledged" { return "acknowledged" }
         return "ready"
     }
@@ -677,7 +815,9 @@ struct CameraScreen: View {
             return "MP4 uploads to the media server after recording stops"
         }
         if model.photoPreviewUrl != nil || model.photoPreviewImage != nil {
-            return directPhone ? "Photo preview loaded from phone receiver" : "Photo preview loaded from cloud server"
+            if directPhone { return "Photo preview loaded from phone receiver" }
+            if glassesStorageEnabled { return "Photo preview downloaded from glasses" }
+            return "Photo preview loaded from cloud server"
         }
         return "Waiting for camera capture"
     }
@@ -1204,7 +1344,9 @@ private func photoDetailsSummary(_ details: PhotoPreviewDetails?) -> String {
         details.source,
         details.byteCount.map(formatBytes),
         dimensionsLabel(width: details.width, height: details.height),
-        details.state == "acknowledged" ? "acknowledged" : "preview ready",
+        details.state == "acknowledged"
+            ? "acknowledged"
+            : details.state == "saved" ? "saved on glasses" : "preview ready",
     ].compactMap { $0 }.joined(separator: " · ")
 }
 
@@ -1214,9 +1356,13 @@ private func photoDetailsRows(_ details: PhotoPreviewDetails?) -> [PhotoDetailsR
     }
     var rows = [
         PhotoDetailsRow(label: "Source", value: details.source),
-        PhotoDetailsRow(label: "State", value: details.state),
+        PhotoDetailsRow(
+            label: "State",
+            value: details.state == "saved" ? "saved on glasses" : details.state
+        ),
     ]
     if let requestId = details.requestId { rows.append(PhotoDetailsRow(label: "Request ID", value: requestId)) }
+    if let fileName = details.fileName { rows.append(PhotoDetailsRow(label: "Glasses filename", value: fileName)) }
     if let byteCount = details.byteCount { rows.append(PhotoDetailsRow(label: "Size", value: formatBytes(byteCount))) }
     if let dimensions = dimensionsLabel(width: details.width, height: details.height) { rows.append(PhotoDetailsRow(label: "Dimensions", value: dimensions)) }
     if let contentType = details.contentType { rows.append(PhotoDetailsRow(label: "Content type", value: contentType)) }

--- a/examples/ios/MentraExample/MentraExample.entitlements
+++ b/examples/ios/MentraExample/MentraExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.HotspotConfiguration</key>
+	<true/>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.18`:
+The Xcode project pins the public Swift package to `0.1.19`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.18
+    exactVersion: 0.1.19
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -38,6 +38,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mentra.bluetoothsdk.example.ios
         PRODUCT_NAME: MentraSdkIosExample
+        CODE_SIGN_ENTITLEMENTS: MentraExample/MentraExample.entitlements
         INFOPLIST_KEY_CFBundleDisplayName: Mentra SDK iOS
         SWIFT_OBJC_BRIDGING_HEADER: MentraExample/MentraExample-Bridging-Header.h
         GSTREAMER_ROOT_IOS: "$(HOME)/Library/Developer/GStreamer/iPhone.sdk"

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7OdPVWmtUqZcDu4tM71jDPO8jM3283TrsWmY+vwSjPACeamxJLwgcYgAXAq/A1imvI8aO9snVcLQQjaTzpuswg=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.18",
+        "@mentra/bluetooth-sdk": "0.1.19",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.18",
+    "@mentra/bluetooth-sdk": "0.1.19",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.18"
+"@mentra/bluetooth-sdk": "0.1.19"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -12,6 +12,10 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.mentra.bluetoothsdk.example.reactnative",
+      "entitlements": {
+        "com.apple.developer.networking.HotspotConfiguration": true,
+        "com.apple.developer.networking.wifi-info": true
+      },
       "infoPlist": {
         "NSBluetoothAlwaysUsageDescription": "This example app uses Bluetooth to connect to smart glasses.",
         "NSBluetoothPeripheralUsageDescription": "This example app uses Bluetooth to connect to smart glasses.",
@@ -31,6 +35,7 @@
         "android.permission.BLUETOOTH_CONNECT",
         "android.permission.ACCESS_FINE_LOCATION",
         "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.NEARBY_WIFI_DEVICES",
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
         "android.permission.INTERNET",
@@ -68,7 +73,8 @@
           "imageWidth": 200
         }
       ],
-      "expo-video"
+      "expo-video",
+      "react-native-wifi-reborn"
     ]
   }
 }

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -21,6 +21,7 @@
         "react-native-safe-area-context": "~5.6.2",
         "react-native-svg": "15.15.3",
         "react-native-webview": "13.16.0",
+        "react-native-wifi-reborn": "^4.13.6",
       },
       "devDependencies": {
         "@types/react": "^19.1.0",
@@ -891,6 +892,8 @@
     "react-native-svg": ["react-native-svg@15.15.3", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA=="],
 
     "react-native-webview": ["react-native-webview@13.16.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "invariant": "2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA=="],
+
+    "react-native-wifi-reborn": ["react-native-wifi-reborn@4.13.6", "", { "peerDependencies": { "react-native": ">=0.13" } }, "sha512-vlZYgRnFapVVeJ8z0G0k7k6wUi9mUPhW6ji008mp5BBKMbZNL0AxdyHUOW3uP1emKYK7eRIvfx6AuECpG2mAsg=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7OdPVWmtUqZcDu4tM71jDPO8jM3283TrsWmY+vwSjPACeamxJLwgcYgAXAq/A1imvI8aO9snVcLQQjaTzpuswg=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.18",
+        "@mentra/bluetooth-sdk": "0.1.19",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.18", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-GT7+X/6u7+G2oJHqjc0thKBwAUVQL1CyixPn7bJSkhzowrRx18AqIRZuCIJisNL1zU9YBcpX3ryK4eqdMoOZvw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-mS5pqXvZx+PDHer+mLZ7kYbg86I8iiz6STqwbrAy1pa49eUV+nr2I9DHhMsgwUbP8PbLXZsBV3qy8EVIbgIwVw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -28,6 +28,7 @@
     "react-native": "0.83.6",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-svg": "15.15.3",
+    "react-native-wifi-reborn": "^4.13.6",
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.18",
+    "@mentra/bluetooth-sdk": "0.1.19",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/scripts/android-run.mjs
+++ b/examples/react-native/scripts/android-run.mjs
@@ -13,8 +13,10 @@ import {expoDeviceName, resolveAndroidPhoneTarget} from "./resolve-android-phone
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(scriptDir, "..")
-const mobileSdkRoot = path.resolve(projectRoot, "../../../mobile/modules/bluetooth-sdk")
 const modulesSdkPath = path.join(projectRoot, "modules/bluetooth-sdk")
+const localSdkOverride = process.env.MENTRA_BLUETOOTH_SDK_PACKAGE_PATH?.trim()
+  ? path.resolve(process.env.MENTRA_BLUETOOTH_SDK_PACKAGE_PATH)
+  : null
 
 const args = process.argv.slice(2)
 
@@ -29,6 +31,8 @@ Skips Mentra Live glasses and emulators unless ANDROID_SERIAL is set.
 Environment:
   ANDROID_SERIAL        Force a specific phone serial when multiple phones are connected
   ALLOW_MENTRA_LIVE=1   Allow targeting Mentra Live (not recommended for this example)
+  MENTRA_BLUETOOTH_SDK_PACKAGE_PATH
+                        Explicitly use a local SDK source checkout instead of npm
 `)
   process.exit(0)
 }
@@ -54,125 +58,18 @@ function run(command, commandArgs) {
   }
 }
 
-/**
- * Expo autolinking prefers `modules/bluetooth-sdk` over node_modules when present.
- * A stale copied tree there ignores package.json `file:` — symlink to mobile SDK instead.
- */
-function ensureBluetoothSdkSymlink() {
-  if (!fs.existsSync(mobileSdkRoot)) {
-    console.warn(`Mobile SDK not found at ${mobileSdkRoot} — skipping modules/ symlink fix`)
-    return
-  }
-
-  const expected = fs.realpathSync(mobileSdkRoot)
-
-  // Broken symlinks: existsSync is false but lstat still finds the link (EEXIST if we skip rm).
-  let hasModulesEntry = false
+function removeStaleBluetoothSdkModuleEntry() {
   try {
-    fs.lstatSync(modulesSdkPath)
-    hasModulesEntry = true
-  } catch {
-    /* path absent */
-  }
-
-  if (hasModulesEntry) {
-    try {
-      if (fs.realpathSync(modulesSdkPath) === expected) {
-        console.log(`modules/bluetooth-sdk -> ${expected}`)
-        return
-      }
-      console.log(`Replacing modules/bluetooth-sdk (was not ${expected})`)
-    } catch {
-      console.warn("Removing broken modules/bluetooth-sdk symlink")
-    }
     const stat = fs.lstatSync(modulesSdkPath)
     if (stat.isSymbolicLink()) {
       fs.unlinkSync(modulesSdkPath)
     } else {
       fs.rmSync(modulesSdkPath, {recursive: true, force: true})
     }
+    console.log("Removed modules/bluetooth-sdk so Expo autolinks the npm dependency")
+  } catch {
+    /* path absent */
   }
-
-  // Use absolute target — relative ../../../ paths break from modules/ (ENOENT on realpath).
-  fs.symlinkSync(expected, modulesSdkPath, "dir")
-  console.log(`Linked modules/bluetooth-sdk -> ${expected}`)
-}
-
-/**
- * bluetooth-sdk depends on :lc3Lib and :silero. Published npm tarballs may omit silero;
- * local dev uses modules/bluetooth-sdk -> MentraOS/mobile/modules/bluetooth-sdk.
- */
-function ensureSettingsGradleNativeModules() {
-  const settingsPath = path.join(projectRoot, "android/settings.gradle")
-  if (!fs.existsSync(settingsPath)) {
-    console.warn("android/settings.gradle missing — run: bunx expo prebuild --platform android")
-    return
-  }
-
-  if (!fs.existsSync(mobileSdkRoot)) {
-    return
-  }
-
-  const sdkRoot = fs.realpathSync(mobileSdkRoot)
-  const sdkRootLiteral = JSON.stringify(sdkRoot)
-
-  let contents = fs.readFileSync(settingsPath, "utf8")
-
-  const rootBlock = `def mentraBluetoothSdkRoot = new File(${sdkRootLiteral})`
-
-  contents = contents.replace(
-    /def mentraBluetoothSdkPackageJson[\s\S]*?def mentraBluetoothSdkRoot = new File\(mentraBluetoothSdkPackageJson\)\.getParentFile\(\)\s*\n?/,
-    `${rootBlock}\n`,
-  )
-
-  if (!contents.includes("def mentraBluetoothSdkRoot")) {
-    contents += `\n${rootBlock}\n`
-  }
-
-  if (!contents.includes("include ':lc3Lib'")) {
-    contents += `
-include ':lc3Lib'
-project(':lc3Lib').projectDir = new File(mentraBluetoothSdkRoot, 'android/lc3Lib')
-`
-  }
-
-  if (!contents.includes("include ':silero'")) {
-    contents += `
-include ':silero'
-project(':silero').projectDir = new File(mentraBluetoothSdkRoot, 'android/silero')
-`
-  }
-
-  fs.writeFileSync(settingsPath, contents)
-  console.log(`android/settings.gradle uses bluetooth-sdk at ${sdkRoot}`)
-}
-
-/** Root project must see bluetooth-sdk's on-disk Maven repo (AAR downloaded in SDK build.gradle). */
-function ensureSherpaOnnxMavenRepo() {
-  const buildGradlePath = path.join(projectRoot, "android/build.gradle")
-  if (!fs.existsSync(buildGradlePath) || !fs.existsSync(mobileSdkRoot)) {
-    return
-  }
-
-  const marker = "// bluetooth-sdk: sherpa-onnx local maven repo"
-  let contents = fs.readFileSync(buildGradlePath, "utf8")
-  if (contents.includes(marker)) {
-    return
-  }
-
-  const repoDir = path.join(fs.realpathSync(mobileSdkRoot), "android/libs/maven")
-  const repoBlock = `    maven {\n      ${marker}\n      url = uri(${JSON.stringify(repoDir)})\n    }`
-
-  const match = contents.match(/allprojects\s*\{[\s\S]*?repositories\s*\{/)
-  if (!match) {
-    console.warn("android/build.gradle: no allprojects.repositories block — add Sherpa maven repo manually")
-    return
-  }
-
-  const insertIdx = match.index + match[0].length
-  contents = contents.slice(0, insertIdx) + "\n" + repoBlock + contents.slice(insertIdx)
-  fs.writeFileSync(buildGradlePath, contents)
-  console.log(`android/build.gradle: Sherpa-ONNX maven -> ${repoDir}`)
 }
 
 /** Fix CMake/codegen after a failed `gradlew clean` (AGP bug 255965912 / missing webview jni). */
@@ -188,32 +85,34 @@ function recoverAndroidNativeBuild() {
   ])
 }
 
-// Metro and native must use the same SDK tree (local mobile has silero + photo-receiver).
-if (fs.existsSync(mobileSdkRoot)) {
-  process.env.MENTRA_BLUETOOTH_SDK_PACKAGE_PATH = fs.realpathSync(mobileSdkRoot)
-}
-
 const target = resolveAndroidPhoneTarget()
 const expoDevice = expoDeviceName(target)
 
-const sdkPkg = output("node", [
+removeStaleBluetoothSdkModuleEntry()
+
+console.log("Installing the package.json dependencies from npm...")
+run("bun", ["install"])
+
+const sdkPackageJson = output("node", [
   "--print",
   "require.resolve('@mentra/bluetooth-sdk/package.json')",
-])
-console.log(`@mentra/bluetooth-sdk resolves to: ${sdkPkg}`)
-console.log(
-  "Local SDK: run `bun install` after adding new .java files (file: deps use per-file symlinks).",
-)
+]).trim()
+if (localSdkOverride && !fs.existsSync(localSdkOverride)) {
+  throw new Error(`Local SDK override not found at ${localSdkOverride}`)
+}
+const sdkRoot = localSdkOverride
+  ? fs.realpathSync(localSdkOverride)
+  : path.dirname(fs.realpathSync(sdkPackageJson))
+const sdkPackage = JSON.parse(fs.readFileSync(path.join(sdkRoot, "package.json"), "utf8"))
+console.log(`@mentra/bluetooth-sdk resolves to: ${sdkRoot} (version ${sdkPackage.version})`)
+console.log(localSdkOverride ? "SDK source: explicit local override" : "SDK source: npm dependency")
 console.log(`Using Android phone: ${expoDevice} (serial ${target.serial})`)
 console.log("Skipping Mentra Live / emulator targets.")
 
-ensureBluetoothSdkSymlink()
-ensureSettingsGradleNativeModules()
-ensureSherpaOnnxMavenRepo()
-
-// Refresh file: symlinks so new SDK sources are visible to Gradle.
-console.log("Refreshing @mentra/bluetooth-sdk symlinks (bun install)...")
-run("bun", ["install"])
+if (!fs.existsSync(path.join(projectRoot, "android/settings.gradle"))) {
+  console.log("Generating the Android project...")
+  run("bunx", ["expo", "prebuild", "--platform", "android"])
+}
 
 const skipClean = process.env.SDK_CLEAN === "0"
 if (!skipClean) {

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -7,7 +7,12 @@ import { Header } from '../components/Header';
 import { useScrollBottomPadding } from '../components/keyboardLayout';
 import { OfflineNotice } from '../components/OfflineNotice';
 import { colors } from '../components/theme';
-import { isGlassesConnected, isGlassesWifiConnected } from '../sdkFormat';
+import {
+  galleryHotspotPasswordLabel,
+  galleryHotspotSsidLabel,
+  isGlassesConnected,
+  isGlassesWifiConnected,
+} from '../sdkFormat';
 import {
   CAMERA_FOV_DEFAULT,
   CAMERA_FOV_MAX,
@@ -55,6 +60,7 @@ function photoSdkCall(
   size: PhotoSize,
   compression: PhotoCompression,
   useCloudServer: boolean,
+  saveOnGlasses: boolean,
   aeExposureDivisor: PhotoAeExposureDivisor | null,
   isoCap: PhotoIsoCap | null,
   noiseReduction: PhotoTuningFlag,
@@ -88,6 +94,17 @@ console.log(\`Camera FOV applied at \${cameraFov.fov}°\`);
         ispDigitalGain !== null ? `  ispDigitalGain: ${ispDigitalGain},` : null,
         ispAnalogGain !== null ? `  ispAnalogGain: "${ispAnalogGain}",` : null,
       ].filter((line): line is string => line !== null).join('\n');
+  if (saveOnGlasses) {
+    return `${prefix}const photo = await BluetoothSdk.requestPhoto({
+  webhookUrl: null,
+  authToken: null,
+  save: true,
+${requestFields}
+})
+const gallery = await fetch(\`\${galleryBaseUrl}/api/gallery?limit=100\`).then(response => response.json());
+const savedPhoto = gallery.data.photos.find(item => item.request_id === photo.requestId);
+console.log("Photo saved on glasses", savedPhoto?.name)`;
+  }
   if (!useCloudServer) {
     return `${prefix}const { uploadUrl } = await MentraPhotoReceiver.startPhotoReceiver();
 const photo = await BluetoothSdk.requestPhoto({
@@ -126,7 +143,8 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const [videoDetailsExpanded, setVideoDetailsExpanded] = React.useState(false);
   const connected = isGlassesConnected(sdk.glasses);
   const glassesWifiConnected = isGlassesWifiConnected(sdk.glasses);
-  const wifiRequired = connected && !glassesWifiConnected;
+  const wifiRequired =
+    connected && !glassesWifiConnected && !sdk.photoGlassesStorageEnabled;
   const videoActionBusy =
     sdk.activeAction === 'Start video recording' ||
     sdk.activeAction === 'Stop & upload video';
@@ -135,6 +153,18 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
     !glassesWifiConnected ||
     videoActionBusy;
   const cameraStatusFailed = isCameraStatusFailure(sdk.cameraStatus);
+  const waitingForGlassesPreview =
+    sdk.photoGlassesStorageEnabled &&
+    sdk.photoPreviewUrl === null &&
+    sdk.photoPreviewDetails?.state === 'saved';
+  const needsGlassesHotspotSetup =
+    connected && sdk.photoGlassesStorageEnabled && sdk.galleryServerReachable !== true;
+  const photoControlsDisabled =
+    !connected ||
+    (!glassesWifiConnected && !sdk.photoGlassesStorageEnabled) ||
+    needsGlassesHotspotSetup ||
+    sdk.activeAction === 'Capture & upload' ||
+    sdk.activeAction === 'Capture scan photo';
   const photoStatusOverlay = photoStatusOverlayInfo(
     sdk.photoStatus,
     sdk.photoPreviewUrl,
@@ -147,6 +177,8 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const cloudSetupHint = localCameraSetupHint(sdk.webhookUrl, sdk.cameraStatus);
   const photoStateText = sdk.photoPreviewUrl
     ? 'preview ready'
+    : waitingForGlassesPreview
+      ? 'saved'
     : sdk.photoStatus
       ? photoStatusTitle(sdk.photoStatus, sdk.photoPreviewDetails)
       : 'ready';
@@ -161,6 +193,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
         sdk.photoSize,
         sdk.photoCompression,
         sdk.photoCloudServerEnabled,
+        sdk.photoGlassesStorageEnabled,
         sdk.photoAeExposureDivisor,
         sdk.photoIsoCap,
         sdk.photoNoiseReduction,
@@ -245,6 +278,16 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
                   <Text style={styles.previewOpenText}>Open</Text>
                 </Pressable>
               </>
+            ) : waitingForGlassesPreview ? (
+              <View style={styles.savedPreviewState}>
+                <View style={styles.savedPreviewIcon}>
+                  <Svg width={22} height={22} viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                    <Polyline points="20 6 9 17 4 12" />
+                  </Svg>
+                </View>
+                <Text style={styles.savedPreviewTitle}>Photo saved on glasses</Text>
+                <Text style={styles.savedPreviewText}>Downloading the saved photo preview.</Text>
+              </View>
             ) : (
               <>
                 <View style={styles.previewGlow} />
@@ -284,6 +327,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             ) : null}
           </LinearGradient>
         </View>
+        {needsGlassesHotspotSetup ? <SavedPhotoHotspotPanel sdk={sdk} /> : null}
         {bleFallbackWarning ? (
           <View style={styles.previewFallbackWarning}>
             <Text style={styles.previewFallbackWarningTitle}>Bluetooth fallback</Text>
@@ -293,8 +337,8 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
 
         <BarcodeResult scan={sdk.barcodeScan} />
 
-        <Pressable disabled={!connected || !glassesWifiConnected} onPress={sdk.captureAndUpload}>
-          <LinearGradient colors={['#26473A', '#1F3A2A']} style={[styles.captureBtn, (!connected || !glassesWifiConnected) && styles.disabled]}>
+        <Pressable disabled={photoControlsDisabled} onPress={sdk.captureAndUpload}>
+          <LinearGradient colors={['#26473A', '#1F3A2A']} style={[styles.captureBtn, photoControlsDisabled && styles.disabled]}>
             <Svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
               <Path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z" />
               <Circle cx={12} cy={13} r={4} />
@@ -302,8 +346,12 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Text style={styles.captureText}>
               {!connected
                 ? 'Connect glasses first'
-                : !glassesWifiConnected
+                : !glassesWifiConnected && !sdk.photoGlassesStorageEnabled
                   ? 'Connect glasses to Wi-Fi'
+                : needsGlassesHotspotSetup
+                  ? sdk.galleryServerReachable === null
+                    ? 'Preparing hotspot…'
+                    : 'Connect glasses hotspot'
                 : sdk.activeAction === 'Capture & upload' || sdk.activeAction === 'Capture scan photo'
                   ? 'Capturing…'
                   : sdk.scanMode
@@ -415,9 +463,13 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
                 : sdk.photoPreviewUrl
                     ? sdk.photoCloudServerEnabled
                       ? 'Photo preview loaded from cloud server'
-                      : 'Photo preview loaded from phone receiver'
+                      : sdk.photoGlassesStorageEnabled
+                        ? 'Photo preview downloaded from glasses'
+                        : 'Photo preview loaded from phone receiver'
                     : sdk.photoCloudServerEnabled
                       ? 'Waiting for media upload'
+                      : sdk.photoGlassesStorageEnabled
+                        ? 'Photo will be saved on glasses'
                       : sdk.phonePhotoReceiverRunning
                         ? 'Phone receiver ready'
                         : 'Preparing phone receiver'}
@@ -429,7 +481,9 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
       {/* Upload to */}
       <LinearGradient colors={['rgba(255,255,255,0.7)', 'rgba(255,255,255,0.5)']} style={styles.uploadCard}>
         <View style={styles.cardHead}>
-          <Text style={styles.eyebrow}>UPLOAD TO</Text>
+          <Text style={styles.eyebrow}>
+            {captureMode === 'photo' ? 'PHOTO DESTINATION' : 'UPLOAD TO'}
+          </Text>
           {captureMode === 'video' || sdk.photoCloudServerEnabled ? (
             <Pressable onPress={sdk.testWebhook}>
               {({pressed}) => (
@@ -478,6 +532,16 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
                 value={sdk.photoCloudServerEnabled}
               />
             </View>
+            <View style={styles.cloudToggleRow}>
+              <Text style={styles.cloudToggleLabel}>Save and preview from glasses</Text>
+              <Switch
+                ios_backgroundColor="rgba(15,42,29,0.18)"
+                onValueChange={sdk.setPhotoGlassesStorageEnabled}
+                thumbColor="#fff"
+                trackColor={{ false: 'rgba(15,42,29,0.18)', true: colors.greenAccent }}
+                value={sdk.photoGlassesStorageEnabled}
+              />
+            </View>
         {sdk.photoCloudServerEnabled ? (
           <>
             <View style={styles.cardHead}>
@@ -500,6 +564,10 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             </View>
             {cloudSetupHint ? <Text style={styles.setupHint}>{cloudSetupHint}</Text> : null}
           </>
+        ) : sdk.photoGlassesStorageEnabled ? (
+          <Text style={styles.setupHint}>
+            Photos stay on the glasses. Capture unlocks when the gallery connection is ready.
+          </Text>
         ) : (
           <Text style={styles.setupHint}>
             The phone keeps a local upload receiver ready on this tab and previews JPEG photos when the glasses upload them.
@@ -870,12 +938,50 @@ type PhotoStatusExtras = {
   captureMetadata?: PhotoPreviewDetails['captureMetadata'];
 };
 
+function SavedPhotoHotspotPanel({sdk}: {sdk: BluetoothSdkExampleModel}) {
+  const hotspotLabel = galleryHotspotSsidLabel(sdk.glasses);
+  const password = galleryHotspotPasswordLabel(sdk.glasses);
+  const statusColor = sdk.galleryServerReachable === true
+    ? colors.greenAccent
+    : sdk.galleryServerReachable === false
+      ? colors.red
+      : colors.muted;
+
+  return (
+    <View style={styles.savedHotspotPanel}>
+      <View style={styles.savedHotspotHeader}>
+        <View style={styles.savedHotspotTextWrap}>
+          <Text style={styles.savedHotspotTitle}>Glasses hotspot</Text>
+          <Text style={styles.savedHotspotCredential}>Join {hotspotLabel}</Text>
+          <Text style={styles.savedHotspotCredential}>Password {password}</Text>
+        </View>
+        <View style={styles.savedHotspotActions}>
+          <SavedPhotoAction label="Retry" onPress={sdk.prepareGlassesPhotoPreview} />
+          <SavedPhotoAction label="Manual setup" onPress={sdk.openWifiSettings} />
+          <SavedPhotoAction label="Copy password" onPress={sdk.copyGalleryHotspotPassword} />
+        </View>
+      </View>
+      <Text numberOfLines={2} style={[styles.savedHotspotStatus, {color: statusColor}]}>
+        {sdk.galleryServerStatus}
+      </Text>
+    </View>
+  );
+}
+
+function SavedPhotoAction({label, onPress}: {label: string; onPress: () => void}) {
+  return (
+    <Pressable onPress={onPress} style={({pressed}) => [styles.savedHotspotAction, pressed && styles.copyChipPressed]}>
+      <Text style={styles.savedHotspotActionText}>{label}</Text>
+    </Pressable>
+  );
+}
+
 function photoStatusOverlayInfo(
   status: PhotoStatusEvent | null,
   previewUrl: string | null,
   details: PhotoPreviewDetails | null,
 ) {
-  if (!status) {
+  if (!status || details?.state === 'saved') {
     return null;
   }
   if (previewUrl && status.status !== 'failed') {
@@ -1652,7 +1758,7 @@ function photoDetailsSummary(details: PhotoPreviewDetails | null) {
     details.byteCount ? formatBytes(details.byteCount) : null,
     details.width && details.height ? `${details.width} x ${details.height}` : null,
     details.captureMetadata ? photoCaptureMetadataDetail(details.captureMetadata) : null,
-    details.source === 'Glasses gallery'
+    details.state === 'saved'
       ? 'saved on glasses'
       : details.state === 'acknowledged'
         ? 'acknowledged'
@@ -1673,12 +1779,12 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
     {
       label: 'State',
       value:
-        details.source === 'Glasses gallery' && details.state === 'acknowledged'
+        details.source === 'Glasses gallery' && details.state === 'saved'
           ? 'saved on glasses'
           : details.state,
     },
   ];
-  if (details.source === 'Glasses gallery') {
+  if (details.source === 'Glasses gallery' && !details.previewUrl) {
     rows.push({
       label: 'Gallery mode',
       value: 'Photo stayed on the glasses and was not previewed on the phone.',
@@ -1689,6 +1795,7 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
     rows.push({label: 'Bluetooth fallback', value: details.bleFallbackMessage, tone: 'warning'});
   }
   if (details.requestId) rows.push({label: 'Request ID', value: details.requestId});
+  if (details.fileName) rows.push({label: 'Glasses filename', value: details.fileName});
   addPhotoClockAdjustmentRow(rows, details.timeline);
   addPhotoTimelineRows(rows, details.timeline);
   if (details.byteCount) rows.push({label: 'Size', value: formatBytes(details.byteCount)});
@@ -2060,6 +2167,19 @@ const styles = StyleSheet.create({
   previewMeta: { position: 'absolute', bottom: 14, right: 14, color: 'rgba(255,255,255,0.85)', fontSize: 11, fontWeight: '500' },
   previewOpenBadge: { position: 'absolute', right: 12, bottom: 12, zIndex: 3, flexDirection: 'row', alignItems: 'center', gap: 6, backgroundColor: 'rgba(0,0,0,0.42)', borderRadius: 999, borderWidth: 1, borderColor: 'rgba(255,255,255,0.22)', paddingVertical: 7, paddingHorizontal: 11 },
   previewOpenText: { color: '#fff', fontSize: 11, fontWeight: '700' },
+  savedPreviewState: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 24 },
+  savedPreviewIcon: { width: 42, height: 42, borderRadius: 999, alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(255,255,255,0.18)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.28)' },
+  savedPreviewTitle: { color: '#fff', fontSize: 15, fontWeight: '800', marginTop: 10 },
+  savedPreviewText: { color: 'rgba(255,255,255,0.82)', fontSize: 11, fontWeight: '600', lineHeight: 15, marginTop: 3, textAlign: 'center' },
+  savedHotspotPanel: { marginTop: 10, marginHorizontal: 6, borderRadius: 14, borderWidth: 1, borderColor: 'rgba(15,42,29,0.08)', backgroundColor: 'rgba(15,42,29,0.04)', paddingVertical: 11, paddingHorizontal: 12, gap: 8 },
+  savedHotspotHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  savedHotspotTextWrap: { flex: 1, minWidth: 0 },
+  savedHotspotTitle: { color: colors.ink, fontSize: 13, fontWeight: '800' },
+  savedHotspotCredential: { color: colors.muted, fontSize: 11, fontWeight: '600', lineHeight: 15, marginTop: 1 },
+  savedHotspotActions: { alignItems: 'stretch', gap: 5 },
+  savedHotspotAction: { minHeight: 32, alignItems: 'center', justifyContent: 'center', borderRadius: 999, backgroundColor: 'rgba(52,199,89,0.14)', paddingVertical: 6, paddingHorizontal: 10 },
+  savedHotspotActionText: { color: colors.greenDeep, fontSize: 11, fontWeight: '800' },
+  savedHotspotStatus: { fontSize: 11, fontWeight: '600', lineHeight: 15 },
   previewStatusOverlay: { position: 'absolute', left: 12, right: 12, bottom: 12, zIndex: 4, borderRadius: 14, borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)', backgroundColor: 'rgba(8,24,16,0.74)', paddingVertical: 10, paddingHorizontal: 12 },
   previewStatusOverlayFailed: { backgroundColor: 'rgba(95,18,18,0.76)', borderColor: 'rgba(255,255,255,0.22)' },
   previewStatusLine: { flexDirection: 'row', alignItems: 'center', gap: 9 },

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, ScrollView, Pressable, StyleSheet, Image } from 'react-native';
+import { ActivityIndicator, View, Text, ScrollView, Pressable, StyleSheet, Image } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Circle, Line, Path, Rect } from 'react-native-svg';
 import { DeviceModels } from '@mentra/bluetooth-sdk';
@@ -333,6 +333,9 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaStatus?.status === 'failed') {
     return 'Update failed';
   }
+  if (isOtaInstalling(sdk)) {
+    return 'Installing update';
+  }
   if (sdk.otaStatus && isOtaInProgress(sdk)) {
     return `Updating ${sdk.otaStatus.step_type || 'firmware'}`;
   }
@@ -345,6 +348,9 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
 function otaCardDetail(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaStatus?.error_message) {
     return sdk.otaStatus.error_message;
+  }
+  if (isOtaInstalling(sdk)) {
+    return 'The glasses client may restart to finish installation.';
   }
   if (sdk.otaStatus) {
     return `${sdk.otaStatus.phase || 'status'} · step ${sdk.otaStatus.current_step}/${sdk.otaStatus.total_steps}`;
@@ -359,12 +365,17 @@ function otaDisplayPercent(sdk: BluetoothSdkExampleModel) {
   return sdk.otaDisplayPercent ?? sdk.otaStatus?.overall_percent ?? 0;
 }
 
+function isOtaInstalling(sdk: BluetoothSdkExampleModel) {
+  return sdk.otaStatus?.status === 'in_progress' && sdk.otaStatus.phase === 'install';
+}
+
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   if (!sdk.otaStatus && !sdk.otaUpdateAvailable) {
     return null;
   }
   const percent = otaDisplayPercent(sdk);
   const updateRequired = sdk.otaUpdateAvailable && !sdk.otaStatus;
+  const installing = isOtaInstalling(sdk);
   return (
     <View style={[styles.otaCard, updateRequired && styles.otaCardRequired]}>
       <View style={styles.otaHead}>
@@ -385,9 +396,13 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Text style={[styles.otaTitle, updateRequired && styles.otaTitleRequired]}>{otaCardTitle(sdk)}</Text>
           </View>
         </View>
-        {sdk.otaStatus ? <Text style={styles.otaPercent}>{percent}%</Text> : null}
+        {installing ? (
+          <ActivityIndicator color={colors.greenPrimary} size="small" />
+        ) : sdk.otaStatus ? (
+          <Text style={styles.otaPercent}>{percent}%</Text>
+        ) : null}
       </View>
-      {sdk.otaStatus ? (
+      {sdk.otaStatus && !installing ? (
         <View style={styles.otaTrack}>
           <View style={[styles.otaFill, { width: `${Math.max(0, Math.min(percent, 100))}%` }]} />
         </View>

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -321,7 +321,7 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
     return `${sdk.otaStatus.status.replace(/_/g, ' ')} · ${otaDisplayPercent(sdk)}%`;
   }
   if (sdk.otaUpdateAvailable) {
-    return 'Update required';
+    return 'Firmware update available';
   }
   if (sdk.otaStatusMessage) {
     return sdk.otaStatusMessage;
@@ -337,7 +337,7 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
     return `Updating ${sdk.otaStatus.step_type || 'firmware'}`;
   }
   if (sdk.otaUpdateAvailable) {
-    return 'Update required';
+    return 'Firmware update available';
   }
   return 'OTA status';
 }
@@ -350,7 +350,7 @@ function otaCardDetail(sdk: BluetoothSdkExampleModel) {
     return `${sdk.otaStatus.phase || 'status'} · step ${sdk.otaStatus.current_step}/${sdk.otaStatus.total_steps}`;
   }
   if (sdk.otaUpdateAvailable) {
-    return 'Update your glasses before continuing. This example app may not work properly until the glasses firmware is current.';
+    return 'A newer firmware version is available for these glasses.';
   }
   return 'Tap Check OTA to compare the current glasses version with the SDK OTA manifest.';
 }
@@ -366,14 +366,12 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const percent = otaDisplayPercent(sdk);
   const updateRequired = sdk.otaUpdateAvailable && !sdk.otaStatus;
   return (
-    <LinearGradient
-      colors={updateRequired ? ['#FFF5DF', '#FFE6E1'] : ['#fff', '#fff']}
-      style={[styles.otaCard, updateRequired && styles.otaCardRequired]}>
+    <View style={[styles.otaCard, updateRequired && styles.otaCardRequired]}>
       <View style={styles.otaHead}>
         <View style={styles.otaTitleRow}>
           {updateRequired ? (
             <View style={styles.otaWarningIcon}>
-              <Svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round">
+              <Svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={colors.amber} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
                 <Path d="m21.7 18.6-8.3-14a1.6 1.6 0 0 0-2.8 0l-8.3 14A1.6 1.6 0 0 0 3.7 21h16.6a1.6 1.6 0 0 0 1.4-2.4Z" />
                 <Path d="M12 8v5" />
                 <Path d="M12 17h.01" />
@@ -382,7 +380,7 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           ) : null}
           <View style={{ flex: 1 }}>
             <Text style={[styles.otaEyebrow, updateRequired && styles.otaEyebrowRequired]}>
-              {updateRequired ? 'ACTION NEEDED' : 'OTA'}
+              {updateRequired ? 'OTA UPDATE' : 'OTA'}
             </Text>
             <Text style={[styles.otaTitle, updateRequired && styles.otaTitleRequired]}>{otaCardTitle(sdk)}</Text>
           </View>
@@ -412,7 +410,7 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           <Text style={styles.otaStartButtonText}>{canStartOta(sdk) ? 'Start OTA' : 'Connect Wi-Fi first'}</Text>
         </Pressable>
       ) : null}
-    </LinearGradient>
+    </View>
   );
 }
 
@@ -647,23 +645,23 @@ const styles = StyleSheet.create({
   signalBars: { flexDirection: 'row', alignItems: 'flex-end', gap: 4, paddingBottom: 6 },
   bar: { width: 6, borderRadius: 3 },
   statRow: { flexDirection: 'row', gap: 10, marginHorizontal: 16, marginTop: 12 },
-  otaCard: { marginHorizontal: 16, marginTop: 10, padding: 14, borderRadius: 16, backgroundColor: '#fff', borderWidth: 1, borderColor: 'rgba(255,255,255,0.7)', shadowColor: '#0F2A1D', shadowOpacity: 0.06, shadowRadius: 18, shadowOffset: { width: 0, height: 6 }, gap: 0 },
-  otaCardRequired: { borderColor: 'rgba(255,59,48,0.34)', shadowColor: '#FF3B30', shadowOpacity: 0.18, shadowRadius: 22, shadowOffset: { width: 0, height: 8 }, elevation: 5 },
+  otaCard: { marginHorizontal: 16, marginTop: 10, padding: 14, borderRadius: 12, backgroundColor: '#fff', borderWidth: 1, borderColor: colors.hairline, gap: 0 },
+  otaCardRequired: { backgroundColor: '#FFFCF5', borderColor: 'rgba(255,149,0,0.32)' },
   otaHead: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 },
   otaTitleRow: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 10 },
-  otaWarningIcon: { width: 34, height: 34, borderRadius: 999, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.red },
-  otaEyebrow: { color: colors.muted, fontSize: 10, fontWeight: '600', letterSpacing: 1.1, fontFamily: 'Courier' },
-  otaEyebrowRequired: { color: colors.red, fontWeight: '800' },
-  otaTitle: { color: colors.ink, fontSize: 15, fontWeight: '700', marginTop: 3 },
-  otaTitleRequired: { color: colors.inkAlt, fontSize: 19, fontWeight: '900' },
-  otaPercent: { color: colors.greenInk, fontSize: 20, fontWeight: '800' },
-  otaTrack: { height: 6, borderRadius: 999, overflow: 'hidden', backgroundColor: 'rgba(14,44,26,0.08)', marginTop: 12 },
-  otaFill: { height: 6, borderRadius: 999, backgroundColor: colors.greenPrimary },
+  otaWarningIcon: { width: 30, height: 30, borderRadius: 7, alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(255,149,0,0.10)' },
+  otaEyebrow: { color: colors.muted, fontSize: 10, fontWeight: '600', letterSpacing: 0, fontFamily: 'Courier' },
+  otaEyebrowRequired: { color: '#9A5A00', fontWeight: '700' },
+  otaTitle: { color: colors.ink, fontSize: 15, fontWeight: '700', marginTop: 2 },
+  otaTitleRequired: { color: colors.ink, fontSize: 16, fontWeight: '700' },
+  otaPercent: { color: colors.greenInk, fontSize: 15, fontWeight: '700', fontVariant: ['tabular-nums'] },
+  otaTrack: { height: 4, borderRadius: 2, overflow: 'hidden', backgroundColor: 'rgba(14,44,26,0.08)', marginTop: 12 },
+  otaFill: { height: 4, borderRadius: 2, backgroundColor: colors.greenPrimary },
   otaDetail: { color: colors.muted, fontSize: 12, fontWeight: '500', lineHeight: 16, marginTop: 9 },
-  otaDetailRequired: { color: '#5F201B', fontSize: 13, fontWeight: '700', lineHeight: 18, marginTop: 11 },
-  otaStartButton: { marginTop: 13, minHeight: 48, borderRadius: 14, backgroundColor: colors.red, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 },
-  otaStartButtonDisabled: { backgroundColor: 'rgba(95,32,27,0.36)' },
-  otaStartButtonText: { color: '#fff', fontSize: 14, fontWeight: '800' },
+  otaDetailRequired: { color: colors.muted, fontSize: 12, fontWeight: '500', lineHeight: 16, marginTop: 9 },
+  otaStartButton: { marginTop: 13, minHeight: 42, borderRadius: 8, backgroundColor: colors.greenInk, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 },
+  otaStartButtonDisabled: { backgroundColor: colors.mutedSoft },
+  otaStartButtonText: { color: '#fff', fontSize: 13, fontWeight: '700' },
   statCard: {
     flex: 1,
     backgroundColor: '#fff',

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1,7 +1,8 @@
 import {createAudioPlayer, setAudioModeAsync, type AudioPlayer} from 'expo-audio';
 import {File, Paths} from 'expo-file-system';
 import {useEffect, useRef, useState} from 'react';
-import {Clipboard, Linking, PermissionsAndroid, Platform} from 'react-native';
+import {Alert, Clipboard, Linking, PermissionsAndroid, Platform} from 'react-native';
+import WifiManager from 'react-native-wifi-reborn';
 import BluetoothSdk, {
   DeviceModels,
   type AudioConnectedEvent,
@@ -211,6 +212,7 @@ export type PhotoPreviewDetails = {
   contentType?: string;
   error?: string;
   estimatedFov?: ImageFovEstimate | null;
+  fileName?: string;
   focalLength35mm?: number | null;
   height?: number;
   previewUrl?: string;
@@ -220,7 +222,7 @@ export type PhotoPreviewDetails = {
   meteredPreview?: PhotoMeteredPreviewDetails;
   captureMetadata?: PhotoCaptureMetadataDetails;
   source: 'Cloud server' | 'Phone receiver' | 'Action button' | 'Glasses gallery';
-  state: 'acknowledged' | 'error' | 'preview';
+  state: 'acknowledged' | 'error' | 'preview' | 'saved';
   timestamp?: number;
   timeline?: PhotoTimelineEvent[];
   uploadUrl?: string;
@@ -257,6 +259,7 @@ type RgbLedAction = 'on' | 'off';
 export type LedColor = 'red' | 'green' | 'blue' | 'orange' | 'white';
 export type PhotoSize = 'low' | 'medium' | 'high' | 'max';
 export type PhotoCompression = 'none' | 'medium' | 'heavy';
+export type PhotoDestination = 'phone' | 'cloud' | 'glasses';
 export type PhotoAeExposureDivisor = 2 | 3 | 5;
 export type PhotoIsoCap = 400 | 800 | 1600;
 export type PhotoIspDigitalGain = 0 | 1 | 2 | 4;
@@ -421,6 +424,7 @@ export type BluetoothSdkExampleState = {
   phonePhotoUploadUrl: string | null;
   photoCompression: PhotoCompression;
   photoCloudServerEnabled: boolean;
+  photoGlassesStorageEnabled: boolean;
   photoAeExposureDivisor: PhotoAeExposureDivisor | null;
   photoIsoCap: PhotoIsoCap | null;
   photoNoiseReduction: PhotoTuningFlag;
@@ -482,6 +486,7 @@ export type BluetoothSdkExampleActions = {
   openGalleryServer: () => Promise<void>;
   openPhotoPreview: () => Promise<void>;
   openWifiSettings: () => Promise<void>;
+  prepareGlassesPhotoPreview: () => Promise<void>;
   checkForOtaUpdate: () => Promise<void>;
   requestWifiScan: () => Promise<void>;
   playMicRecording: () => Promise<void>;
@@ -494,6 +499,7 @@ export type BluetoothSdkExampleActions = {
   setGalleryModeEnabled: (enabled: boolean) => Promise<void>;
   setPhotoCompression: (compression: PhotoCompression) => void;
   setPhotoCloudServerEnabled: (enabled: boolean) => Promise<void>;
+  setPhotoGlassesStorageEnabled: (enabled: boolean) => Promise<void>;
   setPhotoAeExposureDivisor: (divisor: PhotoAeExposureDivisor | null) => void;
   setPhotoIsoCap: (isoCap: PhotoIsoCap | null) => void;
   setPhotoNoiseReduction: (value: PhotoTuningFlag) => void;
@@ -531,6 +537,7 @@ export type BluetoothSdkExampleModel = BluetoothSdkExampleState & BluetoothSdkEx
 
 const PHOTO_APP_ID = 'com.mentra.examples.reactnative';
 const PHOTO_POLL_ATTEMPTS = 45;
+const GLASSES_PHOTO_POLL_ATTEMPTS = 120;
 const VIDEO_POLL_ATTEMPTS = 180;
 const DIRECT_PHOTO_UPLOAD_TIMEOUT_MS = 75_000;
 export const PHOTO_BLE_FALLBACK_QUALITY_WARNING =
@@ -575,7 +582,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [webhookUrl, setWebhookUrlState] = useState(
     process.env?.EXPO_PUBLIC_MENTRA_PHOTO_WEBHOOK_URL ?? PHOTO_UPLOAD_DEFAULT_URL,
   );
-  const [photoCloudServerEnabled, setPhotoCloudServerEnabledState] = useState(false);
+  const [photoDestination, setPhotoDestination] = useState<PhotoDestination>('phone');
+  const photoCloudServerEnabled = photoDestination === 'cloud';
+  const photoGlassesStorageEnabled = photoDestination === 'glasses';
   const [phonePhotoReceiverRunning, setPhonePhotoReceiverRunning] = useState(false);
   const [phonePhotoUploadUrl, setPhonePhotoUploadUrl] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState('Camera: ready to capture to phone');
@@ -670,7 +679,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const streamStartPendingRef = useRef(false);
   const pollGenerationRef = useRef(0);
   const videoPollGenerationRef = useRef(0);
-  const photoCloudServerEnabledRef = useRef(false);
+  const photoDestinationRef = useRef<PhotoDestination>('phone');
+  const galleryConnectionGenerationRef = useRef(0);
+  const galleryConnectionPromiseRef = useRef<Promise<void> | null>(null);
+  const galleryServerReachableRef = useRef<boolean | null>(null);
+  const galleryBaseUrlRef = useRef<string | null>(null);
+  const galleryHotspotSsidRef = useRef<string | null>(null);
+  const hotspotJoinExplanationShownRef = useRef(false);
   const scanModeRef = useRef(false);
   const photoCaptureDefaultsSyncGenerationRef = useRef(0);
   const photoCaptureDefaultsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
@@ -751,6 +766,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   otaStatusRef.current = otaStatus;
   glassesConnectedRef.current = glassesConnected;
   glassesWifiConnectedRef.current = glassesWifiConnected;
+  galleryServerReachableRef.current = galleryServerReachable;
 
   useEffect(() => {
     let cancelled = false;
@@ -892,7 +908,17 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('STORE', `Wi-Fi ${payload.state === 'connected' ? payload.ssid : payload.state}`);
       }),
       BluetoothSdk.addListener('hotspot_status_change', (payload) => {
-        setGalleryServerReachable(null);
+        galleryBaseUrlRef.current = payload.state === 'enabled'
+          ? `http://${payload.localIp}:8089`
+          : null;
+        galleryHotspotSsidRef.current = payload.state === 'enabled' ? payload.ssid : null;
+        setGalleryServerReachable((current) =>
+          payload.state === 'enabled'
+            ? current
+            : photoDestinationRef.current === 'glasses'
+              ? false
+              : null,
+        );
         setGalleryServerStatus(
           payload.state === 'enabled'
             ? `Gallery server: http://${payload.localIp}:8089`
@@ -1001,13 +1027,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }, []);
 
   useEffect(() => {
-    if (activeTab !== 'camera' || photoCloudServerEnabled || !glassesConnected) {
+    if (activeTab !== 'camera' || photoDestination !== 'phone' || !glassesConnected) {
       return;
     }
     void ensurePhonePhotoReceiver('camera tab').catch((error) => {
       addEvent('TX', `photo receiver prewarm failed: ${formatError(error)}`);
     });
-  }, [activeTab, photoCloudServerEnabled, glassesConnected]);
+  }, [activeTab, photoDestination, glassesConnected]);
 
   useEffect(() => {
     if (activeTab !== 'camera') {
@@ -1064,6 +1090,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       if (!wasConnectedRef.current && scanMode) {
         // Re-apply scan preset on reconnect so glasses button preset stays in sync.
         void syncScanCapturePreset(true, buildPhotoCaptureDefaults());
+      }
+      if (!wasConnectedRef.current && photoDestinationRef.current === 'glasses') {
+        void prepareGlassesPhotoPreviewAction();
       }
       wasConnectedRef.current = true;
       return;
@@ -1560,11 +1589,18 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     const captureLabel = scanMode ? 'Capture scan photo' : 'Capture & upload';
     await runAction(captureLabel, async () => {
       requireConnected('capture photos');
-      requireGlassesWifi('capture photos');
       if (!(await ensureAndroidPermissions('photo'))) {
         throw new Error('Camera and Bluetooth permissions are required for photos.');
       }
-      if (!photoCloudServerEnabledRef.current) {
+      if (photoDestinationRef.current === 'glasses') {
+        if (galleryServerReachableRef.current !== true) {
+          throw new Error('Connect to the glasses hotspot before capturing.');
+        }
+        await captureToGlassesStorage();
+        return;
+      }
+      requireGlassesWifi('capture photos');
+      if (photoDestinationRef.current === 'phone') {
         await captureAndUploadToPhone();
         return;
       }
@@ -1765,8 +1801,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setCameraStatus(`Camera: phone upload requested (${requestId})`);
     startPhonePhotoUploadTimeout(requestId);
 
+    let response: PhotoSuccessResponseEvent;
     try {
-      const response = await BluetoothSdk.requestPhoto({
+      response = await BluetoothSdk.requestPhoto({
         requestId,
         webhookUrl: receiver.uploadUrl,
         authToken: null,
@@ -1786,6 +1823,62 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       markPhotoRequestFailed(requestId, 'REQUEST_FAILED', formatError(error));
       throw error;
     }
+  }
+
+  async function captureToGlassesStorage() {
+    const requestedAt = Date.now();
+    const requestId = `photo-${requestedAt}`;
+    activePhotoRequestIdRef.current = requestId;
+    pollGenerationRef.current += 1;
+    const generation = pollGenerationRef.current;
+
+    setPhotoPreviewUrl(null);
+    setPhotoPreviewDetails(null);
+    markPhotoRequestStarted(requestId, 'Glasses gallery', requestedAt);
+    resetBarcodeScan();
+    setCameraStatus(`Camera: saving photo on glasses (${requestId})`);
+
+    let response: PhotoSuccessResponseEvent;
+    try {
+      response = await BluetoothSdk.requestPhoto({
+        requestId,
+        webhookUrl: null,
+        authToken: null,
+        save: true,
+        ...buildPhotoRequestFields(),
+      });
+    } catch (error) {
+      if (activePhotoRequestIdRef.current === requestId) {
+        activePhotoRequestIdRef.current = null;
+      }
+      markPhotoRequestFailed(requestId, 'GLASSES_PHOTO_FAILED', formatError(error));
+      throw error;
+    }
+    handlePhotoResponse(response);
+    setCameraStatus('Camera: photo saved on glasses; loading preview');
+    setPhotoPreviewDetails((current) =>
+      current
+        ? {...current, state: 'saved'}
+        : {requestId, source: 'Glasses gallery', state: 'saved'},
+    );
+    void downloadGlassesPhotoPreview(requestId, generation).catch((error) => {
+      if (
+        activePhotoRequestIdRef.current !== requestId ||
+        pollGenerationRef.current !== generation
+      ) {
+        return;
+      }
+      activePhotoRequestIdRef.current = null;
+      const message = formatError(error);
+      setCameraStatus(`Camera: ${message}`);
+      setPhotoPreviewDetails((current) => ({
+        ...current,
+        error: message,
+        requestId,
+        source: 'Glasses gallery',
+        state: 'saved',
+      }));
+    });
   }
 
   async function testWebhook() {
@@ -1966,7 +2059,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       ...current,
       error: errorMessage || errorCode,
       requestId,
-      source: current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
+      source: current?.source ?? currentPhotoSource(photoDestinationRef.current),
       state: 'error',
       timestamp: failedAt,
       timeline: appendPhotoTimeline(current?.timeline, {
@@ -2076,7 +2169,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             ? 'Glasses gallery'
             : payload.resolvedConfig?.source === 'button'
               ? 'Action button'
-            : current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
+            : current?.source ?? currentPhotoSource(photoDestinationRef.current),
         state: current?.state === 'preview' ? 'preview' : 'acknowledged',
         timestamp: statusDeviceTimestamp,
         timeline: appendPhotoTimeline(current?.timeline, {
@@ -2101,7 +2194,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         ...current,
         error: payload.errorCode ?? payload.errorMessage,
         requestId: payload.requestId,
-        source: current?.source ?? (photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver'),
+        source: current?.source ?? currentPhotoSource(photoDestinationRef.current),
         state: 'error',
         timestamp: statusDeviceTimestamp,
         timeline: current?.timeline ?? [{
@@ -2283,6 +2376,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       return;
     }
     const previewUrl = response.photoUrl;
+    const destination = photoDestinationRef.current;
+    const source: PhotoPreviewDetails['source'] =
+      destination === 'cloud'
+        ? 'Cloud server'
+        : destination === 'glasses'
+          ? 'Glasses gallery'
+          : 'Phone receiver';
     const responsePhoneTimestamp = Date.now();
     const responseDeviceTimestamp = response.timestamp ?? responsePhoneTimestamp;
     if (previewUrl) {
@@ -2293,9 +2393,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setCameraStatus(
       previewUrl
         ? 'Camera: loaded photo preview'
-        : photoCloudServerEnabledRef.current
+        : destination === 'cloud'
           ? 'Camera: photo delivered to cloud webhook'
-          : 'Camera: photo delivered to phone receiver',
+          : destination === 'glasses'
+            ? 'Camera: photo saved on glasses; loading preview'
+            : 'Camera: photo delivered to phone receiver',
     );
     setPhotoPreviewDetails((current) => ({
       ...current,
@@ -2303,7 +2405,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       contentType: response.contentType ?? current?.contentType,
       previewUrl: previewUrl ?? current?.previewUrl,
       requestId: response.requestId,
-      source: photoCloudServerEnabledRef.current ? 'Cloud server' : 'Phone receiver',
+      source,
       state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
       timestamp: responseDeviceTimestamp,
       timeline: appendPhotoResponseTimeline(current?.timeline, {
@@ -2319,6 +2421,101 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }
     }
     addEvent('LIVE', `photo response ${response.requestId}`);
+  }
+
+  async function downloadGlassesPhotoPreview(
+    requestId: string,
+    generation: number,
+  ) {
+    const baseUrl = galleryBaseUrlRef.current ?? galleryServerUrl(glasses, hotspotEnabled);
+    if (!baseUrl || galleryServerReachableRef.current !== true) {
+      throw new Error('The glasses hotspot is not ready for preview downloads.');
+    }
+
+    const localFile = new File(Paths.cache, `mentra-gallery-${requestId}.jpg`);
+    setGalleryServerStatus(`Gallery server: finding ${requestId}`);
+
+    for (let attempt = 0; attempt < GLASSES_PHOTO_POLL_ATTEMPTS; attempt += 1) {
+      if (
+        activePhotoRequestIdRef.current !== requestId ||
+        pollGenerationRef.current !== generation
+      ) {
+        return;
+      }
+      try {
+        const galleryResponse = await fetchWithTimeout(
+          cacheBustedUrl(`${baseUrl}/api/gallery?limit=100`),
+          {cache: 'no-store', headers: {'Cache-Control': 'no-cache', Pragma: 'no-cache'}},
+          3000,
+        );
+        if (!galleryResponse.ok) {
+          throw new Error(`Gallery server returned HTTP ${galleryResponse.status}.`);
+        }
+        const gallery = (await galleryResponse.json()) as {
+          data?: {
+            photos?: Array<{
+              mime_type?: string;
+              name?: string;
+              request_id?: string;
+              size?: number;
+              url?: string;
+            }>;
+          };
+        };
+        const photo = gallery.data?.photos?.find((item) => item.request_id === requestId);
+        setGalleryServerReachable(true);
+        if (!photo?.name) {
+          setGalleryServerStatus(`Gallery server: connected; finding ${requestId}`);
+          await delay(1000);
+          continue;
+        }
+        const fileName = photo.name;
+        const remoteUrl = new URL(photo.url ?? '/api/photo', baseUrl);
+        if (!photo.url) {
+          remoteUrl.searchParams.set('file', fileName);
+        }
+        const downloaded = await File.downloadFileAsync(remoteUrl.toString(), localFile, {idempotent: true});
+        const deliveredAt = Date.now();
+        setPhotoPreviewUrl(downloaded.uri);
+        setPhotoStatus(null);
+        setPhotoPreviewDetails((current) => ({
+          ...current,
+          byteCount: photo.size ?? (downloaded.size || current?.byteCount),
+          contentType: photo.mime_type ?? downloaded.type ?? current?.contentType ?? 'image/jpeg',
+          fileName,
+          previewUrl: remoteUrl.toString(),
+          requestId,
+          source: 'Glasses gallery',
+          state: 'preview',
+          timestamp: current?.timestamp ?? deliveredAt,
+        }));
+        setGalleryServerReachable(true);
+        setGalleryServerStatus(`Gallery server: downloaded ${fileName}`);
+        setCameraStatus('Camera: loaded photo preview from glasses');
+        activePhotoRequestIdRef.current = null;
+        void updatePhotoPreviewMetadata(downloaded.uri);
+        if (scanModeRef.current) {
+          void scanPreviewBarcode(downloaded.uri);
+        }
+        addEvent('LIVE', `glasses photo downloaded ${fileName}`);
+        return;
+      } catch (error) {
+        if (attempt === 0 || attempt % 10 === 9) {
+          setGalleryServerReachable(false);
+          setGalleryServerStatus(
+            `Gallery server: not reachable. Join ${galleryHotspotSsidLabel(glasses)}.`,
+          );
+          setCameraStatus(
+            `Camera: join ${galleryHotspotSsidLabel(glasses)} to load the saved photo`,
+          );
+          addEvent('LIVE', `waiting for glasses photo ${requestId}: ${formatError(error)}`);
+        }
+      }
+      await delay(1000);
+    }
+    throw new Error(
+      `Photo was saved on the glasses, but the preview could not be downloaded from ${baseUrl}.`,
+    );
   }
 
   async function pollPhotoPreview(
@@ -2751,8 +2948,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   async function setPhotoCloudServerEnabledAction(enabled: boolean) {
     await runAction(enabled ? 'Use photo cloud server' : 'Capture photos to phone', async () => {
-      photoCloudServerEnabledRef.current = enabled;
-      setPhotoCloudServerEnabledState(enabled);
+      if (photoDestinationRef.current === 'glasses') {
+        await disableGlassesPhotoPreviewConnection();
+      }
+      const destination: PhotoDestination = enabled ? 'cloud' : 'phone';
+      photoDestinationRef.current = destination;
+      setPhotoDestination(destination);
       activePhotoRequestIdRef.current = null;
       clearPhotoUploadTimeout();
       setPhotoStatus(null);
@@ -2764,6 +2965,125 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }
       setCameraStatus('Camera: ready to capture to phone');
     });
+  }
+
+  async function setPhotoGlassesStorageEnabledAction(enabled: boolean) {
+    await runAction(enabled ? 'Save photos on glasses' : 'Capture photos to phone', async () => {
+      const destination: PhotoDestination = enabled ? 'glasses' : 'phone';
+      photoDestinationRef.current = destination;
+      setPhotoDestination(destination);
+      activePhotoRequestIdRef.current = null;
+      clearPhotoUploadTimeout();
+      setPhotoStatus(null);
+      pollGenerationRef.current += 1;
+      if (!enabled) {
+        await disableGlassesPhotoPreviewConnection();
+        setCameraStatus('Camera: ready to capture to phone');
+        return;
+      }
+      await stopPhonePhotoReceiver().catch(() => undefined);
+      if (!glassesConnected) {
+        setCameraStatus('Camera: connect glasses to save photos on them');
+        return;
+      }
+      await prepareGlassesPhotoPreviewConnection();
+    });
+  }
+
+  async function prepareGlassesPhotoPreviewAction() {
+    await runAction('Connect to glasses hotspot', prepareGlassesPhotoPreviewConnection);
+  }
+
+  async function disableGlassesPhotoPreviewConnection() {
+    galleryConnectionGenerationRef.current += 1;
+    galleryConnectionPromiseRef.current = null;
+    const hotspotSsid = galleryHotspotSsidRef.current ?? galleryHotspotSsidLabel(glasses);
+    galleryBaseUrlRef.current = null;
+    galleryHotspotSsidRef.current = null;
+    setGalleryServerReachable(null);
+    setGalleryServerStatus('Gallery server: hotspot off');
+    await disconnectGlassesHotspotWifi(hotspotSsid).catch((error) => {
+      addEvent('LIVE', `hotspot Wi-Fi disconnect: ${formatError(error)}`);
+    });
+    if (hotspotEnabled) {
+      const status = await BluetoothSdk.setHotspotState(false);
+      addEvent('LIVE', `hotspot ${status.state}`);
+    }
+  }
+
+  async function prepareGlassesPhotoPreviewConnection() {
+    if (galleryConnectionPromiseRef.current) {
+      return galleryConnectionPromiseRef.current;
+    }
+    const generation = ++galleryConnectionGenerationRef.current;
+    const connection = (async () => {
+      requireConnected('prepare saved-photo previews');
+      setGalleryServerReachable(null);
+      setGalleryServerStatus('Gallery server: starting glasses hotspot');
+      setCameraStatus('Camera: preparing glasses hotspot');
+
+      const currentHotspot = enabledHotspotStatus(glasses);
+      const hotspot = currentHotspot ?? await BluetoothSdk.setHotspotState(true);
+      if (hotspot.state !== 'enabled') {
+        throw new Error('The glasses hotspot did not turn on.');
+      }
+      if (generation !== galleryConnectionGenerationRef.current) return;
+
+      const baseUrl = `http://${hotspot.localIp}:8089`;
+      galleryBaseUrlRef.current = baseUrl;
+      galleryHotspotSsidRef.current = hotspot.ssid;
+      const alreadyReady = await waitForGalleryServer(baseUrl, 3, 400);
+      if (alreadyReady) {
+        markGalleryServerReady(baseUrl);
+        return;
+      }
+
+      if (!hotspotJoinExplanationShownRef.current) {
+        await showHotspotJoinExplanation(hotspot.ssid);
+        hotspotJoinExplanationShownRef.current = true;
+      }
+      if (generation !== galleryConnectionGenerationRef.current) return;
+
+      setGalleryServerStatus(`Gallery server: connecting to ${hotspot.ssid}`);
+      setCameraStatus(`Camera: connecting to ${hotspot.ssid}`);
+      let connectionError: unknown = null;
+      try {
+        await WifiManager.connectToProtectedSSID(
+          hotspot.ssid,
+          hotspot.password,
+          false,
+          false,
+        );
+      } catch (error) {
+        connectionError = error;
+      }
+      if (generation !== galleryConnectionGenerationRef.current) return;
+
+      if (await waitForGalleryServer(baseUrl, 20, 500)) {
+        markGalleryServerReady(baseUrl);
+        return;
+      }
+      const reason = connectionError ? ` ${formatError(connectionError)}` : '';
+      setGalleryServerReachable(false);
+      setGalleryServerStatus(`Gallery server: connection required for ${hotspot.ssid}`);
+      setCameraStatus('Camera: connect to the glasses hotspot to enable capture');
+      throw new Error(`Could not reach the glasses gallery.${reason}`);
+    })();
+    galleryConnectionPromiseRef.current = connection;
+    try {
+      await connection;
+    } finally {
+      if (galleryConnectionPromiseRef.current === connection) {
+        galleryConnectionPromiseRef.current = null;
+      }
+    }
+  }
+
+  function markGalleryServerReady(baseUrl: string) {
+    setGalleryServerReachable(true);
+    setGalleryServerStatus(`Gallery server: ready at ${baseUrl}`);
+    setCameraStatus('Camera: ready to save and preview from glasses');
+    addEvent('LIVE', `gallery server ready ${baseUrl}`);
   }
 
   async function setStreamCloudServerEnabledAction(enabled: boolean) {
@@ -3088,8 +3408,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         }
       }
       const ssid = galleryHotspotSsidLabel(glasses);
-      setGalleryServerStatus(`Join ${ssid} from system Wi-Fi settings, then tap Open.`);
-      addEvent('LIVE', `Join ${ssid} from system Wi-Fi settings, then tap Open.`);
+      setGalleryServerStatus(`Join ${ssid} from system Wi-Fi settings, then tap Retry.`);
+      addEvent('LIVE', `Join ${ssid} from system Wi-Fi settings, then tap Retry.`);
     });
   }
 
@@ -3444,6 +3764,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setStreamStatus(status);
     setGalleryServerReachable(null);
     setGalleryServerStatus('Gallery server: connect glasses first');
+    galleryConnectionGenerationRef.current += 1;
+    galleryConnectionPromiseRef.current = null;
+    const hotspotSsid = galleryHotspotSsidRef.current;
+    galleryBaseUrlRef.current = null;
+    galleryHotspotSsidRef.current = null;
+    if (hotspotSsid) {
+      void disconnectGlassesHotspotWifi(hotspotSsid).catch(() => undefined);
+    }
     otaStatusRef.current = null;
     setOtaStatus(null);
     clearOtaDisplayProgress();
@@ -3585,6 +3913,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     openGalleryServer,
     openPhotoPreview,
     openWifiSettings,
+    prepareGlassesPhotoPreview: prepareGlassesPhotoPreviewAction,
     applyCameraSettings,
     pcmBytes,
     pcmFrames,
@@ -3594,6 +3923,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     phonePhotoUploadUrl,
     photoCompression,
     photoCloudServerEnabled,
+    photoGlassesStorageEnabled,
     photoAeExposureDivisor,
     photoIsoCap,
     photoNoiseReduction,
@@ -3630,6 +3960,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setGalleryModeEnabled: setGalleryModeEnabledAction,
     setPhotoCompression: setPhotoCompressionAction,
     setPhotoCloudServerEnabled: setPhotoCloudServerEnabledAction,
+    setPhotoGlassesStorageEnabled: setPhotoGlassesStorageEnabledAction,
     setPhotoAeExposureDivisor: setPhotoAeExposureDivisorAction,
     setPhotoIsoCap: setPhotoIsoCapAction,
     setPhotoNoiseReduction: setPhotoNoiseReductionAction,
@@ -4195,6 +4526,16 @@ function cacheBustedUrl(url: string) {
   return `${url}${url.includes('?') ? '&' : '?'}poll=${Date.now()}`;
 }
 
+function currentPhotoSource(destination: PhotoDestination): PhotoPreviewDetails['source'] {
+  if (destination === 'cloud') {
+    return 'Cloud server';
+  }
+  if (destination === 'glasses') {
+    return 'Glasses gallery';
+  }
+  return 'Phone receiver';
+}
+
 function requireGalleryServerUrl(status: GlassesRuntimeState, fallbackEnabled: boolean) {
   const baseUrl = galleryServerUrl(status, fallbackEnabled);
   if (!baseUrl) {
@@ -4240,6 +4581,48 @@ async function checkGalleryServerReachability(
   }
 }
 
+async function waitForGalleryServer(baseUrl: string, attempts: number, delayMs: number) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetchWithTimeout(
+        cacheBustedUrl(`${baseUrl}/api/health`),
+        {cache: 'no-store', headers: {'Cache-Control': 'no-cache', Pragma: 'no-cache'}},
+        1000,
+      );
+      if (response.status > 0) {
+        return true;
+      }
+    } catch {
+      // The hotspot can take a few seconds to become routable after the OS joins it.
+    }
+    if (attempt < attempts - 1) {
+      await delay(delayMs);
+    }
+  }
+  return false;
+}
+
+function showHotspotJoinExplanation(ssid: string) {
+  return new Promise<void>((resolve) => {
+    Alert.alert(
+      'Connect to Glasses',
+      Platform.OS === 'ios'
+        ? `When prompted, tap "Join" to connect to "${ssid}".`
+        : `When prompted, tap "Connect" to connect to "${ssid}".`,
+      [{text: 'OK', onPress: () => resolve()}],
+      {cancelable: false},
+    );
+  });
+}
+
+async function disconnectGlassesHotspotWifi(ssid: string) {
+  if (Platform.OS === 'ios') {
+    await WifiManager.disconnectFromSSID(ssid);
+    return;
+  }
+  await WifiManager.disconnect();
+}
+
 function androidRuntimePermissions() {
   const permissions = [
     PermissionsAndroid.PERMISSIONS.CAMERA,
@@ -4257,7 +4640,10 @@ function androidRuntimePermissions() {
   }
 
   if (Number(Platform.Version) >= 33) {
-    permissions.push(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+    permissions.push(
+      PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+      'android.permission.NEARBY_WIFI_DEVICES',
+    );
   }
 
   return permissions;
@@ -4517,6 +4903,20 @@ function delay(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function fetchWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, {...init, signal: controller.signal});
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function clampRounded(value: number, min: number, max: number) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -2991,7 +2991,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   async function prepareGlassesPhotoPreviewAction() {
-    await runAction('Connect to glasses hotspot', prepareGlassesPhotoPreviewConnection);
+    await runAction('Connect to glasses hotspot', () => prepareGlassesPhotoPreviewConnection(true));
   }
 
   async function disableGlassesPhotoPreviewConnection() {
@@ -3011,7 +3011,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
   }
 
-  async function prepareGlassesPhotoPreviewConnection() {
+  async function prepareGlassesPhotoPreviewConnection(restart = false) {
+    if (restart) {
+      galleryConnectionGenerationRef.current += 1;
+      galleryConnectionPromiseRef.current = null;
+      addEvent('LIVE', 'restarting glasses hotspot connection');
+    }
     if (galleryConnectionPromiseRef.current) {
       return galleryConnectionPromiseRef.current;
     }

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -107,6 +107,17 @@ function otaVersionInfoSignature(event: VersionInfoResult) {
   ].filter(Boolean).join('|') || 'version-unknown';
 }
 
+function otaAppIdentity(glasses: GlassesRuntimeState) {
+  if (!glasses.connected) {
+    return null;
+  }
+  return [glasses.device.buildNumber, glasses.device.appVersion].filter(Boolean).join('|') || null;
+}
+
+function otaVersionInfoAppIdentity(event: VersionInfoResult) {
+  return [event.buildNumber, event.appVersion].filter(Boolean).join('|') || null;
+}
+
 function versionValue(value: string | null | undefined) {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
@@ -723,6 +734,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const glassesConnectedRef = useRef(false);
   const glassesWifiConnectedRef = useRef(false);
   const otaDisplayProgressRef = useRef<{sessionId: string; percent: number} | null>(null);
+  const otaStartingAppIdentityRef = useRef<string | null>(null);
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
@@ -801,6 +813,25 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     setLatestVersionInfo(payload);
     setLatestVersionInfoSignature(otaVersionInfoSignature(payload));
+    const installedIdentity = otaVersionInfoAppIdentity(payload);
+    const otaStatus = otaStatusRef.current;
+    if (
+      installedIdentity &&
+      otaStartingAppIdentityRef.current &&
+      installedIdentity !== otaStartingAppIdentityRef.current &&
+      otaStatus?.status === 'in_progress' &&
+      otaStatus.phase === 'install'
+    ) {
+      otaStartingAppIdentityRef.current = null;
+      otaStatusRef.current = null;
+      setOtaStatus(null);
+      clearOtaDisplayProgress();
+      setOtaStatusMessage('OTA installed; checking for additional updates');
+      setOtaUpdateAvailable(false);
+      autoOtaCheckedConnectionRef.current = null;
+      setAutoOtaCheckRetryTick((tick) => tick + 1);
+      addEvent('LIVE', `OTA install restarted ASG client as ${installedIdentity}`);
+    }
   }
 
   useEffect(() => {
@@ -1247,6 +1278,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('LIVE', 'OTA check result ignored while update is in progress');
       return updateAvailable;
     }
+    otaStartingAppIdentityRef.current = null;
     clearOtaDisplayProgress();
     if (updateAvailable) {
       otaStatusRef.current = null;
@@ -1327,6 +1359,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }
       requireGlassesWifi('start OTA updates');
       postOtaCheckedSessionRef.current = null;
+      otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
       clearOtaDisplayProgress();
       await BluetoothSdk.startOtaUpdate();
       addEvent('LIVE', 'OTA start acknowledged');
@@ -3778,6 +3811,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       void disconnectGlassesHotspotWifi(hotspotSsid).catch(() => undefined);
     }
     otaStatusRef.current = null;
+    otaStartingAppIdentityRef.current = null;
     setOtaStatus(null);
     clearOtaDisplayProgress();
     setOtaStatusMessage(null);
@@ -3791,6 +3825,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   function applyOtaStatus(payload: OtaStatusEvent) {
     if (!isDisplayableOtaStatus(payload)) {
       otaStatusRef.current = null;
+      otaStartingAppIdentityRef.current = null;
       setOtaStatus(null);
       clearOtaDisplayProgress();
       setOtaStatusMessage('No active OTA');
@@ -3805,6 +3840,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setOtaDisplayPercent(displayPercent);
     setOtaStatusMessage(null);
     if (payload.status === 'complete' || payload.status === 'failed') {
+      otaStartingAppIdentityRef.current = null;
       setOtaUpdateAvailable(false);
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);


### PR DESCRIPTION
## Summary

This PR combines the saved-to-glasses photo preview flow with the example-app Bluetooth SDK 0.1.19 update.

- Adds a glasses-storage destination to the camera tab in the React Native, native Android, and native iOS examples.
- Prepares and joins the Mentra Live hotspot before capture rather than interrupting the user after the shutter fires.
- Keeps Capture disabled until the glasses gallery HTTP server is actually reachable.
- Saves photos on the glasses with no webhook URL, finds the saved gallery entry by request ID, downloads the JPEG over the hotspot, and renders it in the existing preview card.
- Updates all example dependency pins, including the React Native ElevenLabs example, from Bluetooth SDK 0.1.18 to 0.1.19.

## User flow

When **Save and preview from glasses** is enabled:

1. The app asks the Bluetooth SDK to enable the glasses hotspot.
2. It first probes the gallery server, allowing an already-connected phone to proceed without displaying connection UI.
3. If a connection is needed, the app displays the same short preflight explanation used by MentraOS gallery sync.
4. The platform Wi-Fi join prompt is presented.
5. The app polls the gallery HTTP server and enables Capture only after the server responds.
6. A capture uses an empty/null webhook URL with `save: true`.
7. After `photo_response`, the app polls `/api/gallery` for the matching request ID and downloads the returned JPEG.
8. The existing preview card displays the local downloaded image.

The fallback hotspot panel is visible only while readiness has not been established. It provides Retry, manual setup, SSID, and password controls. Once the gallery endpoint is reachable, the panel disappears.

Turning glasses-storage mode off releases the phone-side hotspot connection and asks the glasses to disable their hotspot. Pending connection attempts are invalidated so a late callback cannot overwrite the newly selected destination.

## Platform implementation

### React Native

- Adds `react-native-wifi-reborn`, matching the connection mechanism already exercised by MentraOS gallery sync.
- Adds its Expo config plugin plus explicit iOS hotspot/Wi-Fi entitlements and Android nearby-Wi-Fi permission.
- Uses the library's Android network binding and iOS `NEHotspotConfigurationManager` integration.

### Android

- Uses `WifiNetworkSpecifier` for Android 10 and newer.
- Holds the `NetworkCallback` while glasses-storage mode is active and binds process traffic to the local-only hotspot network.
- Releases the callback and process binding when the mode is disabled or the glasses disconnect.
- Android 9 falls back to the manual Wi-Fi controls because `WifiNetworkSpecifier` is unavailable there.

### iOS

- Uses `NEHotspotConfigurationManager` with a persistent hotspot configuration.
- Adds the Hotspot Configuration and Wi-Fi Information entitlements to both `project.yml` and the checked-in Xcode project.
- Treats the gallery HTTP probe, rather than the configuration callback alone, as proof that routing is ready.

## Bluetooth SDK 0.1.19

The following examples now target 0.1.19:

- Native Android Maven dependency
- Native iOS SwiftPM exact-version pin
- Main React Native npm dependency and Bun lock
- React Native ElevenLabs npm dependency and Bun lock

Mentra-Community/MentraOS#3403 has merged and triggered publication of the npm, Maven, and SwiftPM artifacts. npm 0.1.19 and the SwiftPM 0.1.19 tag are now public. Maven 0.1.19 is still publishing, so native Android registry validation remains publication-gated.

Both React Native Bun locks now contain the integrity published by npm for the final 0.1.19 tarball.

## Validation completed

Before applying the version-only 0.1.19 commit, the complete feature implementation passed:

- `bun install --frozen-lockfile` and `bun x tsc --noEmit` in `examples/react-native`
- Expo prebuild configuration verification for iOS hotspot entitlements and Android nearby-Wi-Fi permission
- `./gradlew :app:compileDebugKotlin --no-daemon` in `examples/android`
- Unsigned generic-device `xcodebuild` for the native iOS example
- Entitlements plist validation with `plutil`
- `git diff --check`

After combining the two commits:

- Confirmed every declared example SDK pin is 0.1.19.
- Confirmed no scoped 0.1.18 references remain.
- Installed the main React Native example from the public npm 0.1.19 package, with no source SDK symlink.
- Confirmed Gradle resolved `mentra-bluetooth-sdk (0.1.19)` plus the npm package's bundled `lc3Lib` and `silero` projects.
- Built, installed, and launched the React Native example on a physical Samsung SM-F956U1.
- Served the feature-worktree JavaScript bundle from Metro on port 8082 and confirmed the app reached its Device screen without fatal native or React Native errors.
- Re-ran frozen Bun installs for both React Native examples and `bun x tsc --noEmit` for the main React Native example against the published package.
- Fixed React Native OTA completion when an APK self-update restarts the ASG client before it can emit `ota_status: complete`: a changed ASG app/build identity now clears the stale install progress and allows the automatic availability check to run after Wi-Fi returns.
- Verified on the connected Android phone that the post-update auto-check runs, removes the 100% install card, and reports `Glasses firmware is up to date` when no additional update is available.
- `git diff --check` passes.

## Publication-gated validation

Once Maven 0.1.19 is visible publicly:

- Compile the native Android example against Maven Central 0.1.19.
- Exercise the complete connection, capture, download, and toggle-off lifecycle with a connected Mentra Live.

## Risk and limitations

The SDK version changes are pin-only. The behavioral risk is isolated to the new optional glasses-storage destination. Existing phone-receiver and cloud-webhook destinations retain their previous capture paths.

The operating systems still own the first connection approval. The examples can request the connection and verify readiness, but they cannot bypass a user denial. Manual controls remain available for that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New hotspot join, process network binding, and gallery HTTP polling add platform- and timing-sensitive behavior, though phone-receiver and cloud upload paths are unchanged and the SDK bump is pin-only.
> 
> **Overview**
> Adds a **Save and preview from glasses** photo destination across the Android, iOS, and React Native examples, and bumps all example Bluetooth SDK pins from **0.1.19** (was 0.1.18).
> 
> When that mode is on, the app turns on the glasses hotspot, probes the on-glasses gallery HTTP server, and only then enables capture—without requiring glasses Wi‑Fi for upload. It joins the hotspot via platform APIs (`WifiNetworkSpecifier` + process network binding on Android 10+, `NEHotspotConfiguration` on iOS, `react-native-wifi-reborn` on RN), shows a short join/approval UI, and tears down the connection when the mode is turned off or glasses disconnect.
> 
> Capture uses `requestPhoto` with **no webhook** and **`save: true`**, then polls `/api/gallery` by request ID, downloads the JPEG over the hotspot, and shows it in the existing preview card (including a “saved on glasses / downloading” state). Camera UI gains destination toggles, a hotspot help panel, and updated SDK sample snippets; Android/iOS/RN gain Wi‑Fi permissions and iOS hotspot entitlements.
> 
> The React Native Android run script now defaults to the **published npm** SDK (optional `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH` override) instead of auto-symlinking a local checkout. Minor RN **OTA** card copy/styling changes are included on the Device screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce15a1c1e1a14f70e1172fbc27574090afbfd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

