### PR TITLE
Track Bluetooth SDK 0.1.21-dev.0

### DIFF
--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.20",
+    "@mentra/bluetooth-sdk": "0.1.21-dev.0",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -917,8 +917,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       postOtaCheckInProgressRef.current = false;
       postOtaCheckedSessionRef.current = null;
       setLatestVersionInfoSignature(null);
-      // A stale in-progress OTA status (e.g. the BES step's final
-      // 'step_complete' before the reboot) must not gate the next check.
+      // A stale in-progress OTA status must not gate the next check. Since
+      // SDK 0.1.21 a BES-final pass on session-aware glasses ends with a
+      // terminal 'complete' before the reboot, but glasses that never
+      // report OTA session state (e.g. April-era ASG client 36 — the very
+      // firmware the OTA flow rescues) still end on 'step_complete', so
+      // keep clearing here.
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
       otaStartInFlightRef.current = false;


### PR DESCRIPTION
## Summary

- `35f8e5e` — bump the React Native example to `@mentra/bluetooth-sdk@0.1.21-dev.0`, the first release through the npm channel-promotion flow (Mentra-Community/MentraOS#3479, dev tag). Picks up the SDK emitting a terminal `complete` ota_status for a BES-final OTA pass (Mentra-Community/MentraOS#3461) and the glasses-side wrong-password fast-fail (Mentra-Community/MentraOS#3460).
- `6358103` — keep (and document) the defensive OTA-state clear on disconnect: #3461 only emits terminal `complete` for session-aware glasses; clients that never report OTA session state — the April-era ASG client 36 this flow rescues — still end a BES flash on `step_complete` before the reboot, so the example continues to clear stale in-progress status on reconnect for new-SDK + old-glasses compatibility.

## Status

Draft until `0.1.21-dev.0` is published (MentraOS#3479 is still open — npm currently 404s the version), then:

1. `cd examples/react-native && bun install` and commit the regenerated `bun.lock` (CI's frozen-lockfile install fails until then, as with the 0.1.20 bump).
2. Retest a BES-final pass from April firmware (36 → step_complete path) and from a session-aware client (terminal `complete` path).

## Verification

- `tsc --noEmit` clean against the SDK source at MentraOS dev (`381dd189ae`, includes #3461)
