### PR TITLE
Update example apps to SDK 0.1.20 and smooth the OTA flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Read the first-party [Mentra Live Bluetooth SDK docs](https://docs.mentraglass.c
 
 Every commit on `main` publishes installable builds of the example apps to [GitHub Releases](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases), grouped by Bluetooth SDK version: the `sdk-<version>` release always carries the latest build of each example for that SDK version.
 
-From the release matching your SDK version (e.g. `sdk-0.1.17`), download:
+From the release matching your SDK version (e.g. `sdk-0.1.20`), download:
 
 - `mentra-example-android.apk` — native Android example
 - `mentra-example-react-native.apk` — React Native example

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,14 +68,14 @@ Add the public Swift package in Xcode or `Package.swift`:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.13` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Use version `0.1.20` or newer, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.13"
+  from: "0.1.20"
 )
 ```
 
@@ -173,7 +173,7 @@ cd examples/react-native
 unset MENTRA_BLUETOOTH_SDK_PACKAGE_PATH
 rm -rf node_modules/@mentra/bluetooth-sdk
 
-bun add @mentra/bluetooth-sdk@0.1.13
+bun add @mentra/bluetooth-sdk@0.1.20
 bun install
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.13` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.20` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.19
+mentraSdkVersion=0.1.20
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.19
+mentraSdkVersion=0.1.20

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.19;
+				version = 0.1.20;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.19`:
+The Xcode project pins the public Swift package to `0.1.20`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.19
+    exactVersion: 0.1.20
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.19",
+        "@mentra/bluetooth-sdk": "0.1.20",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7OdPVWmtUqZcDu4tM71jDPO8jM3283TrsWmY+vwSjPACeamxJLwgcYgAXAq/A1imvI8aO9snVcLQQjaTzpuswg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.20", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-SoiYf2kUBTTropzADCvk2gsnBIqcjAGx8jLrX5HOJLpxZ+S09dAEHgfbUmC4x81FVjsq02IDE6BCZQKdUTRJgA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.19",
+    "@mentra/bluetooth-sdk": "0.1.20",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.19"
+"@mentra/bluetooth-sdk": "0.1.20"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.19",
+        "@mentra/bluetooth-sdk": "0.1.20",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.19", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7OdPVWmtUqZcDu4tM71jDPO8jM3283TrsWmY+vwSjPACeamxJLwgcYgAXAq/A1imvI8aO9snVcLQQjaTzpuswg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.20", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-SoiYf2kUBTTropzADCvk2gsnBIqcjAGx8jLrX5HOJLpxZ+S09dAEHgfbUmC4x81FVjsq02IDE6BCZQKdUTRJgA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.19",
+    "@mentra/bluetooth-sdk": "0.1.20",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -366,7 +366,13 @@ function otaDisplayPercent(sdk: BluetoothSdkExampleModel) {
 }
 
 function isOtaInstalling(sdk: BluetoothSdkExampleModel) {
-  return sdk.otaStatus?.status === 'in_progress' && sdk.otaStatus.phase === 'install';
+  // Only the APK install is indeterminate (pm install restarts the glasses
+  // client); MTK and BES report flash progress with phase 'install'.
+  return (
+    sdk.otaStatus?.status === 'in_progress' &&
+    sdk.otaStatus.phase === 'install' &&
+    (sdk.otaStatus.step_type ?? 'apk') === 'apk'
+  );
 }
 
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {

--- a/examples/react-native/src/screens/SystemScreen.tsx
+++ b/examples/react-native/src/screens/SystemScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
   View,
   Text,
   ScrollView,
@@ -107,6 +108,7 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           />
         ) : null}
         {visibleNetworks.map((network, index) => {
+          const connectingThis = sdk.wifiConnectingSsid === network.ssid;
           const joinNetwork = () => {
             if (network.requiresPassword) {
               setPendingWifi({ssid: network.ssid, requiresPassword: true});
@@ -121,19 +123,27 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <NetworkRow
               key={`${network.ssid}-${index}`}
               actionColor={colors.greenDeep}
-              actionLabel="Join"
+              actionLabel={connectingThis ? undefined : 'Join'}
+              busy={connectingThis}
               name={network.ssid}
-              sub={`${network.requiresPassword ? 'secured' : 'open'} · ${network.signalStrength ?? 0}`}
-              subColor={colors.muted}
+              sub={
+                connectingThis
+                  ? 'connecting…'
+                  : `${network.requiresPassword ? 'secured' : 'open'} · ${network.signalStrength ?? 0}`
+              }
+              subColor={connectingThis ? colors.greenAccent : colors.muted}
               faint
               locked={network.requiresPassword}
               last={index === visibleNetworks.length - 1 && !canToggleWifiList}
-              disabled={!connected}
-              onActionPress={joinNetwork}
-              onPress={joinNetwork}
+              disabled={!connected || (sdk.wifiConnectingSsid !== null && !connectingThis)}
+              onActionPress={connectingThis ? undefined : joinNetwork}
+              onPress={connectingThis ? undefined : joinNetwork}
             />
           );
         })}
+        {sdk.wifiConnectError ? (
+          <Text style={styles.wifiErrorText}>{sdk.wifiConnectError}</Text>
+        ) : null}
         {canToggleWifiList ? (
           <Pressable style={styles.wifiExpandRow} onPress={() => setWifiExpanded((expanded) => !expanded)}>
             <Text style={styles.wifiExpandText}>
@@ -394,6 +404,7 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
 function NetworkRow({
   actionColor = colors.ink,
   actionLabel,
+  busy,
   check,
   disabled,
   faint,
@@ -408,6 +419,7 @@ function NetworkRow({
 }: {
   actionColor?: string;
   actionLabel?: string;
+  busy?: boolean;
   check?: boolean;
   disabled?: boolean;
   faint?: boolean;
@@ -445,7 +457,9 @@ function NetworkRow({
           <Path d="M7 11V7a5 5 0 0 1 10 0v4" />
         </Svg>
       )}
-      {actionLabel ? (
+      {busy ? (
+        <ActivityIndicator color={colors.greenDeep} size="small" />
+      ) : actionLabel ? (
         <Pressable disabled={!onActionPress} onPress={onActionPress} style={[styles.networkAction, { backgroundColor: `${actionColor}1A` }]}>
           <Text style={[styles.networkActionText, { color: actionColor }]}>{actionLabel}</Text>
         </Pressable>
@@ -668,6 +682,7 @@ const styles = StyleSheet.create({
   networkSub: { fontSize: 12, fontWeight: '500' },
   networkAction: { minHeight: 40, minWidth: 64, alignItems: 'center', justifyContent: 'center', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999 },
   networkActionText: { fontSize: 12, fontWeight: '700' },
+  wifiErrorText: { color: colors.red, fontSize: 12, fontWeight: '600', marginTop: 8 },
   wifiExpandRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, borderTopWidth: 1, borderTopColor: 'rgba(15,42,29,0.06)', paddingTop: 12, paddingBottom: 2 },
   wifiExpandText: { color: colors.greenInk, fontSize: 12, fontWeight: '700' },
   tileCard: { flex: 1, borderRadius: 22, paddingVertical: 16, paddingHorizontal: 16, gap: 10, borderWidth: 1, borderColor: colors.borderSoft },

--- a/examples/react-native/src/screens/SystemScreen.tsx
+++ b/examples/react-native/src/screens/SystemScreen.tsx
@@ -40,6 +40,7 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const inputChips = recentInputChips(sdk.events);
   const [pendingWifi, setPendingWifi] = useState<{ssid: string; requiresPassword: boolean} | null>(null);
   const [pendingWifiPassword, setPendingWifiPassword] = useState('');
+  const [showWifiPassword, setShowWifiPassword] = useState(false);
   const [wifiExpanded, setWifiExpanded] = useState(false);
   const didAutoScanWifi = useRef(false);
   const visibleNetworks = wifiExpanded ? networks : networks.slice(0, WIFI_COLLAPSED_NETWORK_LIMIT);
@@ -110,6 +111,7 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             if (network.requiresPassword) {
               setPendingWifi({ssid: network.ssid, requiresPassword: true});
               setPendingWifiPassword('');
+              setShowWifiPassword(false);
             } else {
               void sdk.sendWifiCredentials(network.ssid, '', false);
             }
@@ -332,17 +334,39 @@ export function SystemScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
           <View style={styles.modalCard}>
             <Text style={styles.modalTitle}>Join Wi-Fi</Text>
             <Text style={styles.modalSub}>{pendingWifi?.ssid}</Text>
-            <TextInput
-              autoCapitalize="none"
-              autoCorrect={false}
-              onChangeText={setPendingWifiPassword}
-              placeholder="Password"
-              placeholderTextColor={colors.muted}
-              returnKeyType="done"
-              secureTextEntry
-              style={styles.modalInput}
-              value={pendingWifiPassword}
-            />
+            <View style={styles.modalInputRow}>
+              <TextInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                onChangeText={setPendingWifiPassword}
+                placeholder="Password"
+                placeholderTextColor={colors.muted}
+                returnKeyType="done"
+                secureTextEntry={!showWifiPassword}
+                style={styles.modalInput}
+                value={pendingWifiPassword}
+              />
+              <Pressable
+                accessibilityLabel={showWifiPassword ? 'Hide password' : 'Show password'}
+                accessibilityRole="button"
+                hitSlop={10}
+                onPress={() => setShowWifiPassword((visible) => !visible)}
+                style={styles.modalInputEye}>
+                <Svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke={colors.muted} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                  {showWifiPassword ? (
+                    <>
+                      <Path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                      <Line x1={1} y1={1} x2={23} y2={23} />
+                    </>
+                  ) : (
+                    <>
+                      <Path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8Z" />
+                      <Circle cx={12} cy={12} r={3} />
+                    </>
+                  )}
+                </Svg>
+              </Pressable>
+            </View>
             <View style={styles.modalActions}>
               <Pressable style={styles.modalCancel} onPress={() => setPendingWifi(null)}>
                 <Text style={styles.modalCancelText}>Cancel</Text>
@@ -699,7 +723,9 @@ const styles = StyleSheet.create({
   modalCard: { width: '100%', borderRadius: 24, backgroundColor: colors.bg, padding: 20, gap: 12 },
   modalTitle: { color: colors.ink, fontSize: 22, fontWeight: '800' },
   modalSub: { color: colors.muted, fontSize: 15, fontWeight: '600' },
-  modalInput: { color: colors.ink, fontSize: 16, fontWeight: '500', backgroundColor: 'rgba(15,42,29,0.04)', borderRadius: 14, paddingHorizontal: 14, paddingVertical: 14 },
+  modalInputRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: 'rgba(15,42,29,0.04)', borderRadius: 14 },
+  modalInput: { flex: 1, color: colors.ink, fontSize: 16, fontWeight: '500', paddingHorizontal: 14, paddingVertical: 14 },
+  modalInputEye: { alignItems: 'center', justifyContent: 'center', minWidth: 44, minHeight: 44, paddingRight: 4 },
   modalActions: { flexDirection: 'row', gap: 10, marginTop: 4 },
   modalCancel: { flex: 1, alignItems: 'center', backgroundColor: 'rgba(15,42,29,0.06)', borderRadius: 16, paddingVertical: 14 },
   modalCancelText: { color: colors.ink, fontSize: 15, fontWeight: '700' },

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -85,6 +85,10 @@ const MAX_OTA_CHAIN_PASSES = 4;
 // little longer before declaring failure.
 const WIFI_CONNECT_GRACE_MS = 20_000;
 
+// An armed OTA chain survives the reboots an update itself causes, but a
+// device that stays away longer than this needs a fresh user tap.
+const OTA_CHAIN_RESUME_WINDOW_MS = 5 * 60_000;
+
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
@@ -752,6 +756,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
   const otaChainRemainingRef = useRef(0);
+  const otaChainDeviceKeyRef = useRef<string | null>(null);
+  const otaChainDisconnectedAtRef = useRef<number | null>(null);
+  const otaStartInFlightRef = useRef(false);
+  const connectedDeviceKeyRef = useRef<string | null>(null);
+  const otaAppIdentityRef = useRef<string | null>(null);
   const wifiConnectAttemptRef = useRef(0);
   const wifiConnectGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
@@ -793,6 +802,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   galleryModeEnabledRef.current = galleryModeEnabled;
   latestAutoOtaCheckKeyRef.current = autoOtaCheckKey;
   otaStatusRef.current = otaStatus;
+  connectedDeviceKeyRef.current = connectedDeviceKey;
+  otaAppIdentityRef.current = otaAppIdentity(glasses);
   glassesConnectedRef.current = glassesConnected;
   glassesWifiConnectedRef.current = glassesWifiConnected;
   galleryServerReachableRef.current = galleryServerReachable;
@@ -903,17 +914,28 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       // 'step_complete' before the reboot) must not gate the next check.
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
+      otaStartInFlightRef.current = false;
+      if (otaChainRemainingRef.current > 0 && otaChainDisconnectedAtRef.current === null) {
+        otaChainDisconnectedAtRef.current = Date.now();
+      }
       setOtaStatus(null);
       clearOtaDisplayProgress();
       setOtaStatusMessage(null);
       setOtaUpdateAvailable(false);
       return;
     }
+    if (otaChainDisconnectedAtRef.current !== null) {
+      if (Date.now() - otaChainDisconnectedAtRef.current > OTA_CHAIN_RESUME_WINDOW_MS) {
+        otaChainRemainingRef.current = 0;
+      }
+      otaChainDisconnectedAtRef.current = null;
+    }
     if (
       !autoOtaCheckKey ||
       !glassesWifiConnected ||
       autoOtaCheckedConnectionRef.current === autoOtaCheckKey ||
       autoOtaCheckInProgressRef.current ||
+      otaStartInFlightRef.current ||
       otaInProgress
     ) {
       return;
@@ -935,6 +957,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         if (
           latestAutoOtaCheckKeyRef.current &&
           latestAutoOtaCheckKeyRef.current !== checkedKey &&
+          !otaStartInFlightRef.current &&
           !isOtaEventInProgress(otaStatusRef.current)
         ) {
           setAutoOtaCheckRetryTick((tick) => tick + 1);
@@ -1298,7 +1321,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Connect glasses first.');
       }
       requireGlassesWifi('check for OTA updates');
-      if (isOtaEventInProgress(otaStatusRef.current)) {
+      if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
         addEvent('TX', 'OTA check skipped while update is in progress');
         return;
       }
@@ -1308,7 +1331,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   async function checkForOtaUpdateResult(): Promise<boolean> {
     const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
-    if (isOtaEventInProgress(otaStatusRef.current)) {
+    if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
       addEvent('LIVE', 'OTA check result ignored while update is in progress');
       return updateAvailable;
     }
@@ -1341,19 +1364,30 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (otaChainRemainingRef.current <= 0) {
       return;
     }
+    if (otaChainDeviceKeyRef.current && otaChainDeviceKeyRef.current !== connectedDeviceKeyRef.current) {
+      // The armed run belongs to another device/connection; require a fresh tap.
+      otaChainRemainingRef.current = 0;
+      return;
+    }
     if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
       return;
     }
-    if (isOtaEventInProgress(otaStatusRef.current)) {
+    if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
       return;
     }
     otaChainRemainingRef.current -= 1;
+    otaStartInFlightRef.current = true;
     void runAction('Continue OTA', async () => {
-      postOtaCheckedSessionRef.current = null;
-      otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
-      clearOtaDisplayProgress();
-      await BluetoothSdk.startOtaUpdate();
-      addEvent('LIVE', 'OTA continuing with next update pass');
+      try {
+        postOtaCheckedSessionRef.current = null;
+        otaStartingAppIdentityRef.current = otaAppIdentityRef.current;
+        clearOtaDisplayProgress();
+        await BluetoothSdk.startOtaUpdate();
+        addEvent('LIVE', 'OTA continuing with next update pass');
+      } catch (error) {
+        otaStartInFlightRef.current = false;
+        throw error;
+      }
     });
   }
 
@@ -1419,11 +1453,23 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Connect glasses first.');
       }
       requireGlassesWifi('start OTA updates');
-      otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
+      if (otaStartInFlightRef.current) {
+        addEvent('TX', 'OTA start skipped; a start is already in flight');
+        return;
+      }
       postOtaCheckedSessionRef.current = null;
       otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
       clearOtaDisplayProgress();
-      await BluetoothSdk.startOtaUpdate();
+      otaStartInFlightRef.current = true;
+      try {
+        await BluetoothSdk.startOtaUpdate();
+      } catch (error) {
+        otaStartInFlightRef.current = false;
+        throw error;
+      }
+      // Arm the auto-chain only once the start is acknowledged.
+      otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
+      otaChainDeviceKeyRef.current = connectedDeviceKeyRef.current;
       addEvent('LIVE', 'OTA start acknowledged');
     });
   }
@@ -3959,6 +4005,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     otaStatusRef.current = null;
     otaStartingAppIdentityRef.current = null;
+    otaStartInFlightRef.current = false;
     setOtaStatus(null);
     clearOtaDisplayProgress();
     setOtaStatusMessage(null);
@@ -3972,6 +4019,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   function applyOtaStatus(payload: OtaStatusEvent) {
+    otaStartInFlightRef.current = false;
     if (!isDisplayableOtaStatus(payload)) {
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -882,6 +882,14 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       postOtaCheckInProgressRef.current = false;
       postOtaCheckedSessionRef.current = null;
       setLatestVersionInfoSignature(null);
+      // A stale in-progress OTA status (e.g. the BES step's final
+      // 'step_complete' before the reboot) must not gate the next check.
+      otaStatusRef.current = null;
+      otaStartingAppIdentityRef.current = null;
+      setOtaStatus(null);
+      clearOtaDisplayProgress();
+      setOtaStatusMessage(null);
+      setOtaUpdateAvailable(false);
       return;
     }
     if (
@@ -1128,9 +1136,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       wasConnectedRef.current = true;
       return;
     }
-    if (wasConnectedRef.current && isDisconnectedStatus(glasses)) {
+    // Reset on any connected -> not-connected transition. During an
+    // auto-reconnect (e.g. the post-BES-update reboot) the SDK publishes
+    // 'disconnected' and 'connecting' in the same bridge flush, so the app
+    // never renders the 'disconnected' state.
+    if (wasConnectedRef.current) {
       wasConnectedRef.current = false;
-      applyDisconnectedState('Disconnected');
+      applyDisconnectedState(isDisconnectedStatus(glasses) ? 'Disconnected' : 'Reconnecting');
     }
   }, [glassesConnected, glasses, scanMode, scanAeDivisor, scanIsoCap]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -75,6 +75,11 @@ export type StreamPreviewTarget = {
 type MediaUploadSuccessEvent = BluetoothSdkEventMap['media_success'];
 type MediaUploadErrorEvent = BluetoothSdkEventMap['media_error'];
 
+// A single user-initiated update may need several OTA passes (e.g. legacy
+// glasses first hop to an intermediate ASG client before the firmware pass).
+// Bound the automatic continuations so a misbehaving manifest cannot loop.
+const MAX_OTA_CHAIN_PASSES = 4;
+
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
@@ -737,6 +742,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaStartingAppIdentityRef = useRef<string | null>(null);
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
+  const otaChainRemainingRef = useRef(0);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
   const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoResult | null>(null);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
@@ -1298,14 +1304,41 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       setOtaStatusMessage(null);
       setOtaUpdateAvailable(true);
       addEvent('LIVE', 'OTA update available');
+      maybeContinueOtaChain();
       return true;
     }
+    otaChainRemainingRef.current = 0;
     otaStatusRef.current = null;
     setOtaStatus(null);
     setOtaStatusMessage('Glasses firmware is up to date');
     setOtaUpdateAvailable(false);
     addEvent('LIVE', 'OTA up to date');
     return false;
+  }
+
+  // One user-initiated update run may span several OTA passes: legacy
+  // glasses can finish a pass on an intermediate ASG client (or reboot
+  // after a BES flash) while still being behind the manifest. Whenever a
+  // post-pass or reconnect check reports another update during an armed
+  // run, start the next pass without requiring another tap.
+  function maybeContinueOtaChain() {
+    if (otaChainRemainingRef.current <= 0) {
+      return;
+    }
+    if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
+      return;
+    }
+    if (isOtaEventInProgress(otaStatusRef.current)) {
+      return;
+    }
+    otaChainRemainingRef.current -= 1;
+    void runAction('Continue OTA', async () => {
+      postOtaCheckedSessionRef.current = null;
+      otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
+      clearOtaDisplayProgress();
+      await BluetoothSdk.startOtaUpdate();
+      addEvent('LIVE', 'OTA continuing with next update pass');
+    });
   }
 
   function clearOtaDisplayProgress() {
@@ -1370,6 +1403,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw new Error('Connect glasses first.');
       }
       requireGlassesWifi('start OTA updates');
+      otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
       postOtaCheckedSessionRef.current = null;
       otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
       clearOtaDisplayProgress();
@@ -1380,6 +1414,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   async function disconnect() {
     await runAction('Disconnect', async () => {
+      otaChainRemainingRef.current = 0;
       stopDirectStreamFrameWatchdog();
       await bluetooth.disconnect();
       applyDisconnectedState('Disconnected');
@@ -3896,6 +3931,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (payload.status === 'complete' || payload.status === 'failed') {
       otaStartingAppIdentityRef.current = null;
       setOtaUpdateAvailable(false);
+    }
+    if (payload.status === 'failed') {
+      otaChainRemainingRef.current = 0;
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);
     schedulePostOtaCheck(payload);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -80,6 +80,11 @@ type MediaUploadErrorEvent = BluetoothSdkEventMap['media_error'];
 // Bound the automatic continuations so a misbehaving manifest cannot loop.
 const MAX_OTA_CHAIN_PASSES = 4;
 
+// The SDK gives up waiting for a wifi connect ack after 15s, but the glasses
+// often finish associating shortly after; keep the connecting state alive a
+// little longer before declaring failure.
+const WIFI_CONNECT_GRACE_MS = 20_000;
+
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
@@ -434,6 +439,8 @@ export type BluetoothSdkExampleState = {
   pcmFrames: number;
   speaking: boolean | null;
   voiceActivityDetectionEnabled: boolean;
+  wifiConnectError: string | null;
+  wifiConnectingSsid: string | null;
   permissionStatus: string;
   phonePhotoReceiverRunning: boolean;
   phonePhotoUploadUrl: string | null;
@@ -676,6 +683,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [otaDisplayPercent, setOtaDisplayPercent] = useState<number | null>(null);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
   const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
+  const [wifiConnectingSsid, setWifiConnectingSsid] = useState<string | null>(null);
+  const [wifiConnectError, setWifiConnectError] = useState<string | null>(null);
   const [micAudioRouteStatus, setMicAudioRouteStatus] = useState(
     Platform.OS === 'ios'
       ? IOS_AUDIO_ROUTE_HINT
@@ -743,6 +752,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
   const otaChainRemainingRef = useRef(0);
+  const wifiConnectAttemptRef = useRef(0);
+  const wifiConnectGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
   const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoResult | null>(null);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
@@ -950,6 +961,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('STORE', `battery ${payload.level}%${payload.charging ? ' charging' : ''}`);
       }),
       BluetoothSdk.addListener('wifi_status_change', (payload) => {
+        if (payload.state === 'connected') {
+          // A connect that outlived the SDK request timeout resolved late.
+          settleWifiConnectAttempt();
+          setWifiConnectError(null);
+        }
         addEvent('STORE', `Wi-Fi ${payload.state === 'connected' ? payload.ssid : payload.state}`);
       }),
       BluetoothSdk.addListener('hotspot_status_change', (payload) => {
@@ -3460,14 +3476,56 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     });
   }
 
+  function settleWifiConnectAttempt() {
+    wifiConnectAttemptRef.current += 1;
+    if (wifiConnectGraceTimerRef.current) {
+      clearTimeout(wifiConnectGraceTimerRef.current);
+      wifiConnectGraceTimerRef.current = null;
+    }
+    setWifiConnectingSsid(null);
+  }
+
   async function sendWifiCredentials(ssid: string, password: string, requiresPassword: boolean) {
     await runAction(`Connect Wi-Fi ${ssid}`, async () => {
       requireConnected('send Wi-Fi credentials');
       if (requiresPassword && !password) {
         throw new Error(`Enter the Wi-Fi password before connecting to ${ssid}.`);
       }
-      const status = await BluetoothSdk.sendWifiCredentials(ssid, requiresPassword ? password : '');
-      addEvent('LIVE', `Wi-Fi ${status.state === 'connected' ? status.ssid : status.state}`);
+      const attempt = ++wifiConnectAttemptRef.current;
+      if (wifiConnectGraceTimerRef.current) {
+        clearTimeout(wifiConnectGraceTimerRef.current);
+        wifiConnectGraceTimerRef.current = null;
+      }
+      setWifiConnectingSsid(ssid);
+      setWifiConnectError(null);
+      try {
+        const status = await BluetoothSdk.sendWifiCredentials(ssid, requiresPassword ? password : '');
+        if (wifiConnectAttemptRef.current === attempt) {
+          setWifiConnectingSsid(null);
+        }
+        addEvent('LIVE', `Wi-Fi ${status.state === 'connected' ? status.ssid : status.state}`);
+      } catch (error) {
+        if (wifiConnectAttemptRef.current !== attempt) {
+          return;
+        }
+        if ((error as {code?: string})?.code === 'request_timeout') {
+          // The glasses often finish associating after the SDK stops
+          // waiting; keep the connecting state during a grace window and
+          // let a late wifi_status_change resolve it.
+          wifiConnectGraceTimerRef.current = setTimeout(() => {
+            wifiConnectGraceTimerRef.current = null;
+            if (wifiConnectAttemptRef.current === attempt) {
+              setWifiConnectingSsid(null);
+              setWifiConnectError(`Could not connect to ${ssid}. Check the password and try again.`);
+            }
+          }, WIFI_CONNECT_GRACE_MS);
+          addEvent('LIVE', `Wi-Fi connect to ${ssid} still pending`);
+          return;
+        }
+        setWifiConnectingSsid(null);
+        setWifiConnectError(formatError(error));
+        throw error;
+      }
     });
   }
 
@@ -3905,6 +3963,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     clearOtaDisplayProgress();
     setOtaStatusMessage(null);
     setOtaUpdateAvailable(false);
+    settleWifiConnectAttempt();
+    setWifiConnectError(null);
     setMicRecording(false);
     micRecordingRef.current = false;
     stopMicElapsedTimer();
@@ -4137,6 +4197,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     toggleStream,
     voiceActivityDetectionEnabled,
     webhookUrl,
+    wifiConnectError,
+    wifiConnectingSsid,
   };
 }
 

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -763,6 +763,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaAppIdentityRef = useRef<string | null>(null);
   const wifiConnectAttemptRef = useRef(0);
   const wifiConnectGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wifiConnectingSsidRef = useRef<string | null>(null);
   const [autoOtaCheckRetryTick, setAutoOtaCheckRetryTick] = useState(0);
   const [latestVersionInfo, setLatestVersionInfo] = useState<VersionInfoResult | null>(null);
   const [latestVersionInfoSignature, setLatestVersionInfoSignature] = useState<string | null>(null);
@@ -985,9 +986,18 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }),
       BluetoothSdk.addListener('wifi_status_change', (payload) => {
         if (payload.state === 'connected') {
-          // A connect that outlived the SDK request timeout resolved late.
-          settleWifiConnectAttempt();
-          setWifiConnectError(null);
+          const targetSsid = wifiConnectingSsidRef.current;
+          if (!targetSsid || payload.ssid === targetSsid) {
+            // A connect that outlived the SDK request timeout resolved late,
+            // or the glasses (re)connected with no attempt pending.
+            settleWifiConnectAttempt();
+            setWifiConnectError(null);
+          } else {
+            // Re-associating with a different network while a join is
+            // pending means the join failed (e.g. wrong password).
+            settleWifiConnectAttempt();
+            setWifiConnectError(`Could not connect to ${targetSsid}. Check the password and try again.`);
+          }
         }
         addEvent('STORE', `Wi-Fi ${payload.state === 'connected' ? payload.ssid : payload.state}`);
       }),
@@ -1914,7 +1924,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         });
         handlePhotoResponse(response);
       } catch (error) {
-        if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
+        if (isRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
           markPhotoRequestStillWaiting(requestId, 'Cloud server', error);
           void pollPhotoPreview(requestId, statusUrl, pollGeneration);
           return;
@@ -1953,7 +1963,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       });
       handlePhotoResponse(response);
     } catch (error) {
-      if (isPhotoRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
+      if (isRequestTimeoutError(error) && activePhotoRequestIdRef.current === requestId) {
         markPhotoRequestStillWaiting(requestId, 'Phone receiver', error);
         startPhonePhotoUploadTimeout(requestId);
         return;
@@ -3524,6 +3534,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function settleWifiConnectAttempt() {
     wifiConnectAttemptRef.current += 1;
+    wifiConnectingSsidRef.current = null;
     if (wifiConnectGraceTimerRef.current) {
       clearTimeout(wifiConnectGraceTimerRef.current);
       wifiConnectGraceTimerRef.current = null;
@@ -3542,25 +3553,29 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         clearTimeout(wifiConnectGraceTimerRef.current);
         wifiConnectGraceTimerRef.current = null;
       }
+      wifiConnectingSsidRef.current = ssid;
       setWifiConnectingSsid(ssid);
       setWifiConnectError(null);
       try {
         const status = await BluetoothSdk.sendWifiCredentials(ssid, requiresPassword ? password : '');
         if (wifiConnectAttemptRef.current === attempt) {
-          setWifiConnectingSsid(null);
+          settleWifiConnectAttempt();
         }
         addEvent('LIVE', `Wi-Fi ${status.state === 'connected' ? status.ssid : status.state}`);
       } catch (error) {
         if (wifiConnectAttemptRef.current !== attempt) {
           return;
         }
-        if ((error as {code?: string})?.code === 'request_timeout') {
+        // iOS loses the 'request_timeout' code in the Expo bridge, so also
+        // match on the message like isRequestTimeoutError does.
+        if ((error as {code?: string})?.code === 'request_timeout' || isRequestTimeoutError(error)) {
           // The glasses often finish associating after the SDK stops
           // waiting; keep the connecting state during a grace window and
           // let a late wifi_status_change resolve it.
           wifiConnectGraceTimerRef.current = setTimeout(() => {
             wifiConnectGraceTimerRef.current = null;
             if (wifiConnectAttemptRef.current === attempt) {
+              wifiConnectingSsidRef.current = null;
               setWifiConnectingSsid(null);
               setWifiConnectError(`Could not connect to ${ssid}. Check the password and try again.`);
             }
@@ -3568,7 +3583,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           addEvent('LIVE', `Wi-Fi connect to ${ssid} still pending`);
           return;
         }
-        setWifiConnectingSsid(null);
+        settleWifiConnectAttempt();
         setWifiConnectError(formatError(error));
         throw error;
       }
@@ -5164,7 +5179,7 @@ function formatError(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function isPhotoRequestTimeoutError(error: unknown) {
+function isRequestTimeoutError(error: unknown) {
   const message = formatError(error).toLowerCase();
   return (
     message.includes('request_timeout') ||


### PR DESCRIPTION
## Summary

Update every Starter Kit example app to target Bluetooth SDK 0.1.20, and fix the OS-1694 OTA sub-issues in the React Native example — one commit per sub-issue:

- `f71ff64` — update all examples to SDK 0.1.20 (OS-1699)
- `6f1ebc8` — OS-1696: show/hide toggle on the Join Wi-Fi password input
- `4a5967b` — OS-1699: point starter kit docs at the 0.1.20 builds
- `2940e21` — OS-1695: show MTK/BES flash percentages in the OTA card (the indeterminate "Installing update" state is now apk-step only)
- `0ed28b6` — OS-1698: reset device state on any connected→not-connected transition; after the BES reboot the SDK publishes `disconnected`+`connecting` in one bridge flush, so the app never rendered `disconnected` and a stale `step_complete` kept the OTA check gated
- `dc811f8` — OS-1697: bounded auto-chain of OTA passes, so one tap carries legacy glasses through the intermediate ASG-client hop to the latest release (root cause is the frozen v1 manifest pin, addressed separately in Mentra-Community/MentraOS#3454)
- `1ac278d` — OS-1693: connecting spinner on the joining network row, joins disabled while pending, 20s grace window past the SDK's 15s request timeout, inline connect error
- `4b8edd0` — pin both React Native Bun lockfiles to the published 0.1.20 tarball (deferred step from the original PR description)
- `387293d` — OS-1697 follow-up from adversarial review: render-synced identity ref (the mount-scoped `ota_status` listener recorded a null starting identity for chained passes), double-start guard, arm-after-ack, device-scoped chain with a 5-minute resume window
- `d862dd7` — OS-1693 follow-up from adversarial review: settle the connect attempt only for the joined SSID (a `connected` event for a different network now surfaces the failure instead of masking it) and detect the request timeout by message too, since the Expo iOS bridge rewrites the error code
- `a6b0826` — OS-1697 follow-up from Bugbot: a failed chain-start dispatch no longer consumes a pass (run ends after three consecutive failures)

## Dependency

Bluetooth SDK 0.1.20 is now published (npm, Maven Central, SwiftPM mirror), so the earlier CI failures ("no versions match 0.1.20") should clear on the current head.

## Verification

- `tsc --noEmit` clean on the React Native example after each commit
- Root causes and fixes for all five behavioral sub-issues confirmed by adversarial multi-agent review across the example app, `@mentra/bluetooth-sdk` native sources, and `asg_client`
- Hardware retest plan (April firmware → latest): one tap should ride APK 36→37 (percent visible) → auto-chained pass 2 (MTK %, BES %) → reboot → auto-reconnect re-enables the OTA card → up to date at ASG 39 / MTK 20260709 / BES 17.26.7.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OTA auto-chain and connection-state resets change firmware-update behavior on real hardware; Wi-Fi join timing and error handling are user-facing but localized to the example app.
> 
> **Overview**
> Bumps every Starter Kit example and related docs from Bluetooth SDK **0.1.19** (and older doc pins) to **0.1.20**—Android `gradle.properties`, iOS SwiftPM pins, both React Native `package.json` files and Bun lockfiles, plus README/getting-started/troubleshooting version examples.
> 
> The substantive behavior change is in the **React Native example**. **OTA**: the Device card treats indeterminate “installing” as **APK-only** (`step_type === 'apk'`) so MTK/BES flash steps show percentages; disconnect/reconnect handling clears stale in-progress OTA state and resets on any connected→not-connected transition (including fast `disconnected`+`connecting` after BES reboot); a **bounded auto-chain** (up to 4 passes) continues multi-hop updates after one user tap, with resume window and guards against duplicate starts. **Wi-Fi**: join flow exposes connecting SSID, row spinner, disabled parallel joins, a **20s grace** after SDK request timeout, late `wifi_status_change` resolution, and inline errors; the password modal adds show/hide. **`isPhotoRequestTimeoutError`** is renamed to **`isRequestTimeoutError`** for shared timeout handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d862dd7dacd3ecc7dc8865b5bfd0f4277ffe9b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

