### PR TITLE
Harden OTA pass chaining and allow photo capture over Bluetooth

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -955,7 +955,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             captureToGlassesStorage()
             return@runAction
         }
-        requireGlassesWifi("capture photos")
+        // Without glasses Wi-Fi the photo is delivered over the Bluetooth
+        // transfer path instead of the network upload.
         if (state.photoDestination == PhotoDestination.THIS_PHONE) {
             captureAndUploadToPhone()
             return@runAction

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/CameraScreen.kt
@@ -103,11 +103,10 @@ fun CameraScreen(controller: MentraExampleController) {
         state.photoPreviewDetails?.state == "saved"
     val needsGlassesHotspotSetup = connected && glassesStorageEnabled && state.galleryServerReachable != true
     val photoControlsEnabled = connected &&
-        (glassesStorageEnabled || glassesWifiConnected) &&
         !needsGlassesHotspotSetup &&
         state.activeAction != "Capture & upload" &&
         state.activeAction != "Capture scan photo"
-    val wifiRequired = connected && !glassesWifiConnected && !glassesStorageEnabled
+    val glassesWifiOff = connected && !glassesWifiConnected && !glassesStorageEnabled
     val videoActionBusy = state.activeAction == "Start video recording" || state.activeAction == "Stop & upload video"
     val videoControlsEnabled = connected &&
         glassesWifiConnected &&
@@ -152,9 +151,9 @@ fun CameraScreen(controller: MentraExampleController) {
         PageHeader("Camera")
         if (!connected) {
             OfflineNotice(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp))
-        } else if (wifiRequired) {
+        } else if (glassesWifiOff) {
             OfflineNotice(
-                message = "Connect the glasses to Wi-Fi from the System tab before capturing photos. Photos are uploaded over the glasses network connection.",
+                message = "Glasses Wi-Fi is off. Photos still work over Bluetooth but take longer to transfer. Connect Wi-Fi from the System tab for faster photos and for video.",
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
             )
         }
@@ -181,8 +180,6 @@ fun CameraScreen(controller: MentraExampleController) {
                         Text(
                             if (!connected) {
                                 "Connect glasses first"
-                            } else if (!glassesWifiConnected && !glassesStorageEnabled) {
-                                "Connect glasses to Wi-Fi"
                             } else if (state.activeAction == "Capture & upload" || state.activeAction == "Capture scan photo") {
                                 "Capturing..."
                             } else if (state.scanMode) {
@@ -281,8 +278,6 @@ fun CameraScreen(controller: MentraExampleController) {
                         Text(
                             if (!connected) {
                                 "Connect glasses first"
-                            } else if (!glassesWifiConnected && !glassesStorageEnabled) {
-                                "Connect glasses to Wi-Fi"
                             } else if (needsGlassesHotspotSetup) {
                                 if (state.galleryServerReachable == null) "Preparing hotspot..." else "Connect glasses hotspot"
                             } else if (state.activeAction == "Capture & upload" || state.activeAction == "Capture scan photo") {

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -1091,7 +1091,8 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 try await captureToGlassesStorage()
                 return
             }
-            try requireGlassesWifi("capture photos")
+            // Without glasses Wi-Fi the photo is delivered over the Bluetooth
+            // transfer path instead of the network upload.
             if photoDestination == .thisPhone {
                 try await captureAndUploadToPhone()
                 return

--- a/examples/ios/MentraExample/CameraScreen.swift
+++ b/examples/ios/MentraExample/CameraScreen.swift
@@ -119,7 +119,7 @@ struct CameraScreen: View {
         model.photoDestination == .thisPhone
     }
 
-    private var wifiRequired: Bool {
+    private var glassesWifiOff: Bool {
         model.glassesConnected && !model.glassesWifiConnected && !glassesStorageEnabled
     }
 
@@ -148,7 +148,6 @@ struct CameraScreen: View {
 
     private var photoControlsEnabled: Bool {
         model.glassesConnected &&
-            (glassesStorageEnabled || model.glassesWifiConnected) &&
             !needsGlassesHotspotSetup &&
             model.activeAction != "Capture & upload" &&
             model.activeAction != "Capture scan photo"
@@ -167,8 +166,8 @@ struct CameraScreen: View {
                     OfflineNotice()
                         .padding(.horizontal, 16)
                         .padding(.bottom, 8)
-                } else if wifiRequired {
-                    OfflineNotice(message: "Connect the glasses to Wi-Fi from the System tab before capturing camera media. Cloud uploads use the glasses network connection.")
+                } else if glassesWifiOff {
+                    OfflineNotice(message: "Glasses Wi-Fi is off. Photos still work over Bluetooth but take longer to transfer. Connect Wi-Fi from the System tab for faster photos and for video.")
                         .padding(.horizontal, 16)
                         .padding(.bottom, 8)
                 }
@@ -348,7 +347,6 @@ struct CameraScreen: View {
 
     private var captureButtonTitle: String {
         if !model.glassesConnected { return "Connect glasses first" }
-        if !model.glassesWifiConnected && !glassesStorageEnabled { return "Connect glasses to Wi-Fi" }
         if needsGlassesHotspotSetup {
             return model.galleryServerReachable == nil ? "Preparing hotspot..." : "Connect glasses hotspot"
         }

--- a/examples/react-native/src/screens/CameraScreen.tsx
+++ b/examples/react-native/src/screens/CameraScreen.tsx
@@ -18,7 +18,7 @@ import {
   CAMERA_FOV_MAX,
   CAMERA_FOV_MIN,
   CAMERA_ROI_POSITIONS,
-  PHOTO_BLE_FALLBACK_QUALITY_WARNING,
+  PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE,
   PHOTO_AE_EXPOSURE_DIVISOR_OPTIONS,
   PHOTO_COMPRESSIONS,
   PHOTO_EXPOSURE_DEFAULT_NS,
@@ -143,7 +143,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   const [videoDetailsExpanded, setVideoDetailsExpanded] = React.useState(false);
   const connected = isGlassesConnected(sdk.glasses);
   const glassesWifiConnected = isGlassesWifiConnected(sdk.glasses);
-  const wifiRequired =
+  const glassesWifiOff =
     connected && !glassesWifiConnected && !sdk.photoGlassesStorageEnabled;
   const videoActionBusy =
     sdk.activeAction === 'Start video recording' ||
@@ -161,7 +161,6 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
     connected && sdk.photoGlassesStorageEnabled && sdk.galleryServerReachable !== true;
   const photoControlsDisabled =
     !connected ||
-    (!glassesWifiConnected && !sdk.photoGlassesStorageEnabled) ||
     needsGlassesHotspotSetup ||
     sdk.activeAction === 'Capture & upload' ||
     sdk.activeAction === 'Capture scan photo';
@@ -172,7 +171,7 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
   );
   const bleFallbackWarning = sdk.photoPreviewDetails?.bleFallbackUsed
     ? sdk.photoPreviewDetails.bleFallbackMessage ??
-      PHOTO_BLE_FALLBACK_QUALITY_WARNING
+      PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE
     : null;
   const cloudSetupHint = localCameraSetupHint(sdk.webhookUrl, sdk.cameraStatus);
   const photoStateText = sdk.photoPreviewUrl
@@ -234,8 +233,8 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
       <Header title="Camera" />
       {!connected ? (
         <OfflineNotice />
-      ) : wifiRequired ? (
-        <OfflineNotice message="Connect the glasses to Wi-Fi from the System tab before capturing photos. Photos are uploaded over the glasses network connection." />
+      ) : glassesWifiOff ? (
+        <OfflineNotice message="Glasses Wi-Fi is off. Photos still work over Bluetooth but take longer to transfer. Connect Wi-Fi from the System tab for faster photos and for video." />
       ) : null}
       {sdk.cameraButtonNotice ? (
         <View pointerEvents="none" style={styles.cameraButtonNoticeWrap}>
@@ -346,8 +345,6 @@ export function CameraScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Text style={styles.captureText}>
               {!connected
                 ? 'Connect glasses first'
-                : !glassesWifiConnected && !sdk.photoGlassesStorageEnabled
-                  ? 'Connect glasses to Wi-Fi'
                 : needsGlassesHotspotSetup
                   ? sdk.galleryServerReachable === null
                     ? 'Preparing hotspot…'
@@ -1791,7 +1788,7 @@ function photoDetailsRows(details: PhotoPreviewDetails | null) {
     });
   }
   if (details.bleFallbackMessage) {
-    rows.push({label: 'Bluetooth fallback', value: details.bleFallbackMessage, tone: 'warning'});
+    rows.push({label: 'Bluetooth transfer', value: details.bleFallbackMessage, tone: 'warning'});
   }
   if (details.requestId) rows.push({label: 'Request ID', value: details.requestId});
   if (details.fileName) rows.push({label: 'Glasses filename', value: details.fileName});

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1407,7 +1407,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         otaStartingAppIdentityRef.current = otaAppIdentityRef.current;
         clearOtaDisplayProgress();
         await BluetoothSdk.startOtaUpdate();
-        otaChainStartFailuresRef.current = 0;
+        if (otaChainGenerationRef.current === generation) {
+          otaChainStartFailuresRef.current = 0;
+        }
         addEvent('LIVE', 'OTA continuing with next update pass');
       } catch (error) {
         otaStartInFlightRef.current = false;

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -89,6 +89,10 @@ const WIFI_CONNECT_GRACE_MS = 20_000;
 // device that stays away longer than this needs a fresh user tap.
 const OTA_CHAIN_RESUME_WINDOW_MS = 5 * 60_000;
 
+// A failed chain-start dispatch does not consume a pass, but this many
+// consecutive failures end the run instead of retrying on every check.
+const MAX_OTA_CHAIN_START_FAILURES = 3;
+
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
@@ -758,6 +762,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaChainRemainingRef = useRef(0);
   const otaChainDeviceKeyRef = useRef<string | null>(null);
   const otaChainDisconnectedAtRef = useRef<number | null>(null);
+  const otaChainStartFailuresRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
   const connectedDeviceKeyRef = useRef<string | null>(null);
   const otaAppIdentityRef = useRef<string | null>(null);
@@ -1393,9 +1398,19 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         otaStartingAppIdentityRef.current = otaAppIdentityRef.current;
         clearOtaDisplayProgress();
         await BluetoothSdk.startOtaUpdate();
+        otaChainStartFailuresRef.current = 0;
         addEvent('LIVE', 'OTA continuing with next update pass');
       } catch (error) {
         otaStartInFlightRef.current = false;
+        // Nothing started, so the failed dispatch should not consume a
+        // pass — but stop the run after repeated failures rather than
+        // retrying on every subsequent check.
+        otaChainStartFailuresRef.current += 1;
+        if (otaChainStartFailuresRef.current >= MAX_OTA_CHAIN_START_FAILURES) {
+          otaChainRemainingRef.current = 0;
+        } else {
+          otaChainRemainingRef.current += 1;
+        }
         throw error;
       }
     });
@@ -1480,6 +1495,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       // Arm the auto-chain only once the start is acknowledged.
       otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
       otaChainDeviceKeyRef.current = connectedDeviceKeyRef.current;
+      otaChainStartFailuresRef.current = 0;
       addEvent('LIVE', 'OTA start acknowledged');
     });
   }

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -763,6 +763,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaChainDeviceKeyRef = useRef<string | null>(null);
   const otaChainDisconnectedAtRef = useRef<number | null>(null);
   const otaChainStartFailuresRef = useRef(0);
+  const otaChainGenerationRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
   const connectedDeviceKeyRef = useRef<string | null>(null);
   const otaAppIdentityRef = useRef<string | null>(null);
@@ -932,7 +933,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     if (otaChainDisconnectedAtRef.current !== null) {
       if (Date.now() - otaChainDisconnectedAtRef.current > OTA_CHAIN_RESUME_WINDOW_MS) {
-        otaChainRemainingRef.current = 0;
+        cancelOtaChain();
       }
       otaChainDisconnectedAtRef.current = null;
     }
@@ -1361,13 +1362,20 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       maybeContinueOtaChain();
       return true;
     }
-    otaChainRemainingRef.current = 0;
+    cancelOtaChain();
     otaStatusRef.current = null;
     setOtaStatus(null);
     setOtaStatusMessage('Glasses firmware is up to date');
     setOtaUpdateAvailable(false);
     addEvent('LIVE', 'OTA up to date');
     return false;
+  }
+
+  // Cancel the armed run; bumping the generation invalidates any pending
+  // continuation dispatch so its failure handling cannot re-arm the chain.
+  function cancelOtaChain() {
+    otaChainGenerationRef.current += 1;
+    otaChainRemainingRef.current = 0;
   }
 
   // One user-initiated update run may span several OTA passes: legacy
@@ -1381,7 +1389,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     if (otaChainDeviceKeyRef.current && otaChainDeviceKeyRef.current !== connectedDeviceKeyRef.current) {
       // The armed run belongs to another device/connection; require a fresh tap.
-      otaChainRemainingRef.current = 0;
+      cancelOtaChain();
       return;
     }
     if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
@@ -1390,6 +1398,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
       return;
     }
+    const generation = otaChainGenerationRef.current;
     otaChainRemainingRef.current -= 1;
     otaStartInFlightRef.current = true;
     void runAction('Continue OTA', async () => {
@@ -1404,12 +1413,15 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         otaStartInFlightRef.current = false;
         // Nothing started, so the failed dispatch should not consume a
         // pass — but stop the run after repeated failures rather than
-        // retrying on every subsequent check.
-        otaChainStartFailuresRef.current += 1;
-        if (otaChainStartFailuresRef.current >= MAX_OTA_CHAIN_START_FAILURES) {
-          otaChainRemainingRef.current = 0;
-        } else {
-          otaChainRemainingRef.current += 1;
+        // retrying on every subsequent check. If the run was cancelled or
+        // re-armed while the dispatch was pending, leave it alone.
+        if (otaChainGenerationRef.current === generation) {
+          otaChainStartFailuresRef.current += 1;
+          if (otaChainStartFailuresRef.current >= MAX_OTA_CHAIN_START_FAILURES) {
+            cancelOtaChain();
+          } else {
+            otaChainRemainingRef.current += 1;
+          }
         }
         throw error;
       }
@@ -1493,6 +1505,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw error;
       }
       // Arm the auto-chain only once the start is acknowledged.
+      otaChainGenerationRef.current += 1;
       otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
       otaChainDeviceKeyRef.current = connectedDeviceKeyRef.current;
       otaChainStartFailuresRef.current = 0;
@@ -1502,7 +1515,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   async function disconnect() {
     await runAction('Disconnect', async () => {
-      otaChainRemainingRef.current = 0;
+      cancelOtaChain();
       stopDirectStreamFrameWatchdog();
       await bluetooth.disconnect();
       applyDisconnectedState('Disconnected');
@@ -4072,7 +4085,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       setOtaUpdateAvailable(false);
     }
     if (payload.status === 'failed') {
-      otaChainRemainingRef.current = 0;
+      cancelOtaChain();
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);
     schedulePostOtaCheck(payload);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -571,10 +571,10 @@ const GLASSES_PHOTO_POLL_ATTEMPTS = 120;
 const GLASSES_GALLERY_FAILURE_THRESHOLD = 3;
 const VIDEO_POLL_ATTEMPTS = 180;
 const DIRECT_PHOTO_UPLOAD_TIMEOUT_MS = 75_000;
-export const PHOTO_BLE_FALLBACK_QUALITY_WARNING =
-  'Wi-Fi upload failed; photo was compressed for Bluetooth fallback, so image quality is lower.';
+export const PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE =
+  'Photo is transferred over Bluetooth, which takes longer than Wi-Fi.';
 const PHOTO_BLE_FALLBACK_COMPRESSION_MESSAGE =
-  'Wi-Fi upload failed; compressing photo for Bluetooth fallback.';
+  'Preparing the photo for Bluetooth transfer.';
 const DIRECT_WEBRTC_RECEIVER_WARMUP_MS = 1000;
 const BARCODE_SCAN_VISIBLE_TIMEOUT_MS = 2_500;
 const ANDROID_12_API_LEVEL = 31;
@@ -1782,7 +1782,8 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         await captureToGlassesStorage();
         return;
       }
-      requireGlassesWifi('capture photos');
+      // Without glasses Wi-Fi the photo is delivered over the Bluetooth
+      // transfer path instead of the network upload.
       if (photoDestinationRef.current === 'phone') {
         await captureAndUploadToPhone();
         return;
@@ -2134,7 +2135,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setPhotoPreviewDetails((current) => ({
       ...current,
       bleFallbackMessage: current?.bleFallbackUsed
-        ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
+        ? PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE
         : current?.bleFallbackMessage,
       byteCount: payload.byteCount,
       previewUrl: payload.fileUri,
@@ -2752,7 +2753,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
             setPhotoPreviewDetails((current) => ({
               ...current,
               bleFallbackMessage: current?.bleFallbackUsed
-                ? PHOTO_BLE_FALLBACK_QUALITY_WARNING
+                ? PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE
                 : current?.bleFallbackMessage,
               byteCount: typeof json.fileSizeBytes === 'number' ? json.fileSizeBytes : current?.byteCount,
               contentType: json.contentType ?? current?.contentType,
@@ -4994,9 +4995,9 @@ function photoBleFallbackMessage(status: string) {
 function photoBleFallbackProgressMessage(status: string, currentMessage?: string) {
   switch (status) {
     case 'ready_for_transfer':
-      return PHOTO_BLE_FALLBACK_QUALITY_WARNING;
+      return PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE;
     case 'transferring':
-      return PHOTO_BLE_FALLBACK_QUALITY_WARNING;
+      return PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE;
     default:
       return currentMessage;
   }


### PR DESCRIPTION
## Summary

Two follow-ups to #32:

**OTA auto-chain hardening** (the first commit was pushed moments before #32 merged and missed it; the next two address review findings on it):

- `928aea2` — a failed chain-start dispatch no longer consumes one of the four auto-continuations; the run ends after three consecutive start failures instead of retrying on every check
- `ac3bdde` — cancelling the run (manual disconnect, failed status, up to date, resume-window expiry, device mismatch) bumps a chain generation, so a dispatch failure from a cancelled run can never re-arm it
- `5c1760c` — the success path's failure-counter reset is guarded by the same generation check

**Photo capture over Bluetooth** (all three example apps — React Native, native Android, native iOS):

- `1a83110` — with the 0.1.20 BLE photo path, captures work without glasses Wi-Fi: the photo button is no longer disabled and the capture-time Wi-Fi guard is removed (video and streaming still require Wi-Fi). The camera-page Wi-Fi notice is kept but reworded — photos still work over Bluetooth, they just take longer to transfer. The BLE fallback messages now mention the longer transfer time instead of lower image quality, since the Bluetooth path no longer noticeably degrades quality.

## Verification

- `tsc --noEmit` clean on the React Native example
- `compileDebugKotlin` clean on the native Android example
- iOS changes are copy/gating-only; the Example App Builds workflow builds the IPA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UX and OTA retry logic only; no SDK or production auth/data paths. Video and cloud upload behavior unchanged aside from clearer messaging.
> 
> **Overview**
> **Photo capture without glasses Wi-Fi** is enabled across the Android, iOS, and React Native example apps. Capture no longer calls `requireGlassesWifi` for photos (video/stream still require Wi‑Fi). Photo controls stay enabled when glasses are connected even if Wi‑Fi is off; the UI shows an informational notice that Bluetooth transfer is slower instead of blocking capture. Copy reframes Bluetooth delivery as a slower transfer path, not a degraded-quality fallback (`PHOTO_BLE_FALLBACK_TRANSFER_MESSAGE`).
> 
> **OTA auto-chain** in the React Native example is hardened: `cancelOtaChain()` bumps a generation counter so stale continuation dispatches cannot re-arm the chain. A failed `startOtaUpdate` dispatch no longer consumes a pass—the budget is restored unless three consecutive start failures occur, then the run ends. Chain cancellation is centralized on disconnect, OTA failure, up-to-date checks, and resume-window expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8311054e9be573e66f65bdf23920a33aeedac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->