### PR TITLE
Fix cleartext support in React Native release APKs

### DIFF
--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -257,6 +257,10 @@ jobs:
         working-directory: examples/react-native
         run: bunx expo prebuild --platform android --no-install
 
+      - name: Verify Android cleartext support
+        working-directory: examples/react-native
+        run: grep -q 'android:usesCleartextTraffic="true"' android/app/src/main/AndroidManifest.xml
+
       - name: Type check generated Android project
         working-directory: examples/react-native/android
         run: |
@@ -343,6 +347,10 @@ jobs:
       - name: Generate Android project
         working-directory: examples/react-native-elevenlabs-audio
         run: bunx expo prebuild --platform android --no-install
+
+      - name: Verify Android cleartext support
+        working-directory: examples/react-native-elevenlabs-audio
+        run: grep -q 'android:usesCleartextTraffic="true"' android/app/src/main/AndroidManifest.xml
 
       - name: Type check generated Android project
         working-directory: examples/react-native-elevenlabs-audio/android

--- a/examples/react-native-elevenlabs-audio/app.json
+++ b/examples/react-native-elevenlabs-audio/app.json
@@ -18,7 +18,6 @@
     "android": {
       "package": "com.mentra.elevenlabsaudio",
       "softwareKeyboardLayoutMode": "pan",
-      "usesCleartextTraffic": true,
       "permissions": [
         "android.permission.BLUETOOTH",
         "android.permission.BLUETOOTH_ADMIN",
@@ -43,6 +42,7 @@
         {
           "android": {
             "minSdkVersion": 28,
+            "usesCleartextTraffic": true,
             "packagingOptions": {
               "pickFirst": [
                 "**/libc++_shared.so",

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -27,7 +27,6 @@
     "android": {
       "package": "com.mentra.bluetoothsdk.example.reactnative",
       "softwareKeyboardLayoutMode": "pan",
-      "usesCleartextTraffic": true,
       "permissions": [
         "android.permission.BLUETOOTH",
         "android.permission.BLUETOOTH_ADMIN",
@@ -54,6 +53,7 @@
         {
           "android": {
             "minSdkVersion": 28,
+            "usesCleartextTraffic": true,
             "packagingOptions": {
               "pickFirst": [
                 "**/libc++_shared.so",


### PR DESCRIPTION
## What failed

The React Native example APK published for Bluetooth SDK 0.1.20 cannot complete a BLE photo transfer to the phone-local photo receiver. The BLE image reaches the Android SDK, but the SDK then relays the decoded JPEG to the receiver over `http://127.0.0.1`. Android rejects that final local POST with:

```
BLE photo upload failed: CLEARTEXT communication to 127.0.0.1 not permitted by network security policy
```

This is a release-packaging issue, not a failure of the glasses-to-phone BLE transfer.

## Root cause

Both Expo examples declared `usesCleartextTraffic: true` under the top-level `expo.android` object. With the current Expo SDK, a clean `expo prebuild` does not apply that field to the generated Android manifest.

Local development had a previously generated, gitignored `android/` tree whose manifest still contained `android:usesCleartextTraffic="true"`, which hid the problem. CI starts from a clean checkout, generated a manifest without the attribute, and published that APK.

I verified the exact `sdk-0.1.20/mentra-example-react-native.apk` release asset (SHA-256 `058efaaa7500eca453952e81c2ccb8d5356eaf19c453de05c1826412e6310d3d`) with `aapt2`: its packaged `<application>` has no `usesCleartextTraffic` attribute.

## Changes

- Move `usesCleartextTraffic: true` into the supported `expo-build-properties` Android configuration for the main React Native example.
- Apply the same correction to the ElevenLabs React Native example, which used the same ineffective configuration.
- Add CI checks immediately after each clean Expo prebuild to require `android:usesCleartextTraffic="true"` in the generated manifest. A future Expo/configuration change will now fail the build instead of silently publishing a broken APK.

The native Android example already declares `android:usesCleartextTraffic="true"` directly in its checked-in manifest and does not need a change.

## Verification

- Ran `bun install --frozen-lockfile` for both Expo examples.
- Ran clean-worktree Android prebuilds for both Expo examples.
- Confirmed both newly generated manifests contain `android:usesCleartextTraffic="true"`.
- Validated both JSON config files with `jq`.
- Ran `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app packaging and CI guardrails only; no SDK or production app runtime logic changes.
> 
> **Overview**
> Fixes **release React Native example APKs** blocking local HTTP (e.g. BLE photo relay to `http://127.0.0.1`) because cleartext was never written into the generated manifest.
> 
> **`usesCleartextTraffic: true`** is removed from top-level `expo.android` in both Expo examples and set under the **`expo-build-properties`** Android block so a clean `expo prebuild` emits `android:usesCleartextTraffic="true"`.
> 
> CI for the main and ElevenLabs React Native Android jobs now **grep the manifest right after prebuild** and fail if that attribute is missing, so future Expo/config regressions cannot ship broken release APKs again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3126db3738adb71a7204c69a4160b5393d0e23d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->