### PR TITLE
Improve OTA action feedback in example apps

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -381,6 +381,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var otaStartingAppIdentity: String? = null
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String? = null
+    private var otaCheckGeneration = 0
     private var otaNoUpdateHideJob: Job? = null
 
     private val micSampleRate = 16_000
@@ -2517,7 +2518,17 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
     }
 
-    private fun handleOtaCheckResult(updateAvailable: Boolean, showNoUpdateCard: Boolean = false): Boolean {
+    private suspend fun checkForOtaUpdateResult(showNoUpdateCard: Boolean = false): Boolean? {
+        val checkGeneration = otaCheckGeneration
+        val updateAvailable = withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() }
+        if (checkGeneration != otaCheckGeneration || !isGlassesConnected()) {
+            addEvent("LIVE", "OTA check result ignored after connection changed")
+            return null
+        }
+        return handleOtaCheckResult(updateAvailable, showNoUpdateCard)
+    }
+
+    private fun handleOtaCheckResult(updateAvailable: Boolean, showNoUpdateCard: Boolean): Boolean {
         if (isOtaInProgress()) {
             addEvent("LIVE", "OTA check result ignored while update is in progress")
             return updateAvailable
@@ -2621,10 +2632,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                 addEvent("TX", "OTA check skipped while update is in progress")
                 return@runAction
             }
-            handleOtaCheckResult(
-                withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() },
-                showNoUpdateCard = true,
-            )
+            checkForOtaUpdateResult(showNoUpdateCard = true)
         }
     }
 
