### PR TITLE
Document debug ota manifest getter / setter

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,6 +16,7 @@ The Mentra Bluetooth SDK exposes the same core glasses lifecycle across Android,
 | iOS | `MentraBluetoothSDK` Swift package | `import MentraBluetoothSDK` |
 | React Native / Expo | `@mentra/bluetooth-sdk` | `import BluetoothSdk, {DeviceModels} from '@mentra/bluetooth-sdk'` |
 | React Native hooks | `@mentra/bluetooth-sdk` | `import {useMentraBluetooth} from '@mentra/bluetooth-sdk/react'` |
+| React Native OTA debugging | `@mentra/bluetooth-sdk` | `import {getOtaVersionUrl, setOtaVersionUrl} from '@mentra/bluetooth-sdk/debug'` |
 
 Only documented imports are part of the supported app developer API. Undocumented package subpaths or symbols with a leading underscore can change without notice.
 
@@ -268,6 +269,27 @@ Mentra Live OTA is owned by the glasses firmware. The SDK exposes the same comma
 Use the returned query/start values for one-shot UI. Keep `ota_status` listeners/delegates for install progress and terminal `complete` / `failed` state.
 
 OTA requires Mentra Live glasses firmware that supports the ASG OTA protocol and network access from the glasses. During install, normal BLE traffic can be interrupted and the glasses may restart; keep the app connected and avoid sending unrelated commands until the OTA status is `complete` or `failed`.
+
+### Override The OTA Version URL (React Native)
+
+The React Native debug entrypoint lets development and staging builds point OTA availability checks at a different version-manifest URL. Production apps should normally use the SDK's default URL.
+
+```ts
+import BluetoothSdk from '@mentra/bluetooth-sdk';
+import {getOtaVersionUrl, setOtaVersionUrl} from '@mentra/bluetooth-sdk/debug';
+
+setOtaVersionUrl('https://staging.example.com/firmware/version.json');
+
+console.log('OTA version URL:', getOtaVersionUrl());
+const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
+```
+
+| Method | Returns | Use |
+| --- | --- | --- |
+| `setOtaVersionUrl(otaVersionUrl)` | `void` | Set the HTTP or HTTPS version-manifest URL used by subsequent OTA availability checks. The SDK rejects invalid or non-HTTP(S) URLs. |
+| `getOtaVersionUrl()` | `string` | Read the currently configured override, or the SDK's default version-manifest URL when no override has been set. |
+
+Set the override before calling `checkForOtaUpdate()`. The override applies to the current SDK session and is not an app setting; if a development build needs it after restart, configure it again during app startup. Do not import these helpers from the main `@mentra/bluetooth-sdk` entrypoint.
 
 ## Display
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API implementation in this diff.
> 
> **Overview**
> Documents the React Native **`@mentra/bluetooth-sdk/debug`** entrypoint for overriding the OTA firmware version-manifest URL in dev/staging builds.
> 
> The **Packages And Imports** table now lists that subpath and `getOtaVersionUrl` / `setOtaVersionUrl`. A new **Override The OTA Version URL (React Native)** section under OTA Updates adds a usage example, method reference (`setOtaVersionUrl` rejects non-HTTP(S) URLs; `getOtaVersionUrl` returns override or default), and notes to configure before `checkForOtaUpdate()`, treat the override as session-scoped, and avoid importing these from the main package entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49dc9d48f727e2542302f0b7b0bb24b96ea5e7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->