### PR TITLE
Harden hotspot photo previews and OTA completion across examples

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
@@ -15,7 +15,10 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resumeWithException
 
-class GlassesHotspotConnector(context: Context) {
+class GlassesHotspotConnector(
+    context: Context,
+    private val onConnectionLost: () -> Unit,
+) {
     private val connectivityManager =
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private var callback: ConnectivityManager.NetworkCallback? = null
@@ -62,7 +65,9 @@ class GlassesHotspotConnector(context: Context) {
                     }
 
                     override fun onLost(network: Network) {
-                        connectivityManager.bindProcessToNetwork(null)
+                        if (callback !== this) return
+                        releaseNetwork()
+                        onConnectionLost()
                     }
                 }
                 callback = networkCallback
@@ -81,9 +86,10 @@ class GlassesHotspotConnector(context: Context) {
 
     private fun releaseNetwork() {
         connectivityManager.bindProcessToNetwork(null)
-        callback?.let { current ->
+        val current = callback
+        callback = null
+        current?.let {
             runCatching { connectivityManager.unregisterNetworkCallback(current) }
         }
-        callback = null
     }
 }

--- a/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/GlassesHotspotConnector.kt
@@ -17,14 +17,14 @@ import kotlin.coroutines.resumeWithException
 
 class GlassesHotspotConnector(
     context: Context,
-    private val onConnectionLost: () -> Unit,
+    private val onConnectionLost: (Int) -> Unit,
 ) {
     private val connectivityManager =
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private var callback: ConnectivityManager.NetworkCallback? = null
     private var pendingContinuation: CancellableContinuation<Unit>? = null
 
-    suspend fun connect(ssid: String, password: String) {
+    suspend fun connect(ssid: String, password: String, connectionGeneration: Int) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             throw IOException("Automatic hotspot connection requires Android 10 or newer.")
         }
@@ -67,7 +67,7 @@ class GlassesHotspotConnector(
                     override fun onLost(network: Network) {
                         if (callback !== this) return
                         releaseNetwork()
-                        onConnectionLost()
+                        onConnectionLost(connectionGeneration)
                     }
                 }
                 callback = networkCallback

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -319,9 +319,11 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private val cloudUrlPrefs =
         appContext.getSharedPreferences("mentra_example_cloud_urls", Context.MODE_PRIVATE)
     private val mentraBluetoothSdk = MentraBluetoothSdk.create(appContext, this)
-    private val glassesHotspotConnector = GlassesHotspotConnector(appContext)
     private val controllerJob = Job()
     private val scope = CoroutineScope(Dispatchers.Main + controllerJob)
+    private val glassesHotspotConnector = GlassesHotspotConnector(appContext) {
+        scope.launch { handleGlassesHotspotConnectionLost() }
+    }
     private val photoUploadServer = LocalPhotoUploadServer(
         appContext,
         onLog = { message -> scope.launch { addEvent("HTTP", message) } },
@@ -334,6 +336,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var galleryConnectionGeneration = 0
     private var pendingHotspotConnection: PendingHotspotConnection? = null
     private var hotspotJoinExplanationShown = false
+    private var photoDestinationBeforeGlasses = PhotoDestination.THIS_PHONE
     private var videoPollGeneration = 0
     private var directPhotoTimeoutJob: Job? = null
     private var gStreamerWhipReceiver: GStreamerWhipReceiver? = null
@@ -366,6 +369,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var photoCaptureDefaultsSyncGeneration = 0
     private var otaDisplayProgressSessionKey: String? = null
     private var otaDisplayOverallPercent: Int? = null
+    private var otaStartingAppIdentity: String? = null
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String? = null
 
@@ -559,11 +563,24 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         savePersistedCloudUrls()
     }
 
-    fun setPhotoDestination(destination: PhotoDestination) {
+    fun setPhotoDestination(requestedDestination: PhotoDestination) {
+        val destination = if (
+            state.photoDestination == PhotoDestination.GLASSES_STORAGE &&
+            requestedDestination == PhotoDestination.THIS_PHONE
+        ) {
+            photoDestinationBeforeGlasses
+        } else {
+            requestedDestination
+        }
         if (state.photoDestination == destination) {
             return
         }
         val wasGlassesStorage = state.photoDestination == PhotoDestination.GLASSES_STORAGE
+        if (destination == PhotoDestination.GLASSES_STORAGE && !wasGlassesStorage) {
+            photoDestinationBeforeGlasses = state.photoDestination
+        } else if (destination != PhotoDestination.GLASSES_STORAGE) {
+            photoDestinationBeforeGlasses = destination
+        }
         stopPhonePhotoServer()
         state = state.copy(
             cameraStatus = when (destination) {
@@ -598,6 +615,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     fun prepareGlassesPhotoPreview() = runAction("Connect to glasses hotspot") {
+        galleryConnectionGeneration += 1
+        glassesHotspotConnector.disconnect()
         prepareGlassesPhotoPreviewConnection()
     }
 
@@ -639,7 +658,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             baseUrl = "http://${hotspot.localIp}:8089",
         )
         pendingHotspotConnection = pending
-        if (waitForGalleryServer(pending.baseUrl, attempts = 3, delayMs = 400)) {
+        val alreadyReady = waitForGalleryServer(pending.baseUrl, attempts = 3, delayMs = 400)
+        if (generation != galleryConnectionGeneration) return
+        if (alreadyReady) {
             markGalleryServerReady(pending.baseUrl)
             return
         }
@@ -671,7 +692,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 glassesHotspotConnector.connect(pending.ssid, pending.password)
             }
             if (generation != galleryConnectionGeneration) return
-            if (!waitForGalleryServer(pending.baseUrl, attempts = 20, delayMs = 500)) {
+            val ready = waitForGalleryServer(pending.baseUrl, attempts = 20, delayMs = 500)
+            if (generation != galleryConnectionGeneration) return
+            if (!ready) {
                 throw IOException("Could not reach the glasses gallery after connecting.")
             }
             markGalleryServerReady(pending.baseUrl)
@@ -702,6 +725,18 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             hotspotJoinPromptSsid = null,
         )
         addEvent("LIVE", "gallery server ready $baseUrl")
+    }
+
+    private fun handleGlassesHotspotConnectionLost() {
+        galleryConnectionGeneration += 1
+        pendingHotspotConnection = null
+        if (state.photoDestination != PhotoDestination.GLASSES_STORAGE) return
+        state = state.copy(
+            cameraStatus = "Camera: reconnect to the glasses hotspot to enable capture",
+            galleryServerReachable = false,
+            galleryServerStatus = "Gallery server: hotspot connection lost",
+        )
+        addEvent("LIVE", "glasses hotspot connection lost")
     }
 
     fun setPhotoSize(size: String) {
@@ -1046,6 +1081,11 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             throw error
         }
         handlePhotoResponse(responseEvent)
+        if (responseEvent.response is PhotoResponse.Error) {
+            activePhotoRequestId = null
+            val error = responseEvent.response as PhotoResponse.Error
+            throw IOException(error.errorCode ?: error.errorMessage)
+        }
         state = state.copy(
             cameraStatus = "Camera: photo saved on glasses; loading preview",
             photoPreviewDetails = state.photoPreviewDetails?.copy(state = "saved"),
@@ -1097,8 +1137,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         requestId: String,
         generation: Int,
     ) {
-        val baseUrl = pendingHotspotConnection?.baseUrl
-            ?: galleryServerUrl(state.glassesStatus, state.hotspotEnabled)
+        val baseUrl = galleryServerUrl(state.glassesStatus, state.hotspotEnabled)
+            ?: pendingHotspotConnection?.baseUrl
             ?: throw IllegalStateException("The glasses hotspot is not ready for preview downloads.")
         if (state.galleryServerReachable != true) {
             throw IllegalStateException("The glasses hotspot is not ready for preview downloads.")
@@ -1154,9 +1194,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             } catch (error: Throwable) {
                 if (attempt == 0 || attempt % 10 == 9) {
                     state = state.copy(
-                        cameraStatus = "Camera: join ${galleryHotspotSsidLabel(state.glassesStatus)} to load the saved photo",
-                        galleryServerReachable = false,
-                        galleryServerStatus = "Gallery server: not reachable. Join ${galleryHotspotSsidLabel(state.glassesStatus)}.",
+                        cameraStatus = "Camera: photo saved on glasses; waiting for preview",
+                        galleryServerStatus = "Gallery server: connected; waiting for $requestId",
                     )
                     addEvent("LIVE", "waiting for glasses photo $requestId: ${error.message}")
                 }
@@ -2398,6 +2437,26 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     override fun onVersionInfo(event: VersionInfoResult) {
         latestOtaVersionInfoSignature = event.otaVersionInfoSignature()
+        val installedIdentity = event.otaAppIdentity()
+        val currentOtaStatus = state.otaStatus
+        if (
+            installedIdentity != null &&
+            otaStartingAppIdentity != null &&
+            installedIdentity != otaStartingAppIdentity &&
+            currentOtaStatus?.status == "in_progress" &&
+            currentOtaStatus.phase == "install"
+        ) {
+            otaStartingAppIdentity = null
+            resetOtaDisplayProgress()
+            autoOtaCheckedConnectionKey = null
+            state = state.copy(
+                otaStatus = null,
+                otaDisplayPercent = null,
+                otaStatusMessage = "OTA installed; checking for additional updates",
+                otaUpdateAvailable = false,
+            )
+            addEvent("LIVE", "OTA install restarted ASG client as $installedIdentity")
+        }
         maybeAutoCheckOta()
     }
 
@@ -2406,6 +2465,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             addEvent("LIVE", "OTA check result ignored while update is in progress")
             return updateAvailable
         }
+        otaStartingAppIdentity = null
         if (updateAvailable) {
             resetOtaDisplayProgress()
             state = state.copy(
@@ -2531,6 +2591,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         requireConnected("start OTA")
         requireGlassesWifi("start OTA updates")
         postOtaCheckedSessionKey = null
+        otaStartingAppIdentity = state.glassesStatus.otaAppIdentity()
         resetOtaDisplayProgress()
         state = state.copy(otaDisplayPercent = null)
         withContext(Dispatchers.IO) { mentraBluetoothSdk.startOtaUpdate() }
@@ -2967,6 +3028,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         galleryConnectionGeneration += 1
         pendingHotspotConnection = null
         glassesHotspotConnector.disconnect()
+        otaStartingAppIdentity = null
         resetOtaDisplayProgress()
         if (hadPhotoRequest) {
             pollGeneration += 1
@@ -3017,6 +3079,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     private fun applyOtaStatus(event: OtaStatusEvent) {
         if (!isDisplayableOtaStatus(event)) {
+            otaStartingAppIdentity = null
             resetOtaDisplayProgress()
             state = state.copy(
                 otaStatus = null,
@@ -3034,6 +3097,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             otaStatusMessage = null,
             otaUpdateAvailable = if (event.status == "complete" || event.status == "failed") false else state.otaUpdateAvailable,
         )
+        if (event.status == "complete" || event.status == "failed") {
+            otaStartingAppIdentity = null
+        }
         addEvent("LIVE", "OTA ${event.status.ifBlank { "status" }} ${event.overallPercent}%")
         schedulePostOtaCheck(event)
     }
@@ -3981,6 +4047,20 @@ fun VersionInfoResult.otaVersionInfoSignature(): String =
         firmwareVersion,
     ).filter { it.isNotBlank() }.joinToString("|").ifBlank { "version-unknown" }
 
+fun GlassesRuntimeState?.otaAppIdentity(): String? =
+    connectedGlassesInfo(this)?.let { device ->
+        listOfNotNull(device.buildNumber, device.appVersion)
+            .filter { it.isNotBlank() }
+            .joinToString("|")
+            .ifBlank { null }
+    }
+
+fun VersionInfoResult.otaAppIdentity(): String? =
+    listOf(buildNumber, appVersion)
+        .filter { it.isNotBlank() }
+        .joinToString("|")
+        .ifBlank { null }
+
 fun deviceLabel(status: GlassesRuntimeState?): String =
     connectedGlassesInfo(status)?.bluetoothName
         ?: connectedGlassesInfo(status)?.serialNumber
@@ -4113,7 +4193,7 @@ private fun PhotoPreviewDetails?.copyForAck(
     (this ?: PhotoPreviewDetails(source = source, state = "acknowledged")).copy(
         requestId = requestId,
         source = source,
-        state = if (this?.state == "preview") "preview" else "acknowledged",
+        state = if (this?.state == "preview" || this?.state == "saved") this.state else "acknowledged",
         timestamp = timestamp,
         uploadUrl = uploadUrl,
     )

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -1145,19 +1145,25 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (state.galleryServerReachable != true) {
             throw IllegalStateException("The glasses hotspot is not ready for preview downloads.")
         }
+        val galleryGeneration = galleryConnectionGeneration
 
         val localFile = File(appContext.cacheDir, "mentra-gallery-$requestId.jpg")
         state = state.copy(galleryServerStatus = "Gallery server: finding $requestId")
         var consecutiveFailures = 0
 
         repeat(GLASSES_PHOTO_POLL_ATTEMPTS) { attempt ->
-            if (activePhotoRequestId != requestId || pollGeneration != generation) {
+            if (
+                activePhotoRequestId != requestId ||
+                pollGeneration != generation ||
+                galleryConnectionGeneration != galleryGeneration
+            ) {
                 return
             }
             try {
                 val photo = withContext(Dispatchers.IO) {
                     findGalleryPhoto(baseUrl, requestId)
                 }
+                if (galleryConnectionGeneration != galleryGeneration) return
                 consecutiveFailures = 0
                 state = state.copy(
                     galleryServerReachable = true,
@@ -1174,6 +1180,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 val contentType = withContext(Dispatchers.IO) {
                     downloadGalleryFile(remoteUrl, localFile)
                 }
+                if (galleryConnectionGeneration != galleryGeneration) return
                 val dimensions = imageDimensions(localFile)
                 val previewUri = Uri.fromFile(localFile).toString()
                 activePhotoRequestId = null
@@ -1196,6 +1203,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 addEvent("LIVE", "glasses photo downloaded ${photo.name}")
                 return
             } catch (error: Throwable) {
+                if (galleryConnectionGeneration != galleryGeneration) return
                 consecutiveFailures += 1
                 val transportUnavailable = consecutiveFailures >= GLASSES_GALLERY_FAILURE_THRESHOLD
                 if (attempt == 0 || attempt % 10 == 9) {

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -234,7 +234,6 @@ data class MentraExampleState(
     val galleryModeEnabled: Boolean = false,
     val galleryServerReachable: Boolean? = null,
     val galleryServerStatus: String = "Gallery server: enable hotspot to check",
-    val hotspotJoinPromptSsid: String? = null,
     val glassesStatus: GlassesRuntimeState? = null,
     val glassesMediaVolume: Int? = null,
     val glassesVolumeStatus: String = "Glasses volume: not checked",
@@ -336,7 +335,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var pollGeneration = 0
     private var galleryConnectionGeneration = 0
     private var pendingHotspotConnection: PendingHotspotConnection? = null
-    private var hotspotJoinExplanationShown = false
     private var photoDestinationBeforeGlasses = PhotoDestination.THIS_PHONE
     private var videoPollGeneration = 0
     private var directPhotoTimeoutJob: Job? = null
@@ -605,7 +603,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         state = state.copy(
             galleryServerReachable = null,
             galleryServerStatus = "Gallery server: hotspot off",
-            hotspotJoinPromptSsid = null,
         )
         runAction("Disable glasses photo hotspot") {
             glassesHotspotConnector.disconnect()
@@ -621,23 +618,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         prepareGlassesPhotoPreviewConnection()
     }
 
-    fun confirmHotspotJoin() {
-        hotspotJoinExplanationShown = true
-        state = state.copy(hotspotJoinPromptSsid = null)
-        runAction("Join glasses hotspot") {
-            connectPendingGlassesHotspot()
-        }
-    }
-
-    fun dismissHotspotJoin() {
-        state = state.copy(
-            galleryServerReachable = false,
-            galleryServerStatus = "Gallery server: connection required",
-            hotspotJoinPromptSsid = null,
-            cameraStatus = "Camera: connect to the glasses hotspot to enable capture",
-        )
-    }
-
     private suspend fun prepareGlassesPhotoPreviewConnection() {
         requireConnected("prepare saved-photo previews")
         val generation = ++galleryConnectionGeneration
@@ -645,7 +625,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             cameraStatus = "Camera: preparing glasses hotspot",
             galleryServerReachable = null,
             galleryServerStatus = "Gallery server: starting glasses hotspot",
-            hotspotJoinPromptSsid = null,
         )
         val existing = enabledHotspotStatus(state.glassesStatus)
         val hotspot = existing ?: withContext(Dispatchers.IO) {
@@ -663,15 +642,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (generation != galleryConnectionGeneration) return
         if (alreadyReady) {
             markGalleryServerReady(pending.baseUrl)
-            return
-        }
-        if (!hotspotJoinExplanationShown) {
-            state = state.copy(
-                cameraStatus = "Camera: approve the glasses hotspot connection",
-                galleryServerReachable = false,
-                galleryServerStatus = "Gallery server: approval required for ${pending.ssid}",
-                hotspotJoinPromptSsid = pending.ssid,
-            )
             return
         }
         connectPendingGlassesHotspot()
@@ -723,7 +693,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             cameraStatus = "Camera: ready to save and preview from glasses",
             galleryServerReachable = true,
             galleryServerStatus = "Gallery server: ready at $baseUrl",
-            hotspotJoinPromptSsid = null,
         )
         addEvent("LIVE", "gallery server ready $baseUrl")
     }
@@ -3071,7 +3040,6 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             glassesVolumeStatus = "Glasses volume: not connected",
             galleryServerReachable = null,
             galleryServerStatus = "Gallery server: connect glasses first",
-            hotspotJoinPromptSsid = null,
             streamRequested = false,
             streamPreviewReady = false,
             streamStartedAt = null,

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -216,6 +216,7 @@ const val CAMERA_WARM_UP_DURATION_MS = 30_000
 const val CAMERA_WARM_UP_REFRESH_MS = 20_000L
 const val CAMERA_WARM_UP_DISCONNECTED_RETRY_MS = 2_000L
 const val GLASSES_PHOTO_POLL_ATTEMPTS = 120
+const val GLASSES_GALLERY_FAILURE_THRESHOLD = 3
 val photoAeExposureDivisorOptions = listOf(2, 3, 5)
 val photoIsoCapOptions = listOf(400, 800, 1600)
 val photoIspDigitalGainOptions = listOf(0, 1, 2, 4)
@@ -321,8 +322,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private val mentraBluetoothSdk = MentraBluetoothSdk.create(appContext, this)
     private val controllerJob = Job()
     private val scope = CoroutineScope(Dispatchers.Main + controllerJob)
-    private val glassesHotspotConnector = GlassesHotspotConnector(appContext) {
-        scope.launch { handleGlassesHotspotConnectionLost() }
+    private val glassesHotspotConnector = GlassesHotspotConnector(appContext) { connectionGeneration ->
+        scope.launch { handleGlassesHotspotConnectionLost(connectionGeneration) }
     }
     private val photoUploadServer = LocalPhotoUploadServer(
         appContext,
@@ -689,7 +690,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         )
         try {
             withContext(Dispatchers.IO) {
-                glassesHotspotConnector.connect(pending.ssid, pending.password)
+                glassesHotspotConnector.connect(pending.ssid, pending.password, generation)
             }
             if (generation != galleryConnectionGeneration) return
             val ready = waitForGalleryServer(pending.baseUrl, attempts = 20, delayMs = 500)
@@ -727,7 +728,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("LIVE", "gallery server ready $baseUrl")
     }
 
-    private fun handleGlassesHotspotConnectionLost() {
+    private fun handleGlassesHotspotConnectionLost(connectionGeneration: Int) {
+        if (connectionGeneration != galleryConnectionGeneration) return
         galleryConnectionGeneration += 1
         pendingHotspotConnection = null
         if (state.photoDestination != PhotoDestination.GLASSES_STORAGE) return
@@ -1146,6 +1148,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
         val localFile = File(appContext.cacheDir, "mentra-gallery-$requestId.jpg")
         state = state.copy(galleryServerStatus = "Gallery server: finding $requestId")
+        var consecutiveFailures = 0
 
         repeat(GLASSES_PHOTO_POLL_ATTEMPTS) { attempt ->
             if (activePhotoRequestId != requestId || pollGeneration != generation) {
@@ -1155,6 +1158,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 val photo = withContext(Dispatchers.IO) {
                     findGalleryPhoto(baseUrl, requestId)
                 }
+                consecutiveFailures = 0
                 state = state.copy(
                     galleryServerReachable = true,
                     galleryServerStatus = "Gallery server: connected; finding $requestId",
@@ -1192,12 +1196,29 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 addEvent("LIVE", "glasses photo downloaded ${photo.name}")
                 return
             } catch (error: Throwable) {
+                consecutiveFailures += 1
+                val transportUnavailable = consecutiveFailures >= GLASSES_GALLERY_FAILURE_THRESHOLD
                 if (attempt == 0 || attempt % 10 == 9) {
                     state = state.copy(
-                        cameraStatus = "Camera: photo saved on glasses; waiting for preview",
-                        galleryServerStatus = "Gallery server: connected; waiting for $requestId",
+                        cameraStatus = if (transportUnavailable) {
+                            "Camera: reconnect to the glasses hotspot to load the saved photo"
+                        } else {
+                            "Camera: photo saved on glasses; waiting for preview"
+                        },
+                        galleryServerReachable = if (transportUnavailable) false else state.galleryServerReachable,
+                        galleryServerStatus = if (transportUnavailable) {
+                            "Gallery server: ${error.message ?: "not reachable"}"
+                        } else {
+                            "Gallery server: connected; waiting for $requestId"
+                        },
                     )
                     addEvent("LIVE", "waiting for glasses photo $requestId: ${error.message}")
+                } else if (transportUnavailable && state.galleryServerReachable != false) {
+                    state = state.copy(
+                        cameraStatus = "Camera: reconnect to the glasses hotspot to load the saved photo",
+                        galleryServerReachable = false,
+                        galleryServerStatus = "Gallery server: ${error.message ?: "not reachable"}",
+                    )
                 }
             }
             delay(1_000)

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -152,12 +152,17 @@ fun CameraScreen(controller: MentraExampleController) {
     }
     state.hotspotJoinPromptSsid?.let { ssid ->
         AlertDialog(
-            onDismissRequest = {},
+            onDismissRequest = controller::dismissHotspotJoin,
             title = { Text("Connect to Glasses") },
             text = { Text("When prompted, tap Connect to connect to \"$ssid\".") },
             confirmButton = {
                 TextButton(onClick = controller::confirmHotspotJoin) {
                     Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = controller::dismissHotspotJoin) {
+                    Text("Not now")
                 }
             },
         )

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -18,11 +18,9 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Icon
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -149,23 +147,6 @@ fun CameraScreen(controller: MentraExampleController) {
             state.activeAction == "Capture & upload" ||
                 state.activeAction == "Capture scan photo" -> captureMode = CameraCaptureMode.PHOTO
         }
-    }
-    state.hotspotJoinPromptSsid?.let { ssid ->
-        AlertDialog(
-            onDismissRequest = controller::dismissHotspotJoin,
-            title = { Text("Connect to Glasses") },
-            text = { Text("When prompted, tap Connect to connect to \"$ssid\".") },
-            confirmButton = {
-                TextButton(onClick = controller::confirmHotspotJoin) {
-                    Text("OK")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = controller::dismissHotspotJoin) {
-                    Text("Not now")
-                }
-            },
-        )
     }
     Column(modifier = Modifier.fillMaxSize().background(AppColor.bg).verticalScroll(rememberScrollState())) {
         PageHeader("Camera")

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -13,12 +13,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -297,8 +297,12 @@ private fun isOtaInProgress(state: com.mentra.examples.android.MentraExampleStat
     state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
 
 private fun otaStatusLine(state: com.mentra.examples.android.MentraExampleState): String =
-    state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${otaDisplayPercent(state)}%" }
-        ?: if (state.otaUpdateAvailable) "Update required" else null
+    if (isOtaInstalling(state)) {
+        "installing update"
+    } else {
+        state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${otaDisplayPercent(state)}%" }
+    }
+        ?: if (state.otaUpdateAvailable) "Firmware update available" else null
         ?: state.otaStatusMessage
         ?: if (isGlassesConnected(state.glassesStatus)) "Check not run" else "Connect glasses"
 
@@ -308,21 +312,28 @@ private fun otaDisplayPercent(state: com.mentra.examples.android.MentraExampleSt
 private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState): String =
     when {
         state.otaStatus?.status == "failed" -> "Update failed"
+        isOtaInstalling(state) -> "Installing update"
         state.otaStatus != null && isOtaInProgress(state) -> "Updating ${state.otaStatus.stepType.ifBlank { "firmware" }}"
-        state.otaUpdateAvailable -> "Update required"
+        state.otaUpdateAvailable -> "Firmware update available"
         else -> "OTA status"
     }
 
 private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState): String {
     state.otaStatus?.errorMessage?.let { return it }
+    if (isOtaInstalling(state)) {
+        return "The glasses client may restart to finish installation."
+    }
     state.otaStatus?.let {
         return "${it.phase.ifBlank { "status" }} · step ${it.currentStep}/${it.totalSteps}"
     }
     if (state.otaUpdateAvailable) {
-        return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
+        return "A newer firmware version is available for these glasses."
     }
     return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
 }
+
+private fun isOtaInstalling(state: com.mentra.examples.android.MentraExampleState): Boolean =
+    state.otaStatus?.status == "in_progress" && state.otaStatus.phase == "install"
 
 @Composable
 private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Modifier) {
@@ -330,22 +341,18 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
     if (state.otaStatus == null && !state.otaUpdateAvailable) return
     val percent = otaDisplayPercent(state)
     val updateRequired = state.otaUpdateAvailable && state.otaStatus == null
+    val installing = isOtaInstalling(state)
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .then(if (updateRequired) Modifier.shadow(8.dp, RoundedCornerShape(16.dp)) else Modifier)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(
-                if (updateRequired) {
-                    Brush.verticalGradient(listOf(Color(0xFFFFF5DF), Color(0xFFFFE6E1)))
-                } else {
-                    Brush.verticalGradient(listOf(Color.White, Color.White))
-                }
+                if (updateRequired) Color(0xFFFFFCF5) else Color.White
             )
             .border(
                 1.dp,
-                if (updateRequired) AppColor.red.copy(alpha = 0.34f) else Color.White.copy(alpha = 0.7f),
-                RoundedCornerShape(16.dp)
+                if (updateRequired) AppColor.amber.copy(alpha = 0.32f) else AppColor.ink.copy(alpha = 0.08f),
+                RoundedCornerShape(12.dp)
             )
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(9.dp),
@@ -354,49 +361,55 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
             Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 if (updateRequired) {
                     Box(
-                        modifier = Modifier.size(34.dp).clip(CircleShape).background(AppColor.red),
+                        modifier = Modifier.size(30.dp).clip(RoundedCornerShape(7.dp)).background(AppColor.amber.copy(alpha = 0.10f)),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Icon(Icons.Outlined.Warning, null, tint = Color.White, modifier = Modifier.size(18.dp))
+                        Icon(Icons.Outlined.Warning, null, tint = AppColor.amber, modifier = Modifier.size(16.dp))
                     }
                 }
                 Column(modifier = Modifier.weight(1f)) {
-                    Eyebrow(if (updateRequired) "ACTION NEEDED" else "OTA", color = if (updateRequired) AppColor.red else AppColor.muted)
+                    Eyebrow(if (updateRequired) "OTA UPDATE" else "OTA", color = if (updateRequired) Color(0xFF9A5A00) else AppColor.muted)
                     Text(
                         otaCardTitle(state),
-                        color = AppColor.inkAlt,
-                        fontSize = if (updateRequired) 19.sp else 15.sp,
-                        fontWeight = if (updateRequired) FontWeight.ExtraBold else FontWeight.Bold,
+                        color = AppColor.ink,
+                        fontSize = if (updateRequired) 16.sp else 15.sp,
+                        fontWeight = FontWeight.Bold,
                     )
                 }
             }
-            if (state.otaStatus != null) {
-                Text("$percent%", color = AppColor.greenInk, fontSize = 20.sp, fontWeight = FontWeight.ExtraBold)
+            if (installing) {
+                CircularProgressIndicator(
+                    color = AppColor.greenPrimary,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(18.dp),
+                )
+            } else if (state.otaStatus != null) {
+                Text("$percent%", color = AppColor.greenInk, fontSize = 15.sp, fontWeight = FontWeight.Bold)
             }
         }
-        if (state.otaStatus != null) {
-            Box(modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(999.dp)).background(AppColor.greenInk.copy(alpha = 0.08f))) {
+        if (state.otaStatus != null && !installing) {
+            Box(modifier = Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)).background(AppColor.greenInk.copy(alpha = 0.08f))) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth((percent.coerceIn(0, 100) / 100f))
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(999.dp))
+                        .height(4.dp)
+                        .clip(RoundedCornerShape(2.dp))
                         .background(AppColor.greenPrimary)
                 )
             }
         }
         Text(
             otaCardDetail(state),
-            color = if (updateRequired) Color(0xFF5F201B) else AppColor.muted,
-            fontSize = if (updateRequired) 13.sp else 12.sp,
-            lineHeight = if (updateRequired) 18.sp else 16.sp,
-            fontWeight = if (updateRequired) FontWeight.Bold else FontWeight.Medium,
+            color = AppColor.muted,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+            fontWeight = FontWeight.Medium,
         )
         if (updateRequired) {
             DarkBtn(
                 if (canStartOta(state)) "Start OTA" else "Connect Wi-Fi first",
                 Icons.Outlined.FileDownload,
-                AppColor.red,
+                AppColor.greenInk,
                 Modifier.fillMaxWidth(),
                 enabled = canStartOta(state),
                 onClick = controller::startOtaUpdate,

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -350,7 +350,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private let glassesHotspotConnector = GlassesHotspotConnector()
     private var galleryConnectionGeneration = 0
     private var pendingHotspotConnection: PendingHotspotConnection?
-    private var hotspotJoinExplanationShown = false
     private var photoDestinationBeforeGlasses: PhotoDestination = .thisPhone
     private var streamConfigurationChangeInProgress = false
     private var photoCaptureDefaultsSyncGeneration = 0
@@ -417,7 +416,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var hotspotEnabled = false
     @Published private(set) var galleryServerReachable: Bool?
     @Published private(set) var galleryServerStatus = "Gallery server: enable hotspot to check"
-    @Published private(set) var hotspotJoinPromptSsid: String?
     @Published private(set) var micRecording = false
     @Published private(set) var micPlaying = false
     @Published private(set) var micElapsedSeconds = 0
@@ -753,7 +751,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         pendingHotspotConnection = nil
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: hotspot off"
-        hotspotJoinPromptSsid = nil
         runAsyncAction("Disable glasses photo hotspot") { [self] in
             if let hotspotSsid {
                 glassesHotspotConnector.disconnect(ssid: hotspotSsid)
@@ -774,21 +771,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    func confirmHotspotJoin() {
-        hotspotJoinExplanationShown = true
-        hotspotJoinPromptSsid = nil
-        runAsyncAction("Join glasses hotspot") { [self] in
-            try await connectPendingGlassesHotspot()
-        }
-    }
-
-    func dismissHotspotJoin() {
-        hotspotJoinPromptSsid = nil
-        galleryServerReachable = false
-        galleryServerStatus = "Gallery server: connection required"
-        cameraStatus = "Camera: connect to the glasses hotspot to enable capture"
-    }
-
     private func prepareGlassesPhotoPreviewConnection() async throws {
         try requireConnected("prepare saved-photo previews")
         galleryConnectionGeneration += 1
@@ -796,7 +778,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         cameraStatus = "Camera: preparing glasses hotspot"
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: starting glasses hotspot"
-        hotspotJoinPromptSsid = nil
 
         let hotspot: (ssid: String, password: String, localIp: String)
         if let current = enabledHotspotStatus(glassesValues) {
@@ -820,13 +801,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         guard generation == galleryConnectionGeneration else { return }
         if alreadyReady {
             markGalleryServerReady(pending.baseUrl)
-            return
-        }
-        if !hotspotJoinExplanationShown {
-            cameraStatus = "Camera: approve the glasses hotspot connection"
-            galleryServerReachable = false
-            galleryServerStatus = "Gallery server: approval required for \(pending.ssid)"
-            hotspotJoinPromptSsid = pending.ssid
             return
         }
         try await connectPendingGlassesHotspot()
@@ -875,7 +849,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         cameraStatus = "Camera: ready to save and preview from glasses"
         galleryServerReachable = true
         galleryServerStatus = "Gallery server: ready at \(baseUrl)"
-        hotspotJoinPromptSsid = nil
         append(tag: "LIVE", text: "gallery server ready \(baseUrl)")
     }
 
@@ -2758,7 +2731,6 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         pendingHotspotConnection = nil
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
-        hotspotJoinPromptSsid = nil
         otaStartingAppIdentity = nil
         resetOtaDisplayProgress()
         otaStatus = nil

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -112,6 +112,7 @@ let photoIsoCapOptions = [400, 800, 1600]
 let photoIspDigitalGainOptions = [0, 1, 2, 4]
 let photoIspAnalogGainOptions = ["low"]
 let glassesPhotoPollAttempts = 120
+let glassesGalleryFailureThreshold = 3
 let cameraRoiPositions: [(label: String, value: Int)] = [("Center", 0), ("Bottom", 1), ("Top", 2)]
 
 enum PhotoDestination {
@@ -1278,10 +1279,12 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
 
         galleryServerStatus = "Gallery server: finding \(requestId)"
+        var consecutiveFailures = 0
         for attempt in 0 ..< glassesPhotoPollAttempts {
             guard activePhotoRequestId == requestId, pollGeneration == generation else { return }
             do {
                 let photo = try await findGalleryPhoto(baseUrl: baseUrl, requestId: requestId)
+                consecutiveFailures = 0
                 galleryServerReachable = true
                 galleryServerStatus = "Gallery server: connected; finding \(requestId)"
                 guard let photo else {
@@ -1332,10 +1335,21 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 append(tag: "LIVE", text: "glasses photo downloaded \(photo.name)")
                 return
             } catch {
+                consecutiveFailures += 1
+                let transportUnavailable = consecutiveFailures >= glassesGalleryFailureThreshold
                 if attempt == 0 || attempt % 10 == 9 {
-                    galleryServerStatus = "Gallery server: connected; waiting for \(requestId)"
-                    cameraStatus = "Camera: photo saved on glasses; waiting for preview"
+                    galleryServerReachable = transportUnavailable ? false : galleryServerReachable
+                    galleryServerStatus = transportUnavailable
+                        ? "Gallery server: \(error.localizedDescription)"
+                        : "Gallery server: connected; waiting for \(requestId)"
+                    cameraStatus = transportUnavailable
+                        ? "Camera: reconnect to the glasses hotspot to load the saved photo"
+                        : "Camera: photo saved on glasses; waiting for preview"
                     append(tag: "LIVE", text: "waiting for glasses photo \(requestId): \(error.localizedDescription)")
+                } else if transportUnavailable, galleryServerReachable != false {
+                    galleryServerReachable = false
+                    galleryServerStatus = "Gallery server: \(error.localizedDescription)"
+                    cameraStatus = "Camera: reconnect to the glasses hotspot to load the saved photo"
                 }
             }
             try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -1277,13 +1277,17 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
               galleryServerReachable == true else {
             throw ExampleActionError(message: "The glasses hotspot is not ready for preview downloads.")
         }
+        let galleryGeneration = galleryConnectionGeneration
 
         galleryServerStatus = "Gallery server: finding \(requestId)"
         var consecutiveFailures = 0
         for attempt in 0 ..< glassesPhotoPollAttempts {
-            guard activePhotoRequestId == requestId, pollGeneration == generation else { return }
+            guard activePhotoRequestId == requestId,
+                  pollGeneration == generation,
+                  galleryConnectionGeneration == galleryGeneration else { return }
             do {
                 let photo = try await findGalleryPhoto(baseUrl: baseUrl, requestId: requestId)
+                guard galleryConnectionGeneration == galleryGeneration else { return }
                 consecutiveFailures = 0
                 galleryServerReachable = true
                 galleryServerStatus = "Gallery server: connected; finding \(requestId)"
@@ -1306,6 +1310,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 request.cachePolicy = .reloadIgnoringLocalCacheData
                 request.timeoutInterval = 30
                 let (data, response) = try await URLSession.shared.data(for: request)
+                guard galleryConnectionGeneration == galleryGeneration else { return }
                 guard let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
                     let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                     throw ExampleActionError(message: "Gallery server returned HTTP \(statusCode).")
@@ -1335,6 +1340,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 append(tag: "LIVE", text: "glasses photo downloaded \(photo.name)")
                 return
             } catch {
+                guard galleryConnectionGeneration == galleryGeneration else { return }
                 consecutiveFailures += 1
                 let transportUnavailable = consecutiveFailures >= glassesGalleryFailureThreshold
                 if attempt == 0 || attempt % 10 == 9 {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -169,7 +169,7 @@ struct PhotoPreviewDetails {
             previewUrl: previewUrl,
             requestId: requestId,
             source: source,
-            state: state == "preview" ? "preview" : "acknowledged",
+            state: state == "preview" || state == "saved" ? state : "acknowledged",
             timestamp: timestamp,
             uploadUrl: uploadUrl,
             uploadedAt: uploadedAt,
@@ -350,6 +350,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var galleryConnectionGeneration = 0
     private var pendingHotspotConnection: PendingHotspotConnection?
     private var hotspotJoinExplanationShown = false
+    private var photoDestinationBeforeGlasses: PhotoDestination = .thisPhone
     private var streamConfigurationChangeInProgress = false
     private var photoCaptureDefaultsSyncGeneration = 0
     private var photoCaptureDefaultsSyncTask: Task<Void, Never>?
@@ -458,6 +459,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var latestOtaVersionInfoSignature: String?
     private var otaDisplayProgressSessionKey: String?
     private var otaDisplayOverallPercent: Int?
+    private var otaStartingAppIdentity: String?
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String?
     private var scanSession: ScanSession?
@@ -691,6 +693,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             try requireConnected("start OTA")
             try requireGlassesWifi("start OTA updates")
             postOtaCheckedSessionKey = nil
+            otaStartingAppIdentity = otaAppIdentity(glassesValues)
             resetOtaDisplayProgress()
             otaDisplayPercent = nil
             _ = try await mentraBluetoothSdk.startOtaUpdate()
@@ -715,9 +718,20 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    func setPhotoDestination(_ destination: PhotoDestination) {
+    func setPhotoDestination(_ requestedDestination: PhotoDestination) {
+        let destination: PhotoDestination
+        if photoDestination == .glassesStorage, requestedDestination == .thisPhone {
+            destination = photoDestinationBeforeGlasses
+        } else {
+            destination = requestedDestination
+        }
         guard photoDestination != destination else { return }
         let wasGlassesStorage = photoDestination == .glassesStorage
+        if destination == .glassesStorage, !wasGlassesStorage {
+            photoDestinationBeforeGlasses = photoDestination
+        } else if destination != .glassesStorage {
+            photoDestinationBeforeGlasses = destination
+        }
         stopPhonePhotoServer()
         photoDestination = destination
         switch destination {
@@ -734,12 +748,15 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
         guard wasGlassesStorage else { return }
         galleryConnectionGeneration += 1
+        let hotspotSsid = pendingHotspotConnection?.ssid ?? enabledHotspotStatus(glassesValues)?.ssid
         pendingHotspotConnection = nil
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: hotspot off"
         hotspotJoinPromptSsid = nil
         runAsyncAction("Disable glasses photo hotspot") { [self] in
-            glassesHotspotConnector.disconnect(ssid: galleryHotspotSsidLabel(glassesValues))
+            if let hotspotSsid {
+                glassesHotspotConnector.disconnect(ssid: hotspotSsid)
+            }
             if hotspotEnabled && glassesConnected {
                 _ = try await mentraBluetoothSdk.setHotspotState(enabled: false)
             }
@@ -747,6 +764,10 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func prepareGlassesPhotoPreview() {
+        galleryConnectionGeneration += 1
+        if let ssid = pendingHotspotConnection?.ssid ?? enabledHotspotStatus(glassesValues)?.ssid {
+            glassesHotspotConnector.disconnect(ssid: ssid)
+        }
         runAsyncAction("Connect to glasses hotspot") { [self] in
             try await prepareGlassesPhotoPreviewConnection()
         }
@@ -758,6 +779,13 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         runAsyncAction("Join glasses hotspot") { [self] in
             try await connectPendingGlassesHotspot()
         }
+    }
+
+    func dismissHotspotJoin() {
+        hotspotJoinPromptSsid = nil
+        galleryServerReachable = false
+        galleryServerStatus = "Gallery server: connection required"
+        cameraStatus = "Camera: connect to the glasses hotspot to enable capture"
     }
 
     private func prepareGlassesPhotoPreviewConnection() async throws {
@@ -787,7 +815,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             baseUrl: "http://\(hotspot.localIp):8089"
         )
         pendingHotspotConnection = pending
-        if await waitForGalleryServer(pending.baseUrl, attempts: 3, delayMs: 400) {
+        let alreadyReady = await waitForGalleryServer(pending.baseUrl, attempts: 3, delayMs: 400)
+        guard generation == galleryConnectionGeneration else { return }
+        if alreadyReady {
             markGalleryServerReady(pending.baseUrl)
             return
         }
@@ -813,7 +843,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         do {
             try await glassesHotspotConnector.connect(ssid: pending.ssid, password: pending.password)
             guard generation == galleryConnectionGeneration else { return }
-            guard await waitForGalleryServer(pending.baseUrl, attempts: 20, delayMs: 500) else {
+            let ready = await waitForGalleryServer(pending.baseUrl, attempts: 20, delayMs: 500)
+            guard generation == galleryConnectionGeneration else { return }
+            guard ready else {
                 throw ExampleActionError(message: "Could not reach the glasses gallery after connecting.")
             }
             markGalleryServerReady(pending.baseUrl)
@@ -1168,6 +1200,13 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             throw error
         }
         handlePhotoResponse(responseEvent)
+        switch responseEvent.response {
+        case .success:
+            break
+        case let .error(_, errorCode, errorMessage, _):
+            activePhotoRequestId = nil
+            throw ExampleActionError(message: errorCode ?? errorMessage)
+        }
         cameraStatus = "Camera: photo saved on glasses; loading preview"
         photoPreviewDetails = photoPreviewDetails.map { $0.withState("saved") }
         Task { @MainActor [weak self] in
@@ -1232,8 +1271,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         requestId: String,
         generation: Int
     ) async throws {
-        guard let baseUrl = pendingHotspotConnection?.baseUrl
-                ?? galleryServerUrl(glassesValues, fallbackEnabled: hotspotEnabled),
+        guard let baseUrl = galleryServerUrl(glassesValues, fallbackEnabled: hotspotEnabled)
+                ?? pendingHotspotConnection?.baseUrl,
               galleryServerReachable == true else {
             throw ExampleActionError(message: "The glasses hotspot is not ready for preview downloads.")
         }
@@ -1294,9 +1333,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 return
             } catch {
                 if attempt == 0 || attempt % 10 == 9 {
-                    galleryServerReachable = false
-                    galleryServerStatus = "Gallery server: not reachable. Join \(galleryHotspotSsidLabel(glassesValues))."
-                    cameraStatus = "Camera: join \(galleryHotspotSsidLabel(glassesValues)) to load the saved photo"
+                    galleryServerStatus = "Gallery server: connected; waiting for \(requestId)"
+                    cameraStatus = "Camera: photo saved on glasses; waiting for preview"
                     append(tag: "LIVE", text: "waiting for glasses photo \(requestId): \(error.localizedDescription)")
                 }
             }
@@ -2174,6 +2212,21 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             applyOtaStatus(event)
         case let .versionInfo(event):
             latestOtaVersionInfoSignature = otaVersionInfoSignature(event)
+            let installedIdentity = otaAppIdentity(event)
+            if let installedIdentity,
+               let otaStartingAppIdentity,
+               installedIdentity != otaStartingAppIdentity,
+               otaStatus?.status == "in_progress",
+               otaStatus?.phase == "install" {
+                self.otaStartingAppIdentity = nil
+                resetOtaDisplayProgress()
+                autoOtaCheckedConnectionKey = nil
+                otaStatus = nil
+                otaDisplayPercent = nil
+                otaStatusMessage = "OTA installed; checking for additional updates"
+                otaUpdateAvailable = false
+                append(tag: "LIVE", text: "OTA install restarted ASG client as \(installedIdentity)")
+            }
             maybeAutoCheckOta()
         case let .raw(name, values):
             handleRawEvent(name: name, values: values)
@@ -2191,6 +2244,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             append(tag: "LIVE", text: "OTA check result ignored while update is in progress")
             return updateAvailable
         }
+        otaStartingAppIdentity = nil
         resetOtaDisplayProgress()
         if updateAvailable {
             otaStatus = nil
@@ -2211,6 +2265,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func applyOtaStatus(_ event: OtaStatusEvent) {
         guard isDisplayableOtaStatus(event) else {
+            otaStartingAppIdentity = nil
             resetOtaDisplayProgress()
             otaStatus = nil
             otaDisplayPercent = nil
@@ -2223,6 +2278,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         otaStatus = event
         otaStatusMessage = nil
         if event.status == "complete" || event.status == "failed" {
+            otaStartingAppIdentity = nil
             otaUpdateAvailable = false
         }
         append(tag: "LIVE", text: "OTA \(event.status.isEmpty ? "status" : event.status) \(event.overallPercent)%")
@@ -2683,6 +2739,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
         hotspotJoinPromptSsid = nil
+        otaStartingAppIdentity = nil
         resetOtaDisplayProgress()
         otaStatus = nil
         otaDisplayPercent = nil
@@ -3269,6 +3326,22 @@ func otaVersionInfoSignature(_ event: VersionInfoResult) -> String {
     .filter { !$0.isEmpty }
     .joined(separator: "|")
     return key.isEmpty ? "version-unknown" : key
+}
+
+func otaAppIdentity(_ status: GlassesRuntimeState?) -> String? {
+    guard let device = connectedGlassesInfo(status) else { return nil }
+    let key = [device.buildNumber, device.appVersion]
+        .compactMap { $0 }
+        .filter { !$0.isEmpty }
+        .joined(separator: "|")
+    return key.isEmpty ? nil : key
+}
+
+func otaAppIdentity(_ event: VersionInfoResult) -> String? {
+    let key = [event.buildNumber, event.appVersion]
+        .filter { !$0.isEmpty }
+        .joined(separator: "|")
+    return key.isEmpty ? nil : key
 }
 
 func otaSessionKey(_ status: OtaStatusEvent) -> String {

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -190,18 +190,6 @@ struct CameraScreen: View {
         }
         .background(AppColor.bg)
         .scrollDismissesKeyboard(.interactively)
-        .alert(
-            "Connect to Glasses",
-            isPresented: Binding(
-                get: { model.hotspotJoinPromptSsid != nil },
-                set: { _ in }
-            )
-        ) {
-            Button("OK", action: model.confirmHotspotJoin)
-            Button("Not now", role: .cancel, action: model.dismissHotspotJoin)
-        } message: {
-            Text("When prompted, tap Join to connect to \"\(model.hotspotJoinPromptSsid ?? "the glasses hotspot")\".")
-        }
         .onChange(of: model.activeAction) { action in
             if action == "Capture & upload" || action == "Capture scan photo" {
                 captureMode = .photo

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -198,6 +198,7 @@ struct CameraScreen: View {
             )
         ) {
             Button("OK", action: model.confirmHotspotJoin)
+            Button("Not now", role: .cancel, action: model.dismissHotspotJoin)
         } message: {
             Text("When prompted, tap Join to connect to \"\(model.hotspotJoinPromptSsid ?? "the glasses hotspot")\".")
         }

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -325,36 +325,40 @@ struct DeviceScreen: View {
 
     private var otaCard: some View {
         let updateRequired = model.otaUpdateAvailable && model.otaStatus == nil
+        let installing = isOtaInstalling(model: model)
         return VStack(alignment: .leading, spacing: 9) {
             HStack(alignment: .top) {
                 HStack(alignment: .center, spacing: 10) {
                     if updateRequired {
                         ZStack {
-                            Circle().fill(AppColor.red)
+                            RoundedRectangle(cornerRadius: 7).fill(AppColor.amber.opacity(0.10))
                             Image(systemName: "exclamationmark.triangle")
-                                .font(.system(size: 15, weight: .bold))
-                                .foregroundColor(.white)
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(AppColor.amber)
                         }
-                        .frame(width: 34, height: 34)
+                        .frame(width: 30, height: 30)
                     }
                     VStack(alignment: .leading, spacing: 3) {
-                        Text(updateRequired ? "ACTION NEEDED" : "OTA")
-                            .font(.system(size: 10, weight: updateRequired ? .heavy : .semibold).monospaced())
-                            .tracking(1.1)
-                            .foregroundColor(updateRequired ? AppColor.red : AppColor.muted)
+                        Text(updateRequired ? "OTA UPDATE" : "OTA")
+                            .font(.system(size: 10, weight: .semibold).monospaced())
+                            .foregroundColor(updateRequired ? Color(hex: 0x9A5A00) : AppColor.muted)
                         Text(otaCardTitle(model: model))
-                            .font(.system(size: updateRequired ? 19 : 15, weight: updateRequired ? .heavy : .bold))
-                            .foregroundColor(AppColor.inkAlt)
+                            .font(.system(size: updateRequired ? 16 : 15, weight: .bold))
+                            .foregroundColor(AppColor.ink)
                     }
                 }
                 Spacer()
-                if let status = model.otaStatus {
+                if installing {
+                    ProgressView()
+                        .tint(AppColor.greenPrimary)
+                        .controlSize(.small)
+                } else if let status = model.otaStatus {
                     Text("\(otaDisplayPercent(model: model, status: status))%")
-                        .font(.system(size: 20, weight: .heavy))
+                        .font(.system(size: 15, weight: .bold).monospacedDigit())
                         .foregroundColor(AppColor.greenInk)
                 }
             }
-            if let status = model.otaStatus {
+            if let status = model.otaStatus, !installing {
                 GeometryReader { geometry in
                     ZStack(alignment: .leading) {
                         Capsule().fill(AppColor.greenInk.opacity(0.08))
@@ -363,12 +367,11 @@ struct DeviceScreen: View {
                             .frame(width: geometry.size.width * CGFloat(min(max(otaDisplayPercent(model: model, status: status), 0), 100)) / 100.0)
                     }
                 }
-                .frame(height: 6)
+                .frame(height: 4)
             }
             Text(otaCardDetail(model: model))
-                .font(.system(size: updateRequired ? 13 : 12, weight: updateRequired ? .bold : .medium))
-                .foregroundColor(updateRequired ? Color(hex: 0x5F201B) : AppColor.muted)
-                .lineSpacing(updateRequired ? 2 : 0)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(AppColor.muted)
                 .fixedSize(horizontal: false, vertical: true)
             if updateRequired {
                 Button(action: model.startOtaUpdate) {
@@ -376,29 +379,22 @@ struct DeviceScreen: View {
                         Image(systemName: "arrow.down.to.line")
                             .font(.system(size: 15, weight: .bold))
                         Text(canStartOta(model: model) ? "Start OTA" : "Connect Wi-Fi first")
-                            .font(.system(size: 14, weight: .heavy))
+                            .font(.system(size: 13, weight: .bold))
                     }
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
-                    .frame(minHeight: 48)
-                    .background(canStartOta(model: model) ? AppColor.red : Color(hex: 0x5F201B).opacity(0.36))
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .frame(minHeight: 42)
+                    .background(canStartOta(model: model) ? AppColor.greenInk : AppColor.muted.opacity(0.55))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
                 .buttonStyle(.plain)
                 .disabled(!canStartOta(model: model))
             }
         }
         .padding(14)
-        .background(
-            LinearGradient(
-                colors: updateRequired ? [Color(hex: 0xFFF5DF), Color(hex: 0xFFE6E1)] : [.white, .white],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
-        .overlay(RoundedRectangle(cornerRadius: 16).stroke(updateRequired ? AppColor.red.opacity(0.34) : Color.white.opacity(0.7), lineWidth: 1))
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-        .shadow(color: (updateRequired ? AppColor.red : Color(hex: 0x0F2A1D)).opacity(updateRequired ? 0.18 : 0.06), radius: updateRequired ? 22 : 18, x: 0, y: updateRequired ? 8 : 6)
+        .background(updateRequired ? Color(hex: 0xFFFCF5) : .white)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(updateRequired ? AppColor.amber.opacity(0.32) : AppColor.ink.opacity(0.08), lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 
@@ -449,11 +445,14 @@ private func isOtaInProgress(model: BluetoothViewModel) -> Bool {
 
 @MainActor
 private func otaStatusLine(model: BluetoothViewModel) -> String {
+    if isOtaInstalling(model: model) {
+        return "installing update"
+    }
     if let status = model.otaStatus {
         return "\(status.status.replacingOccurrences(of: "_", with: " ")) · \(otaDisplayPercent(model: model, status: status))%"
     }
     if model.otaUpdateAvailable {
-        return "Update required"
+        return "Firmware update available"
     }
     if let message = model.otaStatusMessage {
         return message
@@ -471,11 +470,14 @@ private func otaCardTitle(model: BluetoothViewModel) -> String {
     if model.otaStatus?.status == "failed" {
         return "Update failed"
     }
+    if isOtaInstalling(model: model) {
+        return "Installing update"
+    }
     if let status = model.otaStatus, isOtaInProgress(model: model) {
         return "Updating \(status.stepType.isEmpty ? "firmware" : status.stepType)"
     }
     if model.otaUpdateAvailable {
-        return "Update required"
+        return "Firmware update available"
     }
     return "OTA status"
 }
@@ -485,13 +487,21 @@ private func otaCardDetail(model: BluetoothViewModel) -> String {
     if let error = model.otaStatus?.errorMessage {
         return error
     }
+    if isOtaInstalling(model: model) {
+        return "The glasses client may restart to finish installation."
+    }
     if let status = model.otaStatus {
         return "\(status.phase.isEmpty ? "status" : status.phase) · step \(status.currentStep)/\(status.totalSteps)"
     }
     if model.otaUpdateAvailable {
-        return "Update your glasses before continuing. This example app may not work properly until the glasses firmware is current."
+        return "A newer firmware version is available for these glasses."
     }
     return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
+}
+
+@MainActor
+private func isOtaInstalling(model: BluetoothViewModel) -> Bool {
+    model.otaStatus?.status == "in_progress" && model.otaStatus?.phase == "install"
 }
 
 @MainActor

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -1783,7 +1783,7 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
           : details.state,
     },
   ];
-  if (details.source === 'Glasses gallery' && !details.previewUrl) {
+  if (details.source === 'Glasses gallery' && !details.previewUrl && details.error) {
     rows.push({
       label: 'Gallery mode',
       value: 'Photo stayed on the glasses and was not previewed on the phone.',

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -2467,6 +2467,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (!baseUrl || galleryServerReachableRef.current !== true) {
       throw new Error('The glasses hotspot is not ready for preview downloads.');
     }
+    const galleryGeneration = galleryConnectionGenerationRef.current;
 
     const localFile = new File(Paths.cache, `mentra-gallery-${requestId}.jpg`);
     setGalleryServerStatus(`Gallery server: finding ${requestId}`);
@@ -2475,7 +2476,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     for (let attempt = 0; attempt < GLASSES_PHOTO_POLL_ATTEMPTS; attempt += 1) {
       if (
         activePhotoRequestIdRef.current !== requestId ||
-        pollGenerationRef.current !== generation
+        pollGenerationRef.current !== generation ||
+        galleryConnectionGenerationRef.current !== galleryGeneration
       ) {
         return;
       }
@@ -2485,6 +2487,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           {cache: 'no-store', headers: {'Cache-Control': 'no-cache', Pragma: 'no-cache'}},
           3000,
         );
+        if (galleryConnectionGenerationRef.current !== galleryGeneration) return;
         if (!galleryResponse.ok) {
           throw new Error(`Gallery server returned HTTP ${galleryResponse.status}.`);
         }
@@ -2499,6 +2502,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             }>;
           };
         };
+        if (galleryConnectionGenerationRef.current !== galleryGeneration) return;
         const photo = gallery.data?.photos?.find((item) => item.request_id === requestId);
         consecutiveFailures = 0;
         setGalleryServerReachable(true);
@@ -2513,6 +2517,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           remoteUrl.searchParams.set('file', fileName);
         }
         const downloaded = await File.downloadFileAsync(remoteUrl.toString(), localFile, {idempotent: true});
+        if (galleryConnectionGenerationRef.current !== galleryGeneration) return;
         const deliveredAt = Date.now();
         setPhotoPreviewUrl(downloaded.uri);
         setPhotoStatus(null);
@@ -2538,6 +2543,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('LIVE', `glasses photo downloaded ${fileName}`);
         return;
       } catch (error) {
+        if (galleryConnectionGenerationRef.current !== galleryGeneration) return;
         consecutiveFailures += 1;
         const transportUnavailable =
           consecutiveFailures >= GLASSES_GALLERY_FAILURE_THRESHOLD;

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1,7 +1,7 @@
 import {createAudioPlayer, setAudioModeAsync, type AudioPlayer} from 'expo-audio';
 import {File, Paths} from 'expo-file-system';
 import {useEffect, useRef, useState} from 'react';
-import {Alert, Clipboard, Linking, PermissionsAndroid, Platform} from 'react-native';
+import {Clipboard, Linking, PermissionsAndroid, Platform} from 'react-native';
 import WifiManager from 'react-native-wifi-reborn';
 import BluetoothSdk, {
   DeviceModels,
@@ -697,7 +697,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const galleryServerReachableRef = useRef<boolean | null>(null);
   const galleryBaseUrlRef = useRef<string | null>(null);
   const galleryHotspotSsidRef = useRef<string | null>(null);
-  const hotspotJoinExplanationShownRef = useRef(false);
   const scanModeRef = useRef(false);
   const photoCaptureDefaultsSyncGenerationRef = useRef(0);
   const photoCaptureDefaultsSyncQueueRef = useRef<Promise<void>>(Promise.resolve());
@@ -3123,12 +3122,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         return;
       }
 
-      if (!hotspotJoinExplanationShownRef.current) {
-        await showHotspotJoinExplanation(hotspot.ssid);
-        hotspotJoinExplanationShownRef.current = true;
-      }
-      if (generation !== galleryConnectionGenerationRef.current) return;
-
       setGalleryServerStatus(`Gallery server: connecting to ${hotspot.ssid}`);
       setCameraStatus(`Camera: connecting to ${hotspot.ssid}`);
       let connectionError: unknown = null;
@@ -4690,19 +4683,6 @@ async function waitForGalleryServer(baseUrl: string, attempts: number, delayMs: 
     }
   }
   return false;
-}
-
-function showHotspotJoinExplanation(ssid: string) {
-  return new Promise<void>((resolve) => {
-    Alert.alert(
-      'Connect to Glasses',
-      Platform.OS === 'ios'
-        ? `When prompted, tap "Join" to connect to "${ssid}".`
-        : `When prompted, tap "Connect" to connect to "${ssid}".`,
-      [{text: 'OK', onPress: () => resolve()}],
-      {cancelable: false},
-    );
-  });
 }
 
 async function disconnectGlassesHotspotWifi(ssid: string) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -690,6 +690,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const pollGenerationRef = useRef(0);
   const videoPollGenerationRef = useRef(0);
   const photoDestinationRef = useRef<PhotoDestination>('phone');
+  const photoDestinationBeforeGlassesRef = useRef<Exclude<PhotoDestination, 'glasses'>>('phone');
   const galleryConnectionGenerationRef = useRef(0);
   const galleryConnectionPromiseRef = useRef<Promise<void> | null>(null);
   const galleryServerReachableRef = useRef<boolean | null>(null);
@@ -2201,7 +2202,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             : payload.resolvedConfig?.source === 'button'
               ? 'Action button'
             : current?.source ?? currentPhotoSource(photoDestinationRef.current),
-        state: current?.state === 'preview' ? 'preview' : 'acknowledged',
+        state:
+          current?.state === 'preview' || current?.state === 'saved'
+            ? current.state
+            : 'acknowledged',
         timestamp: statusPhoneTimestamp,
         timeline: appendPhotoTimeline(current?.timeline, {
           source: 'photo_status',
@@ -2435,7 +2439,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       previewUrl: previewUrl ?? current?.previewUrl,
       requestId: response.requestId,
       source,
-      state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
+      state:
+        current?.state === 'preview' || previewUrl
+          ? 'preview'
+          : current?.state === 'saved'
+            ? 'saved'
+            : 'acknowledged',
       timestamp: responseDeviceTimestamp,
       timeline: appendPhotoResponseTimeline(current?.timeline, {timestamp: responsePhoneTimestamp}),
       uploadUrl: response.uploadUrl,
@@ -2527,12 +2536,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         return;
       } catch (error) {
         if (attempt === 0 || attempt % 10 === 9) {
-          setGalleryServerReachable(false);
           setGalleryServerStatus(
-            `Gallery server: not reachable. Join ${galleryHotspotSsidLabel(glasses)}.`,
+            `Gallery server: connected; waiting for ${requestId}.`,
           );
           setCameraStatus(
-            `Camera: join ${galleryHotspotSsidLabel(glasses)} to load the saved photo`,
+            'Camera: photo saved on glasses; waiting for preview',
           );
           addEvent('LIVE', `waiting for glasses photo ${requestId}: ${formatError(error)}`);
         }
@@ -2978,6 +2986,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         await disableGlassesPhotoPreviewConnection();
       }
       const destination: PhotoDestination = enabled ? 'cloud' : 'phone';
+      photoDestinationBeforeGlassesRef.current = destination;
       photoDestinationRef.current = destination;
       setPhotoDestination(destination);
       activePhotoRequestIdRef.current = null;
@@ -2994,26 +3003,43 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   async function setPhotoGlassesStorageEnabledAction(enabled: boolean) {
-    await runAction(enabled ? 'Save photos on glasses' : 'Capture photos to phone', async () => {
-      const destination: PhotoDestination = enabled ? 'glasses' : 'phone';
-      photoDestinationRef.current = destination;
-      setPhotoDestination(destination);
-      activePhotoRequestIdRef.current = null;
-      clearPhotoUploadTimeout();
-      setPhotoStatus(null);
-      pollGenerationRef.current += 1;
-      if (!enabled) {
-        await disableGlassesPhotoPreviewConnection();
-        setCameraStatus('Camera: ready to capture to phone');
-        return;
-      }
-      await stopPhonePhotoReceiver().catch(() => undefined);
-      if (!glassesConnected) {
-        setCameraStatus('Camera: connect glasses to save photos on them');
-        return;
-      }
-      await prepareGlassesPhotoPreviewConnection();
-    });
+    const restoredDestination = photoDestinationBeforeGlassesRef.current;
+    await runAction(
+      enabled
+        ? 'Save photos on glasses'
+        : restoredDestination === 'cloud'
+          ? 'Restore photo cloud server'
+          : 'Capture photos to phone',
+      async () => {
+        if (enabled && photoDestinationRef.current !== 'glasses') {
+          photoDestinationBeforeGlassesRef.current = photoDestinationRef.current;
+        }
+        const destination: PhotoDestination = enabled
+          ? 'glasses'
+          : photoDestinationBeforeGlassesRef.current;
+        photoDestinationRef.current = destination;
+        setPhotoDestination(destination);
+        activePhotoRequestIdRef.current = null;
+        clearPhotoUploadTimeout();
+        setPhotoStatus(null);
+        pollGenerationRef.current += 1;
+        if (!enabled) {
+          await disableGlassesPhotoPreviewConnection();
+          setCameraStatus(
+            destination === 'cloud'
+              ? 'Camera: enter the cloud media upload URL'
+              : 'Camera: ready to capture to phone',
+          );
+          return;
+        }
+        await stopPhonePhotoReceiver().catch(() => undefined);
+        if (!glassesConnected) {
+          setCameraStatus('Camera: connect glasses to save photos on them');
+          return;
+        }
+        await prepareGlassesPhotoPreviewConnection();
+      },
+    );
   }
 
   async function prepareGlassesPhotoPreviewAction() {
@@ -3040,7 +3066,15 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   async function prepareGlassesPhotoPreviewConnection(restart = false) {
     if (restart) {
       galleryConnectionGenerationRef.current += 1;
+      const staleConnection = galleryConnectionPromiseRef.current;
       galleryConnectionPromiseRef.current = null;
+      const hotspotSsid = galleryHotspotSsidRef.current;
+      if (hotspotSsid) {
+        await disconnectGlassesHotspotWifi(hotspotSsid).catch((error) => {
+          addEvent('LIVE', `hotspot retry cleanup: ${formatError(error)}`);
+        });
+      }
+      void staleConnection?.catch(() => undefined);
       addEvent('LIVE', 'restarting glasses hotspot connection');
     }
     if (galleryConnectionPromiseRef.current) {
@@ -3064,6 +3098,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       galleryBaseUrlRef.current = baseUrl;
       galleryHotspotSsidRef.current = hotspot.ssid;
       const alreadyReady = await waitForGalleryServer(baseUrl, 3, 400);
+      if (generation !== galleryConnectionGenerationRef.current) return;
       if (alreadyReady) {
         markGalleryServerReady(baseUrl);
         return;
@@ -3090,7 +3125,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }
       if (generation !== galleryConnectionGenerationRef.current) return;
 
-      if (await waitForGalleryServer(baseUrl, 20, 500)) {
+      const ready = await waitForGalleryServer(baseUrl, 20, 500);
+      if (generation !== galleryConnectionGenerationRef.current) return;
+      if (ready) {
         markGalleryServerReady(baseUrl);
         return;
       }

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -548,6 +548,7 @@ export type BluetoothSdkExampleModel = BluetoothSdkExampleState & BluetoothSdkEx
 const PHOTO_APP_ID = 'com.mentra.examples.reactnative';
 const PHOTO_POLL_ATTEMPTS = 45;
 const GLASSES_PHOTO_POLL_ATTEMPTS = 120;
+const GLASSES_GALLERY_FAILURE_THRESHOLD = 3;
 const VIDEO_POLL_ATTEMPTS = 180;
 const DIRECT_PHOTO_UPLOAD_TIMEOUT_MS = 75_000;
 export const PHOTO_BLE_FALLBACK_QUALITY_WARNING =
@@ -2469,6 +2470,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
     const localFile = new File(Paths.cache, `mentra-gallery-${requestId}.jpg`);
     setGalleryServerStatus(`Gallery server: finding ${requestId}`);
+    let consecutiveFailures = 0;
 
     for (let attempt = 0; attempt < GLASSES_PHOTO_POLL_ATTEMPTS; attempt += 1) {
       if (
@@ -2498,6 +2500,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           };
         };
         const photo = gallery.data?.photos?.find((item) => item.request_id === requestId);
+        consecutiveFailures = 0;
         setGalleryServerReachable(true);
         if (!photo?.name) {
           setGalleryServerStatus(`Gallery server: connected; finding ${requestId}`);
@@ -2535,14 +2538,24 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('LIVE', `glasses photo downloaded ${fileName}`);
         return;
       } catch (error) {
+        consecutiveFailures += 1;
+        const transportUnavailable =
+          consecutiveFailures >= GLASSES_GALLERY_FAILURE_THRESHOLD;
         if (attempt === 0 || attempt % 10 === 9) {
           setGalleryServerStatus(
-            `Gallery server: connected; waiting for ${requestId}.`,
+            transportUnavailable
+              ? `Gallery server: ${formatError(error)}`
+              : `Gallery server: connected; waiting for ${requestId}.`,
           );
           setCameraStatus(
-            'Camera: photo saved on glasses; waiting for preview',
+            transportUnavailable
+              ? 'Camera: reconnect to the glasses hotspot to load the saved photo'
+              : 'Camera: photo saved on glasses; waiting for preview',
           );
           addEvent('LIVE', `waiting for glasses photo ${requestId}: ${formatError(error)}`);
+        }
+        if (transportUnavailable) {
+          setGalleryServerReachable(false);
         }
       }
       await delay(1000);


### PR DESCRIPTION
## Summary

This follow-up addresses the unresolved review feedback left on #26 after it was merged and brings the native Android and iOS examples up to parity with the later React Native hotspot and OTA behavior.

The main correctness issue was lifecycle state leaking across asynchronous hotspot connection, gallery polling, and photo response work. A canceled connection could still mark the gallery ready, a failed photo response could be presented as saved, and transient photo lookup failures could incorrectly disable an otherwise healthy hotspot connection.

## Gallery photo fixes

- Reject failed glasses-storage photo responses before marking the photo saved or starting gallery polling on Android and iOS.
- Preserve the `saved` preview state when later `photo_status` or `photo_response` events arrive.
- Keep hotspot reachability true while waiting for a newly saved photo to appear in the gallery; photo availability and network reachability are separate states.
- Resolve downloads against the current hotspot IP before falling back to cached connection data.
- Restore the previous phone/cloud destination when glasses storage is disabled instead of always selecting phone capture.
- Remove iOS hotspot configurations using the raw SSID returned by the glasses, not the user-facing SSID label.
- Invalidate stale asynchronous work after retry, cancellation, or replacement, and check the connection generation after every gallery reachability wait.
- Make Retry tear down the existing native Wi-Fi connection before starting a new attempt.
- Clear Android gallery readiness when the requested hotspot network is actually lost, while preventing deliberate disconnects from reporting a loss.
- Wire the Android and iOS hotspot explanation dismissal actions so users can leave the prompt and retry later.
- Only show the React Native “not previewed” detail after a real preview error, not while the saved photo is still downloading.

## Android routing review

The suggestion to add a separate `forceWifiUsageWithOptions` call is intentionally not applied. The pinned `react-native-wifi-reborn` 4.13.6 Android implementation already calls `bindProcessToNetwork(network)` from its `WifiNetworkSpecifier` callback and unbinds during disconnect. Adding another network request would duplicate and potentially compete with the library-owned connection.

## OTA parity

The React Native example already handled the ASG client restarting during the install phase. Android and iOS now capture the pre-install ASG app/build identity, recognize the changed identity from the next version-info event, clear the stale 100% install state, and immediately resume automatic OTA availability checking.

The native OTA cards now also match the restrained React Native presentation: flat borders, no decorative gradient or shadow, a compact install spinner instead of a stuck 100% progress bar, and clearer update/install copy.

## Validation

- `examples/react-native`: `bun x tsc --noEmit`
- `examples/android`: `./gradlew :app:compileDebugKotlin --no-daemon`
- `examples/ios`: unsigned generic-device `xcodebuild` for the `MentraExample` scheme
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Wi‑Fi routing, multi-step async gallery flows, and OTA state across three example apps; regressions would affect developer demos rather than production SDK consumers, but connection/generation bugs could still confuse capture and update flows.
> 
> **Overview**
> Hardens **glasses-storage photo preview** and **OTA install** behavior across the Android, iOS, and React Native example apps so async hotspot work cannot leave the UI in a stale “ready” or “saved” state.
> 
> **Gallery / hotspot:** Failed glasses photo responses are rejected before marking saved or polling the gallery. Preview state keeps **`saved`** through later status events. Gallery polling uses a **connection generation** token, prefers the **live hotspot URL**, and only marks the server unreachable after repeated failures—so a slow photo index does not look like a dead connection. Leaving glasses storage **restores the prior phone/cloud destination** instead of always defaulting to phone. Pre-join **Alert** flows and related state are **removed**; connections proceed directly to the OS Wi‑Fi prompt. **Android** reports real hotspot loss via `NetworkCallback.onLost` (with generation checks so intentional disconnects do not fire). Retries bump generation and tear down existing Wi‑Fi before reconnecting.
> 
> **OTA:** Native examples track **pre-install app identity** and, when version info changes during the install phase, clear stuck install UI and resume automatic update checks—matching existing React Native behavior. Device OTA cards use calmer copy and an install spinner instead of a frozen 100% bar.
> 
> **UI:** React Native only shows the “not previewed on phone” gallery detail when there is an actual preview **error**, not while a download is still in progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0749a2abc4c3e26c981de0f72275aa00e7f9c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->