### PR TITLE
Use phone timestamps for photo capture timeline

### DIFF
--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -1768,7 +1768,6 @@ function photoDetailsSummary(details: PhotoPreviewDetails | null) {
 
 type DetailRow = {label: string; value: string};
 type DetailRowTone = 'default' | 'warning';
-const GLASSES_TO_PHONE_CLOCK_OFFSET_MS = 0;
 
 function photoDetailsRows(details: PhotoPreviewDetails | null) {
   if (!details) {
@@ -1796,7 +1795,6 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
   }
   if (details.requestId) rows.push({label: 'Request ID', value: details.requestId});
   if (details.fileName) rows.push({label: 'Glasses filename', value: details.fileName});
-  addPhotoClockAdjustmentRow(rows, details.timeline);
   addPhotoTimelineRows(rows, details.timeline);
   if (details.byteCount) rows.push({label: 'Size', value: formatBytes(details.byteCount)});
   if (details.width && details.height) rows.push({label: 'Dimensions', value: `${details.width} x ${details.height}`});
@@ -1985,20 +1983,9 @@ function addPhotoTimelineRows(rows: DetailRow[], timeline: PhotoPreviewDetails['
   for (const event of timeline) {
     rows.push({
       label: photoTimelineLabel(event),
-      value: formatPhotoTimelineTimestamp(photoTimelineDisplayTimestamp(event), startTimestamp),
+      value: formatPhotoTimelineTimestamp(event.timestamp, startTimestamp),
     });
   }
-}
-
-function addPhotoClockAdjustmentRow(rows: DetailRow[], timeline: PhotoPreviewDetails['timeline']) {
-  const hasDeviceTimestamp = timeline?.some((event) => event.deviceTimestamp != null);
-  if (!hasDeviceTimestamp) {
-    return;
-  }
-  rows.push({
-    label: 'Clock adjustment',
-    value: `Glasses timestamps +${formatOffsetSeconds(GLASSES_TO_PHONE_CLOCK_OFFSET_MS)} to phone clock`,
-  });
 }
 
 function photoTimelineStart(timeline: PhotoPreviewDetails['timeline']) {
@@ -2006,13 +1993,7 @@ function photoTimelineStart(timeline: PhotoPreviewDetails['timeline']) {
   if (requestEvent) {
     return requestEvent.timestamp;
   }
-  return timeline?.[0] ? photoTimelineDisplayTimestamp(timeline[0]) : undefined;
-}
-
-function photoTimelineDisplayTimestamp(event: NonNullable<PhotoPreviewDetails['timeline']>[number]) {
-  return event.deviceTimestamp != null
-    ? event.deviceTimestamp + GLASSES_TO_PHONE_CLOCK_OFFSET_MS
-    : event.timestamp;
+  return timeline?.[0]?.timestamp;
 }
 
 function photoTimelineLabel(event: NonNullable<PhotoPreviewDetails['timeline']>[number]) {
@@ -2052,10 +2033,6 @@ function formatTimelineDelta(deltaMs: number) {
     return `${sign}${Math.round(absoluteMs)}ms`;
   }
   return `${sign}${(absoluteMs / 1000).toFixed(3)}s`;
-}
-
-function formatOffsetSeconds(ms: number) {
-  return `${(Math.abs(ms) / 1000).toFixed(3)}s`;
 }
 
 function formatFovEstimate(fov: NonNullable<PhotoPreviewDetails['estimatedFov']>) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -213,7 +213,6 @@ export type PhotoCaptureMetadataDetails = {
 export type PhotoTimelineEvent = {
   source: 'request' | 'photo_status' | 'photo_response';
   status?: string;
-  deviceTimestamp?: number;
   timestamp: number;
 };
 export type PhotoPreviewDetails = {
@@ -2184,7 +2183,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     const bleTransferStatus =
       payload.status === 'ready_for_transfer' || payload.status === 'transferring';
     const statusPhoneTimestamp = Date.now();
-    const statusDeviceTimestamp = payload.timestamp ?? statusPhoneTimestamp;
     setPhotoPreviewDetails((current) => {
       const bleFallbackUsed =
         current?.bleFallbackUsed || payload.status === 'ble_fallback_compression';
@@ -2204,11 +2202,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
               ? 'Action button'
             : current?.source ?? currentPhotoSource(photoDestinationRef.current),
         state: current?.state === 'preview' ? 'preview' : 'acknowledged',
-        timestamp: statusDeviceTimestamp,
+        timestamp: statusPhoneTimestamp,
         timeline: appendPhotoTimeline(current?.timeline, {
           source: 'photo_status',
           status: payload.status,
-          deviceTimestamp: payload.timestamp,
           timestamp: statusPhoneTimestamp,
         }),
         resolvedConfig: payload.resolvedConfig ?? current?.resolvedConfig,
@@ -2229,11 +2226,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         requestId: payload.requestId,
         source: current?.source ?? currentPhotoSource(photoDestinationRef.current),
         state: 'error',
-        timestamp: statusDeviceTimestamp,
+        timestamp: statusPhoneTimestamp,
         timeline: current?.timeline ?? [{
           source: 'photo_status',
           status: payload.status,
-          deviceTimestamp: payload.timestamp,
           timestamp: statusPhoneTimestamp,
         }],
       }));
@@ -2441,10 +2437,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       source,
       state: current?.state === 'preview' || previewUrl ? 'preview' : 'acknowledged',
       timestamp: responseDeviceTimestamp,
-      timeline: appendPhotoResponseTimeline(current?.timeline, {
-        deviceTimestamp: response.timestamp,
-        timestamp: responsePhoneTimestamp,
-      }),
+      timeline: appendPhotoResponseTimeline(current?.timeline, {timestamp: responsePhoneTimestamp}),
       uploadUrl: response.uploadUrl,
     }));
     if (previewUrl) {
@@ -4780,18 +4773,17 @@ function appendPhotoTimeline(
     (entry) =>
       entry.source === event.source &&
       entry.status === event.status &&
-      (entry.deviceTimestamp ?? entry.timestamp) === (event.deviceTimestamp ?? event.timestamp),
+      entry.timestamp === event.timestamp,
   );
   return duplicate ? entries : [...entries, event];
 }
 
 function appendPhotoResponseTimeline(
   timeline: PhotoTimelineEvent[] | undefined,
-  event: Pick<PhotoTimelineEvent, 'deviceTimestamp' | 'timestamp'>,
+  event: Pick<PhotoTimelineEvent, 'timestamp'>,
 ) {
   return appendPhotoTimeline(timeline, {
     source: 'photo_response',
-    deviceTimestamp: event.deviceTimestamp,
     timestamp: event.timestamp,
   });
 }


### PR DESCRIPTION
## Summary
- record React Native photo_status timeline entries with the phone receipt time instead of the glasses event timestamp
- remove the photo timeline deviceTimestamp plumbing and clock-adjustment row
- keep photo_response timeline entries on phone receipt time as well so the timeline uses one clock

## Validation
- `bun install --frozen-lockfile`
- `bunx tsc --noEmit`

Linear: OS-1661

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI and demo telemetry only; no auth or production SDK contract changes beyond dropping unused timeline fields in the sample.
> 
> **Overview**
> Photo capture timelines in the React Native example now use a **single clock**: phone receipt time when events arrive, instead of mixing glasses `payload.timestamp` with optional clock-adjustment display.
> 
> **`useBluetoothSdkExample`** drops `deviceTimestamp` from `PhotoTimelineEvent`, records `photo_status` (and related preview `timestamp`) with `Date.now()`, and simplifies timeline deduplication and `photo_response` append to only `timestamp`.
> 
> **`CameraScreen`** removes the clock-adjustment detail row and helpers that mapped device times onto the phone clock; timeline rows format `event.timestamp` directly with deltas from the request (or first) event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1a384cb905fc193e05490aed01e450057d9645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->