### PR TITLE
Update example apps to Bluetooth SDK 0.1.21-beta.2

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.21-beta.1
+mentraSdkVersion=0.1.21-beta.2
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.21-beta.1
+mentraSdkVersion=0.1.21-beta.2

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.21-beta.1;
+				version = 0.1.21-beta.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.21-beta.1`:
+The Xcode project pins the public Swift package to `0.1.21-beta.2`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.21-beta.1
+    exactVersion: 0.1.21-beta.2
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.1",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.2",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.1", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-M1z6i6v97QNzdp7RWc2LuGk6G+hAQxowTPkYascbKmowymCKJOuqKkNiEBlT8obC2bVByeVf50UMlpbFjt7CWg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.2", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yvKUGq2fCSBj4yydEkmeyoD+MKHQPXOaru07eriiyuWOCq0W8qmxQef3V1fO5YNZggfTEJ4V/KMPa60nGpEheQ=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.1",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.2",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.21-beta.1"
+"@mentra/bluetooth-sdk": "0.1.21-beta.2"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.1",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.2",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.1", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-M1z6i6v97QNzdp7RWc2LuGk6G+hAQxowTPkYascbKmowymCKJOuqKkNiEBlT8obC2bVByeVf50UMlpbFjt7CWg=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.2", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yvKUGq2fCSBj4yydEkmeyoD+MKHQPXOaru07eriiyuWOCq0W8qmxQef3V1fO5YNZggfTEJ4V/KMPa60nGpEheQ=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.1",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.2",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
## Summary

- update the native Android example to `com.mentraglass:bluetooth-sdk:0.1.21-beta.2`
- update the native iOS example to the SwiftPM `0.1.21-beta.2` tag
- update the React Native and ElevenLabs audio examples to `@mentra/bluetooth-sdk@0.1.21-beta.2`
- regenerate both Bun lockfiles and refresh version snippets in the example READMEs

## Verification

- `bun install --frozen-lockfile --ignore-scripts` in both React Native examples
- `bunx tsc --noEmit` in both React Native examples
- native iOS generic-device build with code signing disabled
- `./gradlew :app:compileDebugKotlin --no-daemon` for native Android
- confirmed the npm package, SwiftPM tag, and Maven Central artifact are published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and lockfile updates in example projects only; no production SDK or runtime behavior changes in this diff.
> 
> **Overview**
> Bumps all starter-kit **example apps** from Mentra Bluetooth SDK **0.1.21-beta.1** to **0.1.21-beta.2** so they track the latest published release.
> 
> **Android** (`examples/android`): `mentraSdkVersion` in `gradle.properties` and the README snippet.
> 
> **iOS** (`examples/ios`): SwiftPM exact version in `project.pbxproj`, `project.yml`, and README.
> 
> **React Native** (`examples/react-native` and `examples/react-native-elevenlabs-audio`): `@mentra/bluetooth-sdk` in `package.json`, regenerated `bun.lock` files, and README version example.
> 
> No application logic changes—dependency pins, lockfiles, and docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba4761a639ce463aca83b52a633d5d2557dfad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->