@@ -2653,8 +2661,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             try {
                 requireConnected("check OTA")
                 requireGlassesWifi("check for OTA updates")
-                handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
-                checkSucceeded = true
+                checkSucceeded = checkForOtaUpdateResult() != null
             } finally {
                 autoOtaCheckInProgress = false
                 if (checkSucceeded) {
@@ -3131,6 +3138,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         glassesHotspotConnector.disconnect()
         otaStartingAppIdentity = null
         latestVersionInfo = null
+        otaCheckGeneration += 1
         resetOtaDisplayProgress()
         hideOtaNoUpdateCard()
         if (hadPhotoRequest) {
@@ -3245,11 +3253,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                     addEvent("LIVE", "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
                     return@runAction
                 }
-                handleOtaCheckResult(
-                    withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() },
-                    showNoUpdateCard = true,
-                )
-                checkSucceeded = true
+                checkSucceeded = checkForOtaUpdateResult(showNoUpdateCard = true) != null
             } finally {
                 postOtaCheckInProgress = false
                 autoOtaCheckInProgress = false

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -255,6 +255,7 @@ data class MentraExampleState(
     val micPlaying: Boolean = false,
     val micRecording: Boolean = false,
     val otaDisplayPercent: Int? = null,
+    val otaNoUpdateVisible: Boolean = false,
     val otaStartPending: Boolean = false,
     val otaStatus: OtaStatusEvent? = null,
     val otaStatusMessage: String? = null,
@@ -380,6 +381,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private var otaStartingAppIdentity: String? = null
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String? = null
+    private var otaNoUpdateHideJob: Job? = null
 
     private val micSampleRate = 16_000
     private val micChannelCount = 1
@@ -398,6 +400,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         private const val CLOUD_URLS_STREAM_KEY = "stream_url"
         private const val CLOUD_URLS_WEBHOOK_KEY = "webhook_url"
         private const val CLOUD_URLS_SAVED_AT_KEY = "saved_at"
+        private const val OTA_NO_UPDATE_CARD_DURATION_MS = 10_000L
     }
 
     private val audioDeviceCallback = object : AudioDeviceCallback() {
@@ -2469,6 +2472,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             otaStartingAppIdentity = null
             resetOtaDisplayProgress()
             autoOtaCheckedConnectionKey = null
+            hideOtaNoUpdateCard()
             state = state.copy(
                 otaStartPending = false,
                 otaStatus = null,
@@ -2513,13 +2517,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
     }
 
-    private fun handleOtaCheckResult(updateAvailable: Boolean): Boolean {
+    private fun handleOtaCheckResult(updateAvailable: Boolean, showNoUpdateCard: Boolean = false): Boolean {
         if (isOtaInProgress()) {
             addEvent("LIVE", "OTA check result ignored while update is in progress")
             return updateAvailable
         }
         otaStartingAppIdentity = null
         if (updateAvailable) {
+            hideOtaNoUpdateCard()
             resetOtaDisplayProgress()
             state = state.copy(
                 otaStatus = null,
@@ -2538,8 +2543,29 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             otaStatusMessage = "Glasses firmware is up to date",
             otaUpdateAvailable = false,
         )
+        if (showNoUpdateCard) {
+            showOtaNoUpdateCard()
+        }
         addEvent("LIVE", "OTA up to date")
         return false
+    }
+
+    private fun showOtaNoUpdateCard() {
+        hideOtaNoUpdateCard()
+        state = state.copy(otaNoUpdateVisible = true)
+        otaNoUpdateHideJob = scope.launch {
+            delay(OTA_NO_UPDATE_CARD_DURATION_MS)
+            otaNoUpdateHideJob = null
+            state = state.copy(otaNoUpdateVisible = false)
+        }
+    }
+
+    private fun hideOtaNoUpdateCard() {
+        otaNoUpdateHideJob?.cancel()
+        otaNoUpdateHideJob = null
+        if (state.otaNoUpdateVisible) {
+            state = state.copy(otaNoUpdateVisible = false)
+        }
     }
 
     override fun onMicPcm(event: MicPcmEvent) {
@@ -2586,14 +2612,20 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         addEvent("LIVE", "audio output ${state.phoneAudioRoute}; ${state.audioMediaStatus}")
     }
 
-    fun checkForOtaUpdate() = runAction("Check OTA") {
-        requireConnected("check OTA")
-        requireGlassesWifi("check for OTA updates")
-        if (isOtaInProgress()) {
-            addEvent("TX", "OTA check skipped while update is in progress")
-            return@runAction
+    fun checkForOtaUpdate() {
+        hideOtaNoUpdateCard()
+        runAction("Check OTA") {
+            requireConnected("check OTA")
+            requireGlassesWifi("check for OTA updates")
+            if (isOtaInProgress()) {
+                addEvent("TX", "OTA check skipped while update is in progress")
+                return@runAction
+            }
+            handleOtaCheckResult(
+                withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() },
+                showNoUpdateCard = true,
+            )
         }
-        handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
     }
 
     private fun maybeAutoCheckOta() {
@@ -2761,6 +2793,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         unregisterAudioStateObservers()
         glassesHotspotConnector.disconnect()
         volumeRefreshJob?.cancel()
+        otaNoUpdateHideJob?.cancel()
         controllerJob.cancel()
         mentraBluetoothSdk.close()
     }
@@ -3099,6 +3132,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         otaStartingAppIdentity = null
         latestVersionInfo = null
         resetOtaDisplayProgress()
+        hideOtaNoUpdateCard()
         if (hadPhotoRequest) {
             pollGeneration += 1
         }
@@ -3148,6 +3182,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     private fun applyOtaStatus(event: OtaStatusEvent) {
+        hideOtaNoUpdateCard()
         if (!isDisplayableOtaStatus(event)) {
             otaStartingAppIdentity = null
             resetOtaDisplayProgress()
@@ -3210,7 +3245,10 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
                     addEvent("LIVE", "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
                     return@runAction
                 }
-                handleOtaCheckResult(withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() })
+                handleOtaCheckResult(
+                    withContext(Dispatchers.IO) { mentraBluetoothSdk.checkForOtaUpdate() },
+                    showNoUpdateCard = true,
+                )
                 checkSucceeded = true
             } finally {
                 postOtaCheckInProgress = false

--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -255,6 +255,7 @@ data class MentraExampleState(
     val micPlaying: Boolean = false,
     val micRecording: Boolean = false,
     val otaDisplayPercent: Int? = null,
+    val otaStartPending: Boolean = false,
     val otaStatus: OtaStatusEvent? = null,
     val otaStatusMessage: String? = null,
     val otaUpdateAvailable: Boolean = false,
@@ -2469,6 +2470,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             resetOtaDisplayProgress()
             autoOtaCheckedConnectionKey = null
             state = state.copy(
+                otaStartPending = false,
                 otaStatus = null,
                 otaDisplayPercent = null,
                 otaStatusMessage = "OTA installed; checking for additional updates",
@@ -2639,15 +2641,27 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
     }
 
-    fun startOtaUpdate() = runAction("Start OTA") {
-        requireConnected("start OTA")
-        requireGlassesWifi("start OTA updates")
-        postOtaCheckedSessionKey = null
-        otaStartingAppIdentity = state.glassesStatus.otaAppIdentity()
-        resetOtaDisplayProgress()
-        state = state.copy(otaDisplayPercent = null)
-        withContext(Dispatchers.IO) { mentraBluetoothSdk.startOtaUpdate() }
-        addEvent("LIVE", "OTA start acknowledged")
+    fun startOtaUpdate() {
+        if (state.otaStartPending) {
+            addEvent("TX", "OTA start skipped; a start is already in flight")
+            return
+        }
+        state = state.copy(otaStartPending = true)
+        runAction("Start OTA") {
+            try {
+                requireConnected("start OTA")
+                requireGlassesWifi("start OTA updates")
+                postOtaCheckedSessionKey = null
+                otaStartingAppIdentity = state.glassesStatus.otaAppIdentity()
+                resetOtaDisplayProgress()
+                state = state.copy(otaDisplayPercent = null)
+                withContext(Dispatchers.IO) { mentraBluetoothSdk.startOtaUpdate() }
+                addEvent("LIVE", "OTA start acknowledged")
+            } catch (error: Throwable) {
+                state = state.copy(otaStartPending = false)
+                throw error
+            }
+        }
     }
 
     fun openBluetoothSettings() = runAction("Open Bluetooth settings") {
@@ -2944,7 +2958,9 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     private fun isGlassesConnected(): Boolean = isGlassesConnected(state.glassesStatus)
 
     private fun isOtaInProgress(): Boolean =
-        state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
+        state.otaStartPending ||
+            state.otaStatus?.status == "in_progress" ||
+            state.otaStatus?.status == "step_complete"
 
     private fun startCameraWarmUpLoop() {
         if (cameraWarmUpJob?.isActive == true) {
@@ -3101,6 +3117,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             streamStatus = status,
             hotspotEnabled = false,
             mentraLiveVersions = MentraLiveVersions(),
+            otaStartPending = false,
             otaStatus = null,
             otaDisplayPercent = null,
             otaStatusMessage = null,
@@ -3135,6 +3152,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             otaStartingAppIdentity = null
             resetOtaDisplayProgress()
             state = state.copy(
+                otaStartPending = false,
                 otaStatus = null,
                 otaDisplayPercent = null,
                 otaStatusMessage = "No active OTA",
@@ -3145,6 +3163,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
 
         val displayPercent = updateOtaDisplayPercent(event)
         state = state.copy(
+            otaStartPending = false,
             otaStatus = event,
             otaDisplayPercent = displayPercent,
             otaStatusMessage = null,

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -167,7 +167,7 @@ fun DeviceScreen(controller: MentraExampleController) {
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     LightBtn(if (connected && !glassesWifiConnected) "Connect Wi-Fi" else "Check OTA", Icons.Outlined.Refresh, Modifier.weight(1f), enabled = canCheckOta, onClick = controller::checkForOtaUpdate)
-                    LightBtn("Start OTA", Icons.Outlined.FileDownload, Modifier.weight(1f), enabled = canStartOta(state), onClick = controller::startOtaUpdate)
+                    LightBtn(if (state.otaStartPending) "Starting OTA..." else "Start OTA", Icons.Outlined.FileDownload, Modifier.weight(1f), enabled = canStartOta(state), onClick = controller::startOtaUpdate)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     LightBtn("Clear Default", Icons.Outlined.DeleteOutline, Modifier.weight(1f), enabled = hasDefaultTarget, onClick = controller::clearDefaultDevice)
@@ -301,10 +301,12 @@ private fun canStartOta(state: com.mentra.examples.android.MentraExampleState): 
     isGlassesConnected(state.glassesStatus) && isGlassesWifiConnected(state.glassesStatus) && state.otaUpdateAvailable && !isOtaInProgress(state)
 
 private fun isOtaInProgress(state: com.mentra.examples.android.MentraExampleState): Boolean =
-    state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
+    state.otaStartPending || state.otaStatus?.status == "in_progress" || state.otaStatus?.status == "step_complete"
 
 private fun otaStatusLine(state: com.mentra.examples.android.MentraExampleState): String =
-    if (isOtaInstalling(state)) {
+    if (state.otaStartPending) {
+        "starting update"
+    } else if (isOtaInstalling(state)) {
         "installing update"
     } else {
         state.otaStatus?.let { "${it.status.replace('_', ' ')} · ${otaDisplayPercent(state)}%" }
@@ -318,6 +320,7 @@ private fun otaDisplayPercent(state: com.mentra.examples.android.MentraExampleSt
 
 private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState): String =
     when {
+        state.otaStartPending -> "Starting update"
         state.otaStatus?.status == "failed" -> "Update failed"
         isOtaInstalling(state) -> "Installing update"
         state.otaStatus != null && isOtaInProgress(state) -> "Updating ${state.otaStatus.stepType.ifBlank { "firmware" }}"
@@ -326,6 +329,9 @@ private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState):
     }
 
 private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState): String {
+    if (state.otaStartPending) {
+        return "Sending the OTA start request to the glasses."
+    }
     state.otaStatus?.errorMessage?.let { return it }
     if (isOtaInstalling(state)) {
         return "The glasses client may restart to finish installation."
@@ -384,7 +390,7 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
                     )
                 }
             }
-            if (installing) {
+            if (state.otaStartPending || installing) {
                 CircularProgressIndicator(
                     color = AppColor.greenPrimary,
                     strokeWidth = 2.dp,
@@ -414,7 +420,7 @@ private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Mo
         )
         if (updateRequired) {
             DarkBtn(
-                if (canStartOta(state)) "Start OTA" else "Connect Wi-Fi first",
+                if (state.otaStartPending) "Starting OTA..." else if (canStartOta(state)) "Start OTA" else "Connect Wi-Fi first",
                 Icons.Outlined.FileDownload,
                 AppColor.greenInk,
                 Modifier.fillMaxWidth(),

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -134,7 +134,7 @@ fun DeviceScreen(controller: MentraExampleController) {
                 StatTile("WI-FI", wifiLabel(glasses), currentWifi?.localIp ?: "unknown", AppColor.muted, Modifier.weight(1f), bold = true)
                 StatTile("RSSI", rssiLabel(glasses), rssiUpdatedLabel(glasses), AppColor.greenAccent, Modifier.weight(1f), bold = true)
             }
-            if (state.otaStatus != null || state.otaUpdateAvailable) {
+            if (state.otaStatus != null || state.otaUpdateAvailable || state.otaNoUpdateVisible) {
                 OtaCard(controller, modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp))
             }
             if (otaWifiRequired) {
@@ -325,6 +325,7 @@ private fun otaCardTitle(state: com.mentra.examples.android.MentraExampleState):
         isOtaInstalling(state) -> "Installing update"
         state.otaStatus != null && isOtaInProgress(state) -> "Updating ${state.otaStatus.stepType.ifBlank { "firmware" }}"
         state.otaUpdateAvailable -> "Firmware update available"
+        state.otaNoUpdateVisible -> "No OTA available"
         else -> "OTA status"
     }
 
@@ -342,6 +343,9 @@ private fun otaCardDetail(state: com.mentra.examples.android.MentraExampleState)
     if (state.otaUpdateAvailable) {
         return "A newer firmware version is available for these glasses."
     }
+    if (state.otaNoUpdateVisible) {
+        return "Your glasses firmware is up to date."
+    }
     return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
 }
 
@@ -351,7 +355,7 @@ private fun isOtaInstalling(state: com.mentra.examples.android.MentraExampleStat
 @Composable
 private fun OtaCard(controller: MentraExampleController, modifier: Modifier = Modifier) {
     val state = controller.state
-    if (state.otaStatus == null && !state.otaUpdateAvailable) return
+    if (state.otaStatus == null && !state.otaUpdateAvailable && !state.otaNoUpdateVisible) return
     val percent = otaDisplayPercent(state)
     val updateRequired = state.otaUpdateAvailable && state.otaStatus == null
     val installing = isOtaInstalling(state)

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -433,6 +433,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var lastMicBytes = 0
     @Published private(set) var micPlaybackHint: String?
     @Published private(set) var otaDisplayPercent: Int?
+    @Published private(set) var otaStartPending = false
     @Published private(set) var otaStatus: OtaStatusEvent?
     @Published private(set) var otaStatusMessage: String?
     @Published private(set) var otaUpdateAvailable = false
@@ -700,15 +701,25 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func startOtaUpdate() {
+        guard !otaStartPending else {
+            append(tag: "TX", text: "OTA start skipped; a start is already in flight")
+            return
+        }
+        otaStartPending = true
         runAsyncAction("Start OTA") { [self] in
-            try requireConnected("start OTA")
-            try requireGlassesWifi("start OTA updates")
-            postOtaCheckedSessionKey = nil
-            otaStartingAppIdentity = otaAppIdentity(glassesValues)
-            resetOtaDisplayProgress()
-            otaDisplayPercent = nil
-            _ = try await mentraBluetoothSdk.startOtaUpdate()
-            append(tag: "LIVE", text: "OTA start acknowledged")
+            do {
+                try requireConnected("start OTA")
+                try requireGlassesWifi("start OTA updates")
+                postOtaCheckedSessionKey = nil
+                otaStartingAppIdentity = otaAppIdentity(glassesValues)
+                resetOtaDisplayProgress()
+                otaDisplayPercent = nil
+                _ = try await mentraBluetoothSdk.startOtaUpdate()
+                append(tag: "LIVE", text: "OTA start acknowledged")
+            } catch {
+                otaStartPending = false
+                throw error
+            }
         }
     }
 
@@ -2235,6 +2246,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 self.otaStartingAppIdentity = nil
                 resetOtaDisplayProgress()
                 autoOtaCheckedConnectionKey = nil
+                otaStartPending = false
                 otaStatus = nil
                 otaDisplayPercent = nil
                 otaStatusMessage = "OTA installed; checking for additional updates"
@@ -2306,6 +2318,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         guard isDisplayableOtaStatus(event) else {
             otaStartingAppIdentity = nil
             resetOtaDisplayProgress()
+            otaStartPending = false
             otaStatus = nil
             otaDisplayPercent = nil
             otaStatusMessage = "No active OTA"
@@ -2314,6 +2327,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
 
         otaDisplayPercent = updateOtaDisplayPercent(event)
+        otaStartPending = false
         otaStatus = event
         otaStatusMessage = nil
         if event.status == "complete" || event.status == "failed" {
@@ -2508,7 +2522,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     private func isOtaInProgress() -> Bool {
-        otaStatus?.status == "in_progress" || otaStatus?.status == "step_complete"
+        otaStartPending || otaStatus?.status == "in_progress" || otaStatus?.status == "step_complete"
     }
 
     private func startCameraWarmUpLoop() {
@@ -2779,6 +2793,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         galleryServerReachable = nil
         galleryServerStatus = "Gallery server: connect glasses first"
         otaStartingAppIdentity = nil
+        otaStartPending = false
         latestVersionInfo = nil
         mentraLiveVersions = MentraLiveVersions()
         resetOtaDisplayProgress()

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -471,6 +471,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var otaStartingAppIdentity: String?
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String?
+    private var otaCheckGeneration = 0
     private var otaNoUpdateHideTask: Task<Void, Never>?
     private var scanSession: ScanSession?
     private var micStartedAt: Date?
@@ -2266,11 +2267,14 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func checkForOtaUpdateResult(showNoUpdateCard: Bool = false) async throws -> Bool {
-        handleOtaCheckResult(
-            try await mentraBluetoothSdk.checkForOtaUpdate(),
-            showNoUpdateCard: showNoUpdateCard
-        )
+    private func checkForOtaUpdateResult(showNoUpdateCard: Bool = false) async throws -> Bool? {
+        let checkGeneration = otaCheckGeneration
+        let updateAvailable = try await mentraBluetoothSdk.checkForOtaUpdate()
+        guard checkGeneration == otaCheckGeneration, glassesConnected else {
+            append(tag: "LIVE", text: "OTA check result ignored after connection changed")
+            return nil
+        }
+        return handleOtaCheckResult(updateAvailable, showNoUpdateCard: showNoUpdateCard)
     }
 
     private func applyVersionInfo(_ event: VersionInfoResult) {
@@ -2412,8 +2416,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 append(tag: "LIVE", text: "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
                 return
             }
-            _ = try await checkForOtaUpdateResult(showNoUpdateCard: true)
-            checkSucceeded = true
+            checkSucceeded = (try await checkForOtaUpdateResult(showNoUpdateCard: true)) != nil
         }
     }
 
@@ -2462,8 +2465,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
             }
             try requireConnected("check OTA")
             try requireGlassesWifi("check for OTA updates")
-            _ = try await checkForOtaUpdateResult()
-            checkSucceeded = true
+            checkSucceeded = (try await checkForOtaUpdateResult()) != nil
         }
     }
 
@@ -2826,6 +2828,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         otaStartingAppIdentity = nil
         otaStartPending = false
         latestVersionInfo = nil
+        otaCheckGeneration += 1
         mentraLiveVersions = MentraLiveVersions()
         resetOtaDisplayProgress()
         otaStatus = nil

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -433,6 +433,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     @Published private(set) var lastMicBytes = 0
     @Published private(set) var micPlaybackHint: String?
     @Published private(set) var otaDisplayPercent: Int?
+    @Published private(set) var otaNoUpdateVisible = false
     @Published private(set) var otaStartPending = false
     @Published private(set) var otaStatus: OtaStatusEvent?
     @Published private(set) var otaStatusMessage: String?
@@ -470,6 +471,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     private var otaStartingAppIdentity: String?
     private var postOtaCheckInProgress = false
     private var postOtaCheckedSessionKey: String?
+    private var otaNoUpdateHideTask: Task<Void, Never>?
     private var scanSession: ScanSession?
     private var micStartedAt: Date?
     private var micElapsedTask: Task<Void, Never>?
@@ -576,6 +578,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         directStreamStartTask?.cancel()
         directStreamStopTask?.cancel()
         micElapsedTask?.cancel()
+        otaNoUpdateHideTask?.cancel()
         directWhipProxy.stop()
         directWhipReceiver.stop()
         photoUploadServer?.stop()
@@ -689,6 +692,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func checkForOtaUpdate() {
+        hideOtaNoUpdateCard()
         runAsyncAction("Check OTA") { [self] in
             try requireConnected("check OTA")
             try requireGlassesWifi("check for OTA updates")
@@ -696,7 +700,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 append(tag: "TX", text: "OTA check skipped while update is in progress")
                 return
             }
-            _ = try await checkForOtaUpdateResult()
+            _ = try await checkForOtaUpdateResult(showNoUpdateCard: true)
         }
     }
 
@@ -2246,6 +2250,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 self.otaStartingAppIdentity = nil
                 resetOtaDisplayProgress()
                 autoOtaCheckedConnectionKey = nil
+                hideOtaNoUpdateCard()
                 otaStartPending = false
                 otaStatus = nil
                 otaDisplayPercent = nil
@@ -2261,8 +2266,11 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func checkForOtaUpdateResult() async throws -> Bool {
-        handleOtaCheckResult(try await mentraBluetoothSdk.checkForOtaUpdate())
+    private func checkForOtaUpdateResult(showNoUpdateCard: Bool = false) async throws -> Bool {
+        handleOtaCheckResult(
+            try await mentraBluetoothSdk.checkForOtaUpdate(),
+            showNoUpdateCard: showNoUpdateCard
+        )
     }
 
     private func applyVersionInfo(_ event: VersionInfoResult) {
@@ -2290,7 +2298,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         }
     }
 
-    private func handleOtaCheckResult(_ updateAvailable: Bool) -> Bool {
+    private func handleOtaCheckResult(_ updateAvailable: Bool, showNoUpdateCard: Bool = false) -> Bool {
         if isOtaInProgress() {
             append(tag: "LIVE", text: "OTA check result ignored while update is in progress")
             return updateAvailable
@@ -2298,6 +2306,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         otaStartingAppIdentity = nil
         resetOtaDisplayProgress()
         if updateAvailable {
+            hideOtaNoUpdateCard()
             otaStatus = nil
             otaDisplayPercent = nil
             otaStatusMessage = nil
@@ -2310,11 +2319,32 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         otaDisplayPercent = nil
         otaStatusMessage = "Glasses firmware is up to date"
         otaUpdateAvailable = false
+        if showNoUpdateCard {
+            showOtaNoUpdateCard()
+        }
         append(tag: "LIVE", text: "OTA up to date")
         return false
     }
 
+    private func showOtaNoUpdateCard() {
+        hideOtaNoUpdateCard()
+        otaNoUpdateVisible = true
+        otaNoUpdateHideTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.otaNoUpdateVisible = false
+            self?.otaNoUpdateHideTask = nil
+        }
+    }
+
+    private func hideOtaNoUpdateCard() {
+        otaNoUpdateHideTask?.cancel()
+        otaNoUpdateHideTask = nil
+        otaNoUpdateVisible = false
+    }
+
     private func applyOtaStatus(_ event: OtaStatusEvent) {
+        hideOtaNoUpdateCard()
         guard isDisplayableOtaStatus(event) else {
             otaStartingAppIdentity = nil
             resetOtaDisplayProgress()
@@ -2382,7 +2412,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 append(tag: "LIVE", text: "OTA complete; skipped verification because glasses Wi-Fi is unavailable")
                 return
             }
-            _ = try await checkForOtaUpdateResult()
+            _ = try await checkForOtaUpdateResult(showNoUpdateCard: true)
             checkSucceeded = true
         }
     }
@@ -2774,6 +2804,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
 
     private func applyDisconnectedState(status: String) {
         glassesValues = .disconnected(connection: .disconnected)
+        hideOtaNoUpdateCard()
         stopPreviewHealthPoll()
         activeStreamId = nil
         streamRequested = false

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -19,7 +19,7 @@ struct DeviceScreen: View {
                         .padding(.horizontal, 16)
                         .padding(.top, 12)
 
-                    if model.otaStatus != nil || model.otaUpdateAvailable {
+                    if model.otaStatus != nil || model.otaUpdateAvailable || model.otaNoUpdateVisible {
                         otaCard
                             .padding(.horizontal, 16)
                             .padding(.top, 10)
@@ -490,6 +490,9 @@ private func otaCardTitle(model: BluetoothViewModel) -> String {
     if model.otaUpdateAvailable {
         return "Firmware update available"
     }
+    if model.otaNoUpdateVisible {
+        return "No OTA available"
+    }
     return "OTA status"
 }
 
@@ -509,6 +512,9 @@ private func otaCardDetail(model: BluetoothViewModel) -> String {
     }
     if model.otaUpdateAvailable {
         return "A newer firmware version is available for these glasses."
+    }
+    if model.otaNoUpdateVisible {
+        return "Your glasses firmware is up to date."
     }
     return "Tap Check OTA to compare the current glasses version with the SDK OTA manifest."
 }

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -150,7 +150,7 @@ struct DeviceScreen: View {
                 }
                 HStack(spacing: 8) {
                     LightActionButton(icon: "arrow.triangle.2.circlepath", title: otaWifiRequired ? "Connect Wi-Fi" : "Check OTA", enabled: canCheckOta, action: model.checkForOtaUpdate)
-                    LightActionButton(icon: "arrow.down.to.line", title: "Start OTA", enabled: canStartOta(model: model), action: model.startOtaUpdate)
+                    LightActionButton(icon: "arrow.down.to.line", title: model.otaStartPending ? "Starting OTA..." : "Start OTA", enabled: canStartOta(model: model), action: model.startOtaUpdate)
                 }
                 HStack(spacing: 8) {
                     LightActionButton(icon: "trash", title: "Clear Default", enabled: hasDefaultTarget, action: model.clearDefaultDevice)
@@ -353,7 +353,7 @@ struct DeviceScreen: View {
                     }
                 }
                 Spacer()
-                if installing {
+                if model.otaStartPending || installing {
                     ProgressView()
                         .tint(AppColor.greenPrimary)
                         .controlSize(.small)
@@ -383,7 +383,7 @@ struct DeviceScreen: View {
                     HStack(spacing: 8) {
                         Image(systemName: "arrow.down.to.line")
                             .font(.system(size: 15, weight: .bold))
-                        Text(canStartOta(model: model) ? "Start OTA" : "Connect Wi-Fi first")
+                        Text(model.otaStartPending ? "Starting OTA..." : canStartOta(model: model) ? "Start OTA" : "Connect Wi-Fi first")
                             .font(.system(size: 13, weight: .bold))
                     }
                     .foregroundColor(.white)
@@ -445,11 +445,14 @@ private func canStartOta(model: BluetoothViewModel) -> Bool {
 
 @MainActor
 private func isOtaInProgress(model: BluetoothViewModel) -> Bool {
-    model.otaStatus?.status == "in_progress" || model.otaStatus?.status == "step_complete"
+    model.otaStartPending || model.otaStatus?.status == "in_progress" || model.otaStatus?.status == "step_complete"
 }
 
 @MainActor
 private func otaStatusLine(model: BluetoothViewModel) -> String {
+    if model.otaStartPending {
+        return "starting update"
+    }
     if isOtaInstalling(model: model) {
         return "installing update"
     }
@@ -472,6 +475,9 @@ private func otaDisplayPercent(model: BluetoothViewModel, status: OtaStatusEvent
 
 @MainActor
 private func otaCardTitle(model: BluetoothViewModel) -> String {
+    if model.otaStartPending {
+        return "Starting update"
+    }
     if model.otaStatus?.status == "failed" {
         return "Update failed"
     }
@@ -489,6 +495,9 @@ private func otaCardTitle(model: BluetoothViewModel) -> String {
 
 @MainActor
 private func otaCardDetail(model: BluetoothViewModel) -> String {
+    if model.otaStartPending {
+        return "Sending the OTA start request to the glasses."
+    }
     if let error = model.otaStatus?.errorMessage {
         return error
     }

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -154,7 +154,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
               <Svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke={colors.inkAlt} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
                 <Path d="M12 3v12" /><Path d="m7 10 5 5 5-5" /><Path d="M5 21h14" />
               </Svg>
-              <Text style={styles.btnTextDark}>Start OTA</Text>
+              <Text style={styles.btnTextDark}>{sdk.otaStartPending ? 'Starting OTA...' : 'Start OTA'}</Text>
             </Pressable>
           </View>
           <View style={styles.btnRow}>
@@ -313,10 +313,13 @@ function canStartOta(sdk: BluetoothSdkExampleModel) {
 }
 
 function isOtaInProgress(sdk: BluetoothSdkExampleModel) {
-  return sdk.otaStatus?.status === 'in_progress' || sdk.otaStatus?.status === 'step_complete';
+  return sdk.otaStartPending || sdk.otaStatus?.status === 'in_progress' || sdk.otaStatus?.status === 'step_complete';
 }
 
 function otaStatusLine(sdk: BluetoothSdkExampleModel) {
+  if (sdk.otaStartPending) {
+    return 'starting update';
+  }
   if (sdk.otaStatus) {
     return `${sdk.otaStatus.status.replace(/_/g, ' ')} · ${otaDisplayPercent(sdk)}%`;
   }
@@ -330,6 +333,9 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
 }
 
 function otaCardTitle(sdk: BluetoothSdkExampleModel) {
+  if (sdk.otaStartPending) {
+    return 'Starting update';
+  }
   if (sdk.otaStatus?.status === 'failed') {
     return 'Update failed';
   }
@@ -346,6 +352,9 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
 }
 
 function otaCardDetail(sdk: BluetoothSdkExampleModel) {
+  if (sdk.otaStartPending) {
+    return 'Sending the OTA start request to the glasses.';
+  }
   if (sdk.otaStatus?.error_message) {
     return sdk.otaStatus.error_message;
   }
@@ -402,7 +411,7 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Text style={[styles.otaTitle, updateRequired && styles.otaTitleRequired]}>{otaCardTitle(sdk)}</Text>
           </View>
         </View>
-        {installing ? (
+        {sdk.otaStartPending || installing ? (
           <ActivityIndicator color={colors.greenPrimary} size="small" />
         ) : sdk.otaStatus ? (
           <Text style={styles.otaPercent}>{percent}%</Text>
@@ -428,7 +437,9 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Path d="m7 10 5 5 5-5" />
             <Path d="M5 21h14" />
           </Svg>
-          <Text style={styles.otaStartButtonText}>{canStartOta(sdk) ? 'Start OTA' : 'Connect Wi-Fi first'}</Text>
+          <Text style={styles.otaStartButtonText}>
+            {sdk.otaStartPending ? 'Starting OTA...' : canStartOta(sdk) ? 'Start OTA' : 'Connect Wi-Fi first'}
+          </Text>
         </Pressable>
       ) : null}
     </View>

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -99,7 +99,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <StatCard label="WI-FI" value={wifiLabel(sdk.glasses)} sub={wifiSubLabel(sdk.glasses)} subColor={colors.muted} bold />
             <StatCard label="RSSI" value={rssiLabel(sdk.glasses)} sub={rssiUpdatedLabel(sdk.glasses)} subColor={colors.greenAccent} bold />
           </View>
-          {(sdk.otaStatus || sdk.otaUpdateAvailable) ? <OtaCard sdk={sdk} /> : null}
+          {(sdk.otaStatus || sdk.otaUpdateAvailable || sdk.otaNoUpdateVisible) ? <OtaCard sdk={sdk} /> : null}
           {otaWifiRequired ? (
             <OfflineNotice message="Connect the glasses to Wi-Fi from the System tab before checking or starting OTA updates. OTA downloads run over the glasses network connection." />
           ) : null}
@@ -348,6 +348,9 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaUpdateAvailable) {
     return 'Firmware update available';
   }
+  if (sdk.otaNoUpdateVisible) {
+    return 'No OTA available';
+  }
   return 'OTA status';
 }
 
@@ -367,6 +370,9 @@ function otaCardDetail(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaUpdateAvailable) {
     return 'A newer firmware version is available for these glasses.';
   }
+  if (sdk.otaNoUpdateVisible) {
+    return 'Your glasses firmware is up to date.';
+  }
   return 'Tap Check OTA to compare the current glasses version with the SDK OTA manifest.';
 }
 
@@ -385,7 +391,7 @@ function isOtaInstalling(sdk: BluetoothSdkExampleModel) {
 }
 
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
-  if (!sdk.otaStatus && !sdk.otaUpdateAvailable) {
+  if (!sdk.otaStatus && !sdk.otaUpdateAvailable && !sdk.otaNoUpdateVisible) {
     return null;
   }
   const percent = otaDisplayPercent(sdk);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -405,6 +405,7 @@ export type BluetoothSdkExampleState = {
   micPlaying: boolean;
   micRecording: boolean;
   otaDisplayPercent: number | null;
+  otaStartPending: boolean;
   otaStatus: OtaStatusEvent | null;
   otaStatusMessage: string | null;
   otaUpdateAvailable: boolean;
@@ -654,6 +655,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [micPlaybackHint, setMicPlaybackHint] = useState<string | null>(null);
   const [otaStatus, setOtaStatus] = useState<OtaStatusEvent | null>(null);
   const [otaDisplayPercent, setOtaDisplayPercent] = useState<number | null>(null);
+  const [otaStartPending, setOtaStartPending] = useState(false);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
   const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
   const [wifiConnectingSsid, setWifiConnectingSsid] = useState<string | null>(null);
@@ -886,7 +888,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       // 'step_complete' before the reboot) must not gate the next check.
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
-      otaStartInFlightRef.current = false;
+      setOtaStartInFlight(false);
       if (otaChainRemainingRef.current > 0 && otaChainDisconnectedAtRef.current === null) {
         otaChainDisconnectedAtRef.current = Date.now();
       }
@@ -1362,7 +1364,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     const generation = otaChainGenerationRef.current;
     otaChainRemainingRef.current -= 1;
-    otaStartInFlightRef.current = true;
+    setOtaStartInFlight(true);
     void runAction('Continue OTA', async () => {
       try {
         postOtaCheckedSessionRef.current = null;
@@ -1374,7 +1376,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         }
         addEvent('LIVE', 'OTA continuing with next update pass');
       } catch (error) {
-        otaStartInFlightRef.current = false;
+        setOtaStartInFlight(false);
         // Nothing started, so the failed dispatch should not consume a
         // pass — but stop the run after repeated failures rather than
         // retrying on every subsequent check. If the run was cancelled or
@@ -1395,6 +1397,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   function clearOtaDisplayProgress() {
     otaDisplayProgressRef.current = null;
     setOtaDisplayPercent(null);
+  }
+
+  function setOtaStartInFlight(inFlight: boolean) {
+    otaStartInFlightRef.current = inFlight;
+    setOtaStartPending(inFlight);
   }
 
   function updateOtaDisplayPercent(payload: OtaStatusEvent) {
@@ -1461,11 +1468,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       postOtaCheckedSessionRef.current = null;
       otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
       clearOtaDisplayProgress();
-      otaStartInFlightRef.current = true;
+      setOtaStartInFlight(true);
       try {
         await BluetoothSdk.startOtaUpdate();
       } catch (error) {
-        otaStartInFlightRef.current = false;
+        setOtaStartInFlight(false);
         throw error;
       }
       // Arm the auto-chain only once the start is acknowledged.
@@ -3878,7 +3885,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     otaStatusRef.current = null;
     otaStartingAppIdentityRef.current = null;
-    otaStartInFlightRef.current = false;
+    setOtaStartInFlight(false);
     setOtaStatus(null);
     clearOtaDisplayProgress();
     setOtaStatusMessage(null);
@@ -3892,7 +3899,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   function applyOtaStatus(payload: OtaStatusEvent) {
-    otaStartInFlightRef.current = false;
+    setOtaStartInFlight(false);
     if (!isDisplayableOtaStatus(payload)) {
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
@@ -4021,6 +4028,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     micRecording,
     otaStatus,
     otaDisplayPercent,
+    otaStartPending,
     otaStatusMessage,
     otaUpdateAvailable,
     openBluetoothSettings,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -82,6 +82,7 @@ type PhotoCaptureOptions = {
 // glasses first hop to an intermediate ASG client before the firmware pass).
 // Bound the automatic continuations so a misbehaving manifest cannot loop.
 const MAX_OTA_CHAIN_PASSES = 4;
+const OTA_NO_UPDATE_CARD_DURATION_MS = 10_000;
 
 // The SDK gives up waiting for a wifi connect ack after 15s, but the glasses
 // often finish associating shortly after; keep the connecting state alive a
@@ -405,6 +406,7 @@ export type BluetoothSdkExampleState = {
   micPlaying: boolean;
   micRecording: boolean;
   otaDisplayPercent: number | null;
+  otaNoUpdateVisible: boolean;
   otaStartPending: boolean;
   otaStatus: OtaStatusEvent | null;
   otaStatusMessage: string | null;
@@ -655,6 +657,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [micPlaybackHint, setMicPlaybackHint] = useState<string | null>(null);
   const [otaStatus, setOtaStatus] = useState<OtaStatusEvent | null>(null);
   const [otaDisplayPercent, setOtaDisplayPercent] = useState<number | null>(null);
+  const [otaNoUpdateVisible, setOtaNoUpdateVisible] = useState(false);
   const [otaStartPending, setOtaStartPending] = useState(false);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
   const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
@@ -732,6 +735,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaChainStartFailuresRef = useRef(0);
   const otaChainGenerationRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
+  const otaNoUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectedDeviceKeyRef = useRef<string | null>(null);
   const otaAppIdentityRef = useRef<string | null>(null);
   const wifiConnectAttemptRef = useRef(0);
@@ -894,6 +898,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       }
       setOtaStatus(null);
       clearOtaDisplayProgress();
+      hideOtaNoUpdateCard();
       setOtaStatusMessage(null);
       setOtaUpdateAvailable(false);
       return;
@@ -1089,6 +1094,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       barcodeScanRequestIdsRef.current.clear();
       pollGenerationRef.current += 1;
       videoPollGenerationRef.current += 1;
+      if (otaNoUpdateTimerRef.current) {
+        clearTimeout(otaNoUpdateTimerRef.current);
+        otaNoUpdateTimerRef.current = null;
+      }
       stopMicElapsedTimer();
       stopMicPlaybackSync();
     };
@@ -1296,6 +1305,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   async function checkForOtaUpdate() {
+    hideOtaNoUpdateCard();
     await runAction('Check OTA', async () => {
       if (!glassesConnected) {
         throw new Error('Connect glasses first.');
@@ -1305,11 +1315,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('TX', 'OTA check skipped while update is in progress');
         return;
       }
-      await checkForOtaUpdateResult();
+      await checkForOtaUpdateResult(true);
     });
   }
 
-  async function checkForOtaUpdateResult(): Promise<boolean> {
+  async function checkForOtaUpdateResult(showNoUpdateCard = false): Promise<boolean> {
     const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
     if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
       addEvent('LIVE', 'OTA check result ignored while update is in progress');
@@ -1318,6 +1328,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     otaStartingAppIdentityRef.current = null;
     clearOtaDisplayProgress();
     if (updateAvailable) {
+      hideOtaNoUpdateCard();
       otaStatusRef.current = null;
       setOtaStatus(null);
       setOtaStatusMessage(null);
@@ -1331,8 +1342,28 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setOtaStatus(null);
     setOtaStatusMessage('Glasses firmware is up to date');
     setOtaUpdateAvailable(false);
+    if (showNoUpdateCard) {
+      showOtaNoUpdateCard();
+    }
     addEvent('LIVE', 'OTA up to date');
     return false;
+  }
+
+  function showOtaNoUpdateCard() {
+    hideOtaNoUpdateCard();
+    setOtaNoUpdateVisible(true);
+    otaNoUpdateTimerRef.current = setTimeout(() => {
+      otaNoUpdateTimerRef.current = null;
+      setOtaNoUpdateVisible(false);
+    }, OTA_NO_UPDATE_CARD_DURATION_MS);
+  }
+
+  function hideOtaNoUpdateCard() {
+    if (otaNoUpdateTimerRef.current) {
+      clearTimeout(otaNoUpdateTimerRef.current);
+      otaNoUpdateTimerRef.current = null;
+    }
+    setOtaNoUpdateVisible(false);
   }
 
   // Cancel the armed run; bumping the generation invalidates any pending
@@ -1440,7 +1471,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           addEvent('LIVE', 'OTA complete; skipped verification because glasses Wi-Fi is unavailable');
           return;
         }
-        await checkForOtaUpdateResult();
+        await checkForOtaUpdateResult(true);
         checkSucceeded = true;
       } finally {
         postOtaCheckInProgressRef.current = false;
@@ -3886,6 +3917,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     otaStatusRef.current = null;
     otaStartingAppIdentityRef.current = null;
     setOtaStartInFlight(false);
+    hideOtaNoUpdateCard();
     setOtaStatus(null);
     clearOtaDisplayProgress();
     setOtaStatusMessage(null);
@@ -3900,6 +3932,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   function applyOtaStatus(payload: OtaStatusEvent) {
     setOtaStartInFlight(false);
+    hideOtaNoUpdateCard();
     if (!isDisplayableOtaStatus(payload)) {
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
@@ -4028,6 +4061,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     micRecording,
     otaStatus,
     otaDisplayPercent,
+    otaNoUpdateVisible,
     otaStartPending,
     otaStatusMessage,
     otaUpdateAvailable,

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -1491,20 +1491,20 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   }
 
   async function startOtaUpdate() {
+    if (otaStartInFlightRef.current) {
+      addEvent('TX', 'OTA start skipped; a start is already in flight');
+      return;
+    }
+    setOtaStartInFlight(true);
     await runAction('Start OTA', async () => {
-      if (!glassesConnected) {
-        throw new Error('Connect glasses first.');
-      }
-      requireGlassesWifi('start OTA updates');
-      if (otaStartInFlightRef.current) {
-        addEvent('TX', 'OTA start skipped; a start is already in flight');
-        return;
-      }
-      postOtaCheckedSessionRef.current = null;
-      otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
-      clearOtaDisplayProgress();
-      setOtaStartInFlight(true);
       try {
+        if (!glassesConnected) {
+          throw new Error('Connect glasses first.');
+        }
+        requireGlassesWifi('start OTA updates');
+        postOtaCheckedSessionRef.current = null;
+        otaStartingAppIdentityRef.current = otaAppIdentity(glasses);
+        clearOtaDisplayProgress();
         await BluetoothSdk.startOtaUpdate();
       } catch (error) {
         setOtaStartInFlight(false);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -735,6 +735,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaChainStartFailuresRef = useRef(0);
   const otaChainGenerationRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
+  const otaCheckGenerationRef = useRef(0);
   const otaNoUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectedDeviceKeyRef = useRef<string | null>(null);
   const otaAppIdentityRef = useRef<string | null>(null);
@@ -925,8 +926,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     void runAction('Auto-check OTA', async () => {
       let checkSucceeded = false;
       try {
-        await checkForOtaUpdateResult();
-        checkSucceeded = true;
+        checkSucceeded = (await checkForOtaUpdateResult()) !== null;
       } finally {
         autoOtaCheckInProgressRef.current = false;
         if (!checkSucceeded) {
@@ -1319,8 +1319,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     });
   }
 
-  async function checkForOtaUpdateResult(showNoUpdateCard = false): Promise<boolean> {
+  async function checkForOtaUpdateResult(showNoUpdateCard = false): Promise<boolean | null> {
+    const checkGeneration = otaCheckGenerationRef.current;
     const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
+    if (checkGeneration !== otaCheckGenerationRef.current || !glassesConnectedRef.current) {
+      addEvent('LIVE', 'OTA check result ignored after connection changed');
+      return null;
+    }
     if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
       addEvent('LIVE', 'OTA check result ignored while update is in progress');
       return updateAvailable;
@@ -1471,8 +1476,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
           addEvent('LIVE', 'OTA complete; skipped verification because glasses Wi-Fi is unavailable');
           return;
         }
-        await checkForOtaUpdateResult(true);
-        checkSucceeded = true;
+        checkSucceeded = (await checkForOtaUpdateResult(true)) !== null;
       } finally {
         postOtaCheckInProgressRef.current = false;
         autoOtaCheckInProgressRef.current = false;
@@ -3916,6 +3920,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     }
     otaStatusRef.current = null;
     otaStartingAppIdentityRef.current = null;
+    otaCheckGenerationRef.current += 1;
     setOtaStartInFlight(false);
     hideOtaNoUpdateCard();
     setOtaStatus(null);


### PR DESCRIPTION
## Summary

- switch the available-update card to a visible Starting update state immediately when Start OTA is tapped
- show an activity indicator and disable both Start OTA entry points while the command is being dispatched
- keep the pending state through the SDK acknowledgement-to-status gap, then hand off to normal OTA progress on the first status event
- show the existing update prompt when Check OTA finds an available update
- show a transient No OTA available card for 10 seconds when a manual check finds that the glasses are current
- show the same transient up-to-date result after post-install verification, while keeping automatic connection checks quiet
- apply the same lifecycle and UI behavior to the React Native, native Android, and native iOS examples

## Why

Starting an OTA update can take one or two seconds before the SDK call returns or an OTA status event arrives. During that gap, the available-update card previously looked unchanged and its button remained available, so users received no acknowledgement and could send duplicate start requests.

A completed Check OTA request already stored an up-to-date message when no update was found, but the OTA card only rendered for an OTA status or an available update. That left successful no-update checks with no result in the card location.

The examples now maintain explicit UI state for both gaps. Start-pending begins synchronously with the button tap and remains active until the SDK reports actual OTA state. A user-visible no-update result begins when the check resolves false and expires after 10 seconds. Its timer is canceled by a newer update result, OTA status, disconnect, or controller teardown so it cannot hide newer OTA state.

## Validation

- `cd examples/react-native && bun install --frozen-lockfile && bunx tsc --noEmit`
- `cd examples/android && ./gradlew :app:compileDebugKotlin --no-daemon`
- `cd examples/ios && xcodebuild -project MentraExample.xcodeproj -scheme MentraExample -configuration Debug -destination generic/platform=iOS -clonedSourcePackagesDirPath SourcePackages -derivedDataPath build-device CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to example-app controllers and Device screens; no SDK or production firmware paths are modified.
> 
> **Overview**
> **OTA start** now sets **`otaStartPending`** as soon as the user taps Start OTA (React Native, Android, iOS). Buttons show **Starting OTA...**, spinners appear on the OTA card, and **`isOtaInProgress`** treats pending start like an active update so duplicate starts are blocked until the first status event or a failed start clears pending.
> 
> **Check OTA** can surface a **No OTA available** card for **10 seconds** when a **manual** check or **post-install verification** finds firmware current; auto-checks on connect stay quiet. The timer is cleared on disconnect, new OTA state, or when an update is found.
> 
> OTA check handling is centralized with a **generation counter** so results that return after disconnect or a superseded check are **ignored** instead of updating UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b167e600f13ae0885831d8bb04e072bbeaa2262c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->