### PR TITLE
Display Mentra Live versions in native examples

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -156,6 +156,12 @@ data class VideoPreviewDetails(
     val uploadedAt: String? = null,
 )
 
+data class MentraLiveVersions(
+    val appVersion: String? = null,
+    val besFirmwareVersion: String? = null,
+    val mtkFirmwareVersion: String? = null,
+)
+
 private data class RgbLedPattern(
     val action: RgbLedAction,
     val color: RgbLedColor?,
@@ -243,6 +249,7 @@ data class MentraExampleState(
     val ledMode: String = "Off",
     val lastMicBytes: Int = 0,
     val lastMicDurationSeconds: Int? = null,
+    val mentraLiveVersions: MentraLiveVersions = MentraLiveVersions(),
     val micElapsedSeconds: Int = 0,
     val micPlaybackHint: String? = null,
     val micPlaying: Boolean = false,
@@ -363,6 +370,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var cameraWarmUpJob: Job? = null
     private var autoOtaCheckedConnectionKey: String? = null
     private var autoOtaCheckInProgress = false
+    private var latestVersionInfo: VersionInfoResult? = null
     private var latestOtaVersionInfoSignature: String? = null
     private val photoCaptureDefaultsSyncMutex = Mutex()
     private var photoCaptureDefaultsSyncGeneration = 0
@@ -445,6 +453,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             discoveredDevices = initialState.scan.devices,
             galleryModeEnabled = galleryModeEnabled(initialState.sdk),
             hotspotEnabled = enabledHotspotStatus(initialState.glasses) != null,
+            mentraLiveVersions = resolveMentraLiveVersions(initialState.glasses, latestVersionInfo),
             phoneAudioRoute = currentAudioOutputRouteLabel(),
             streamProtocol = savedStreamProtocol ?: state.streamProtocol,
             streamUrl = savedCloudUrls.streamUrl
@@ -454,6 +463,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         )
         registerAudioStateObservers()
         refreshAudioSystemState()
+        if (isMentraLiveRuntime(state.glassesStatus)) {
+            refreshMentraLiveVersionInfo()
+        }
         if (savedDefaultDevice != null) {
             autoConnectDefaultOnStartup()
         }
@@ -2133,14 +2145,20 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
     override fun onGlassesChanged(glasses: GlassesRuntimeState) {
         val wasConnected = isGlassesConnected()
+        if (!glasses.connected || !wasConnected) {
+            latestVersionInfo = null
+        }
         state = state.copy(
             glassesStatus = glasses,
             hotspotEnabled = enabledHotspotStatus(glasses) != null,
+            mentraLiveVersions = resolveMentraLiveVersions(glasses, latestVersionInfo),
         )
+        val shouldRefreshVersions = !wasConnected && isMentraLiveRuntime(glasses)
         if (!glasses.connected) {
             applyDisconnectedState("Disconnected")
         } else if (!wasConnected && isGlassesConnected()) {
             refreshGlassesMediaVolume()
+            refreshMentraLiveVersionInfo()
             // Re-apply scan preset after reconnect so button captures stay in sync.
             if (state.scanMode) {
                 pushScanButtonPreset()
@@ -2149,7 +2167,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 prepareGlassesPhotoPreview()
             }
         }
-        maybeAutoCheckOta()
+        if (!shouldRefreshVersions) {
+            maybeAutoCheckOta()
+        }
         addEvent("STORE", summarize(glasses))
     }
 
@@ -2434,7 +2454,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     override fun onVersionInfo(event: VersionInfoResult) {
-        latestOtaVersionInfoSignature = event.otaVersionInfoSignature()
+        applyVersionInfo(event)
         val installedIdentity = event.otaAppIdentity()
         val currentOtaStatus = state.otaStatus
         if (
@@ -2456,6 +2476,38 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             addEvent("LIVE", "OTA install restarted ASG client as $installedIdentity")
         }
         maybeAutoCheckOta()
+    }
+
+    private fun applyVersionInfo(event: VersionInfoResult) {
+        if (!isGlassesConnected(state.glassesStatus)) {
+            return
+        }
+        latestVersionInfo = event
+        latestOtaVersionInfoSignature = event.otaVersionInfoSignature()
+        state = state.copy(
+            mentraLiveVersions = resolveMentraLiveVersions(state.glassesStatus, event),
+        )
+    }
+
+    private fun refreshMentraLiveVersionInfo() {
+        if (!isMentraLiveRuntime(state.glassesStatus)) {
+            return
+        }
+        val connectionKey = otaConnectionKey(state.glassesStatus)
+        scope.launch {
+            try {
+                val payload = withContext(Dispatchers.IO) { mentraBluetoothSdk.requestVersionInfo() }
+                if (isMentraLiveRuntime(state.glassesStatus) && otaConnectionKey(state.glassesStatus) == connectionKey) {
+                    applyVersionInfo(payload)
+                    maybeAutoCheckOta()
+                }
+            } catch (error: Exception) {
+                if (isMentraLiveRuntime(state.glassesStatus) && otaConnectionKey(state.glassesStatus) == connectionKey) {
+                    addEvent("LIVE", "version info refresh failed: ${error.message ?: "request failed"}")
+                    maybeAutoCheckOta()
+                }
+            }
+        }
     }
 
     private fun handleOtaCheckResult(updateAvailable: Boolean): Boolean {
@@ -2546,6 +2598,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         if (!isGlassesConnected(glasses)) {
             autoOtaCheckedConnectionKey = null
             autoOtaCheckInProgress = false
+            latestVersionInfo = null
             latestOtaVersionInfoSignature = null
             postOtaCheckInProgress = false
             postOtaCheckedSessionKey = null
@@ -3027,6 +3080,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         pendingHotspotConnection = null
         glassesHotspotConnector.disconnect()
         otaStartingAppIdentity = null
+        latestVersionInfo = null
         resetOtaDisplayProgress()
         if (hadPhotoRequest) {
             pollGeneration += 1
@@ -3045,6 +3099,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             streamStartedAt = null,
             streamStatus = status,
             hotspotEnabled = false,
+            mentraLiveVersions = MentraLiveVersions(),
             otaStatus = null,
             otaDisplayPercent = null,
             otaStatusMessage = null,
@@ -4057,6 +4112,59 @@ fun VersionInfoResult.otaAppIdentity(): String? =
         .filter { it.isNotBlank() }
         .joinToString("|")
         .ifBlank { null }
+
+private fun versionValue(value: String?): String? =
+    value?.trim()?.takeIf { it.isNotEmpty() }
+
+fun resolveMentraLiveVersions(
+    status: GlassesRuntimeState?,
+    versionInfo: VersionInfoResult?,
+): MentraLiveVersions {
+    if (!isGlassesConnected(status)) {
+        return MentraLiveVersions()
+    }
+    return MentraLiveVersions(
+        appVersion = versionValue(versionInfo?.appVersion)
+            ?: versionValue(connectedGlassesInfo(status)?.appVersion)
+            ?: versionValue(status?.firmware?.appVersion),
+        besFirmwareVersion = versionValue(versionInfo?.besFirmwareVersion)
+            ?: if (status?.firmware?.source?.name == "BES") versionValue(status?.firmware?.version) else null,
+        mtkFirmwareVersion = versionValue(versionInfo?.mtkFirmwareVersion)
+            ?: if (status?.firmware?.source?.name == "MTK") versionValue(status?.firmware?.version) else null,
+    )
+}
+
+fun isMentraLiveRuntime(status: GlassesRuntimeState?): Boolean {
+    if (!isGlassesConnected(status)) {
+        return false
+    }
+    val device = connectedGlassesInfo(status)
+    val model = listOfNotNull(
+        device?.deviceModel?.deviceType,
+        device?.bluetoothName,
+    ).joinToString(" ").lowercase()
+    return device?.deviceModel == DeviceModel.MENTRA_LIVE || "mentra live" in model
+}
+
+fun shouldShowMentraLiveVersions(status: GlassesRuntimeState?): Boolean =
+    isMentraLiveRuntime(status)
+
+fun versionLabel(version: String?): String =
+    version ?: "Unknown"
+
+fun firmwareCardLabel(state: MentraExampleState): String {
+    if (shouldShowMentraLiveVersions(state.glassesStatus) && state.mentraLiveVersions.appVersion != null) {
+        return state.mentraLiveVersions.appVersion
+    }
+    return firmwareLabel(state.glassesStatus)
+}
+
+fun firmwareCardSubLabel(state: MentraExampleState): String {
+    if (shouldShowMentraLiveVersions(state.glassesStatus) && state.mentraLiveVersions.appVersion != null) {
+        return "ASG client"
+    }
+    return firmwareSubLabel(state.glassesStatus)
+}
 
 fun deviceLabel(status: GlassesRuntimeState?): String =
     connectedGlassesInfo(status)?.bluetoothName

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -43,8 +43,8 @@ import com.mentra.examples.android.connectedWifiStatus
 import com.mentra.examples.android.deviceModelLabel
 import com.mentra.examples.android.deviceLabel
 import com.mentra.examples.android.discoveredDeviceKey
-import com.mentra.examples.android.firmwareLabel
-import com.mentra.examples.android.firmwareSubLabel
+import com.mentra.examples.android.firmwareCardLabel
+import com.mentra.examples.android.firmwareCardSubLabel
 import com.mentra.examples.android.hasSavedConnectionTarget
 import com.mentra.examples.android.isGlassesConnected
 import com.mentra.examples.android.isGlassesWifiConnected
@@ -54,8 +54,10 @@ import com.mentra.examples.android.rssiUpdatedLabel
 import com.mentra.examples.android.savedConnectionTargetDetail
 import com.mentra.examples.android.savedConnectionTargetName
 import com.mentra.examples.android.scanModelOptions
+import com.mentra.examples.android.shouldShowMentraLiveVersions
 import com.mentra.examples.android.supportsDisplay
 import com.mentra.examples.android.targetDeviceDetail
+import com.mentra.examples.android.versionLabel
 import com.mentra.examples.android.wifiLabel
 import com.mentra.examples.android.ui.AppColor
 import com.mentra.examples.android.ui.Eyebrow
@@ -128,7 +130,7 @@ fun DeviceScreen(controller: MentraExampleController) {
 
             // Stat row
             Row(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                StatTile("FIRMWARE", firmwareLabel(glasses), firmwareSubLabel(glasses), AppColor.greenAccent, Modifier.weight(1f))
+                StatTile("FIRMWARE", firmwareCardLabel(state), firmwareCardSubLabel(state), AppColor.greenAccent, Modifier.weight(1f))
                 StatTile("WI-FI", wifiLabel(glasses), currentWifi?.localIp ?: "unknown", AppColor.muted, Modifier.weight(1f), bold = true)
                 StatTile("RSSI", rssiLabel(glasses), rssiUpdatedLabel(glasses), AppColor.greenAccent, Modifier.weight(1f), bold = true)
             }
@@ -231,6 +233,11 @@ fun DeviceScreen(controller: MentraExampleController) {
                     }
                 }
                 StatusKVRow("DEVICE", value = currentDeviceName, mono = true)
+                if (shouldShowMentraLiveVersions(glasses)) {
+                    StatusKVRow("ASG CLIENT", value = versionLabel(state.mentraLiveVersions.appVersion), mono = true)
+                    StatusKVRow("MTK", value = versionLabel(state.mentraLiveVersions.mtkFirmwareVersion), mono = true)
+                    StatusKVRow("BES", value = versionLabel(state.mentraLiveVersions.besFirmwareVersion), mono = true)
+                }
                 StatusKVRow("BATTERY") {
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(batteryLabel(glasses), color = AppColor.inkAlt, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -11,6 +11,12 @@ struct ExampleEvent: Identifiable {
     let text: String
 }
 
+struct MentraLiveVersions {
+    var appVersion: String?
+    var besFirmwareVersion: String?
+    var mtkFirmwareVersion: String?
+}
+
 struct ExampleActionError: LocalizedError {
     let message: String
     var errorDescription: String? {
@@ -432,6 +438,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var otaUpdateAvailable = false
     @Published private(set) var ledColor = "green"
     @Published private(set) var ledMode = "Off"
+    @Published private(set) var mentraLiveVersions = MentraLiveVersions()
     @Published var rawJsonExpanded = false
 
     private let micSampleRate = 16000
@@ -455,6 +462,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var lastDirectStreamFrameStatusRefresh = Date.distantPast
     private var autoOtaCheckedConnectionKey: String?
     private var autoOtaCheckInProgress = false
+    private var latestVersionInfo: VersionInfoResult?
     private var latestOtaVersionInfoSignature: String?
     private var otaDisplayProgressSessionKey: String?
     private var otaDisplayOverallPercent: Int?
@@ -533,8 +541,12 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
         glassesValues = mentraBluetoothSdk.glasses
         hotspotEnabled = enabledHotspotStatus(glassesValues) != nil
+        mentraLiveVersions = resolveMentraLiveVersions(glassesValues, versionInfo: latestVersionInfo)
         refreshGalleryServerStatusForCurrentHotspot(defaultStatus: "Gallery server: enable hotspot to check")
         applySdkState(mentraBluetoothSdk.sdkState)
+        if isMentraLiveRuntime(glassesValues) {
+            refreshMentraLiveVersionInfo()
+        }
         if let value = ProcessInfo.processInfo.environment["MENTRA_PHOTO_WEBHOOK_URL"] {
             webhookUrl = value
         } else if let value = savedCloudUrls.webhookUrl {
@@ -2135,11 +2147,17 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     func mentraBluetoothSDK(_: MentraBluetoothSDK, didUpdateGlasses glasses: GlassesRuntimeState) {
         let wasConnected = glassesConnected
+        if !glasses.connected || !wasConnected {
+            latestVersionInfo = nil
+        }
         glassesValues = glasses
         hotspotEnabled = enabledHotspotStatus(glasses) != nil
+        mentraLiveVersions = resolveMentraLiveVersions(glasses, versionInfo: latestVersionInfo)
+        let shouldRefreshVersions = !wasConnected && isMentraLiveRuntime(glasses)
         if !glasses.connected {
             applyDisconnectedState(status: "Disconnected")
         } else if !wasConnected {
+            refreshMentraLiveVersionInfo()
             // Re-apply scan preset on reconnect so button captures stay in sync.
             if scanMode {
                 pushScanButtonPreset()
@@ -2149,7 +2167,9 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             }
         }
         refreshGalleryServerStatusForCurrentHotspot(defaultStatus: hotspotEnabled ? galleryServerStatus : "Gallery server: hotspot off")
-        maybeAutoCheckOta()
+        if !shouldRefreshVersions {
+            maybeAutoCheckOta()
+        }
         append(tag: "STORE", text: summarize(glasses))
     }
 
@@ -2204,7 +2224,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         case let .otaStatus(event):
             applyOtaStatus(event)
         case let .versionInfo(event):
-            latestOtaVersionInfoSignature = otaVersionInfoSignature(event)
+            applyVersionInfo(event)
             let installedIdentity = otaAppIdentity(event)
             if let installedIdentity,
                let otaStartingAppIdentity,
@@ -2230,6 +2250,31 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func checkForOtaUpdateResult() async throws -> Bool {
         handleOtaCheckResult(try await mentraBluetoothSdk.checkForOtaUpdate())
+    }
+
+    private func applyVersionInfo(_ event: VersionInfoResult) {
+        guard glassesConnected else { return }
+        latestVersionInfo = event
+        latestOtaVersionInfoSignature = otaVersionInfoSignature(event)
+        mentraLiveVersions = resolveMentraLiveVersions(glassesValues, versionInfo: event)
+    }
+
+    private func refreshMentraLiveVersionInfo() {
+        guard isMentraLiveRuntime(glassesValues) else { return }
+        let connectionKey = otaConnectionKey(glassesValues)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let payload = try await mentraBluetoothSdk.requestVersionInfo()
+                guard isMentraLiveRuntime(glassesValues), otaConnectionKey(glassesValues) == connectionKey else { return }
+                applyVersionInfo(payload)
+                maybeAutoCheckOta()
+            } catch {
+                guard isMentraLiveRuntime(glassesValues), otaConnectionKey(glassesValues) == connectionKey else { return }
+                append(tag: "LIVE", text: "version info refresh failed: \(error.localizedDescription)")
+                maybeAutoCheckOta()
+            }
+        }
     }
 
     private func handleOtaCheckResult(_ updateAvailable: Bool) -> Bool {
@@ -2344,6 +2389,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         guard glassesConnected else {
             autoOtaCheckedConnectionKey = nil
             autoOtaCheckInProgress = false
+            latestVersionInfo = nil
             latestOtaVersionInfoSignature = nil
             postOtaCheckInProgress = false
             postOtaCheckedSessionKey = nil
@@ -2732,6 +2778,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
         otaStartingAppIdentity = nil
+        latestVersionInfo = nil
+        mentraLiveVersions = MentraLiveVersions()
         resetOtaDisplayProgress()
         otaStatus = nil
         otaDisplayPercent = nil
@@ -3334,6 +3382,67 @@ func otaAppIdentity(_ event: VersionInfoResult) -> String? {
         .filter { !$0.isEmpty }
         .joined(separator: "|")
     return key.isEmpty ? nil : key
+}
+
+func versionValue(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+        return nil
+    }
+    return trimmed
+}
+
+func resolveMentraLiveVersions(_ status: GlassesRuntimeState?, versionInfo: VersionInfoResult?) -> MentraLiveVersions {
+    guard isGlassesConnected(status) else {
+        return MentraLiveVersions()
+    }
+    return MentraLiveVersions(
+        appVersion: versionValue(versionInfo?.appVersion)
+            ?? versionValue(connectedGlassesInfo(status)?.appVersion)
+            ?? versionValue(status?.firmware?.appVersion),
+        besFirmwareVersion: versionValue(versionInfo?.besFirmwareVersion)
+            ?? (status?.firmware?.source == .bes ? versionValue(status?.firmware?.version) : nil),
+        mtkFirmwareVersion: versionValue(versionInfo?.mtkFirmwareVersion)
+            ?? (status?.firmware?.source == .mtk ? versionValue(status?.firmware?.version) : nil)
+    )
+}
+
+func isMentraLiveRuntime(_ status: GlassesRuntimeState?) -> Bool {
+    guard isGlassesConnected(status) else {
+        return false
+    }
+    let device = connectedGlassesInfo(status)
+    let model = [
+        device?.deviceModel?.deviceType,
+        device?.bluetoothName,
+    ]
+    .compactMap { $0 }
+    .joined(separator: " ")
+    .lowercased()
+    return device?.deviceModel == .mentraLive || model.contains("mentra live")
+}
+
+func shouldShowMentraLiveVersions(_ status: GlassesRuntimeState?) -> Bool {
+    isMentraLiveRuntime(status)
+}
+
+func versionLabel(_ version: String?) -> String {
+    version ?? "Unknown"
+}
+
+@MainActor
+func firmwareCardLabel(model: BluetoothViewModel) -> String {
+    if shouldShowMentraLiveVersions(model.glassesValues), let appVersion = model.mentraLiveVersions.appVersion {
+        return appVersion
+    }
+    return firmwareLabel(model.glassesValues)
+}
+
+@MainActor
+func firmwareCardSubLabel(model: BluetoothViewModel) -> String {
+    if shouldShowMentraLiveVersions(model.glassesValues), model.mentraLiveVersions.appVersion != nil {
+        return "ASG client"
+    }
+    return firmwareSubLabel(model.glassesValues)
 }
 
 func otaSessionKey(_ status: OtaStatusEvent) -> String {

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -106,7 +106,7 @@ struct DeviceScreen: View {
     private var statRow: some View {
         let currentWifi = connectedWifiStatus(model.glassesValues)
         return HStack(spacing: 10) {
-            StatTile(label: "FIRMWARE", value: firmwareLabel(model.glassesValues), sub: firmwareSubLabel(model.glassesValues), subColor: AppColor.greenAccent)
+            StatTile(label: "FIRMWARE", value: firmwareCardLabel(model: model), sub: firmwareCardSubLabel(model: model), subColor: AppColor.greenAccent)
             StatTile(label: "WI-FI", value: wifiLabel(model.glassesValues), sub: currentWifi?.localIp ?? "unknown", subColor: AppColor.muted, bold: true)
             StatTile(label: "RSSI", value: rssiLabel(model.glassesValues), sub: rssiUpdatedLabel(model.glassesValues), subColor: AppColor.greenAccent, bold: true)
         }
@@ -288,6 +288,11 @@ struct DeviceScreen: View {
                     HStack(spacing: 6) { Circle().fill(AppColor.greenPrimary).frame(width: 6, height: 6); Text(connectionLabel(model.glassesValues)).font(.system(size: 13, weight: .semibold)).foregroundColor(AppColor.greenInk) }
                 ))
                 StatusKVRow(label: "DEVICE", value: deviceLabel(model.glassesValues), mono: true)
+                if shouldShowMentraLiveVersions(model.glassesValues) {
+                    StatusKVRow(label: "ASG CLIENT", value: versionLabel(model.mentraLiveVersions.appVersion), mono: true)
+                    StatusKVRow(label: "MTK", value: versionLabel(model.mentraLiveVersions.mtkFirmwareVersion), mono: true)
+                    StatusKVRow(label: "BES", value: versionLabel(model.mentraLiveVersions.besFirmwareVersion), mono: true)
+                }
                 StatusKVRow(label: "BATTERY", custom: AnyView(
                     HStack(spacing: 8) {
                         Text(batteryLabel(model.glassesValues)).font(.system(size: 13, weight: .semibold)).foregroundColor(AppColor.inkAlt)


### PR DESCRIPTION
## Summary
- Mirror the React Native Mentra Live version display from #24 in the native Android example.
- Mirror the same version refresh, fallback, and Device tab rows in the native iOS example.
- Request `version_info` on new Mentra Live connections, keep the latest payload in app state, and show ASG client, MTK, and BES versions only for connected Mentra Live devices.

## Verification
- `git diff --check`
- `./gradlew :app:compileDebugKotlin` in `examples/android`
- `xcodebuild -project MentraExample.xcodeproj -scheme MentraExample -configuration Debug CODE_SIGNING_ALLOWED=NO build` in `examples/ios`

Notes: Android compile still reports the existing `BluetoothAdapter.getDefaultAdapter()` deprecation warning. Xcode still reports existing destination/orientation warnings, but the build succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only UI and state wiring around existing SDK version_info/OTA helpers; no auth, persistence, or core SDK API changes.
> 
> **Overview**
> Brings the React Native Mentra Live version UI into the **native Android and iOS example apps**: ASG client, MTK, and BES versions on the Device tab, with the firmware stat tile preferring the ASG app version when available.
> 
> Both platforms add **`MentraLiveVersions` state**, **`resolveMentraLiveVersions`** (SDK `version_info` with fallbacks from connected device / firmware runtime), and **`isMentraLiveRuntime`** gating so extra rows only show for connected Mentra Live hardware. On connect and at startup, they **`requestVersionInfo()`**, store **`latestVersionInfo`**, and route **`onVersionInfo`** through **`applyVersionInfo`** (also feeding OTA signature logic). Cached version info is cleared on disconnect; reconnect triggers a refresh and **defers auto OTA check** until that refresh finishes (or skips duplicate OTA when refresh runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01942fdb73ad9a17d142c4a8d2a02d454b57bca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->