### PR TITLE
Keep React Native OTA to one start per session

### DIFF
--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -99,7 +99,7 @@ export function DeviceScreen({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <StatCard label="WI-FI" value={wifiLabel(sdk.glasses)} sub={wifiSubLabel(sdk.glasses)} subColor={colors.muted} bold />
             <StatCard label="RSSI" value={rssiLabel(sdk.glasses)} sub={rssiUpdatedLabel(sdk.glasses)} subColor={colors.greenAccent} bold />
           </View>
-          {(sdk.otaStatus || sdk.otaUpdateAvailable || sdk.otaNoUpdateVisible) ? <OtaCard sdk={sdk} /> : null}
+          {(sdk.otaStatus || sdk.otaUpdateAvailable || sdk.otaNoUpdateVisible || sdk.otaPendingAction) ? <OtaCard sdk={sdk} /> : null}
           {otaWifiRequired ? (
             <OfflineNotice message="Connect the glasses to Wi-Fi from the System tab before checking or starting OTA updates. OTA downloads run over the glasses network connection." />
           ) : null}
@@ -313,11 +313,17 @@ function canStartOta(sdk: BluetoothSdkExampleModel) {
 }
 
 function isOtaInProgress(sdk: BluetoothSdkExampleModel) {
-  return sdk.otaStartPending || sdk.otaStatus?.status === 'in_progress' || sdk.otaStatus?.status === 'step_complete';
+  return sdk.otaPendingAction !== null || sdk.otaStatus?.status === 'in_progress' || sdk.otaStatus?.status === 'step_complete';
 }
 
 function otaStatusLine(sdk: BluetoothSdkExampleModel) {
-  if (sdk.otaStartPending) {
+  if (sdk.otaPendingAction === 'verify') {
+    return 'checking for remaining updates';
+  }
+  if (sdk.otaPendingAction === 'continue') {
+    return 'continuing update';
+  }
+  if (sdk.otaPendingAction === 'start') {
     return 'starting update';
   }
   if (sdk.otaStatus) {
@@ -333,7 +339,13 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
 }
 
 function otaCardTitle(sdk: BluetoothSdkExampleModel) {
-  if (sdk.otaStartPending) {
+  if (sdk.otaPendingAction === 'verify') {
+    return 'Checking for updates';
+  }
+  if (sdk.otaPendingAction === 'continue') {
+    return 'Continuing update';
+  }
+  if (sdk.otaPendingAction === 'start') {
     return 'Starting update';
   }
   if (sdk.otaStatus?.status === 'failed') {
@@ -355,7 +367,13 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
 }
 
 function otaCardDetail(sdk: BluetoothSdkExampleModel) {
-  if (sdk.otaStartPending) {
+  if (sdk.otaPendingAction === 'verify') {
+    return 'Checking whether any firmware components still need to be updated.';
+  }
+  if (sdk.otaPendingAction === 'continue') {
+    return 'Starting the next required firmware update pass.';
+  }
+  if (sdk.otaPendingAction === 'start') {
     return 'Sending the OTA start request to the glasses.';
   }
   if (sdk.otaStatus?.error_message) {
@@ -391,7 +409,7 @@ function isOtaInstalling(sdk: BluetoothSdkExampleModel) {
 }
 
 function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
-  if (!sdk.otaStatus && !sdk.otaUpdateAvailable && !sdk.otaNoUpdateVisible) {
+  if (!sdk.otaStatus && !sdk.otaUpdateAvailable && !sdk.otaNoUpdateVisible && sdk.otaPendingAction === null) {
     return null;
   }
   const percent = otaDisplayPercent(sdk);
@@ -417,13 +435,13 @@ function OtaCard({ sdk }: { sdk: BluetoothSdkExampleModel }) {
             <Text style={[styles.otaTitle, updateRequired && styles.otaTitleRequired]}>{otaCardTitle(sdk)}</Text>
           </View>
         </View>
-        {sdk.otaStartPending || installing ? (
+        {sdk.otaPendingAction !== null || installing ? (
           <ActivityIndicator color={colors.greenPrimary} size="small" />
         ) : sdk.otaStatus ? (
           <Text style={styles.otaPercent}>{percent}%</Text>
         ) : null}
       </View>
-      {sdk.otaStatus && !installing ? (
+      {sdk.otaStatus && !installing && sdk.otaPendingAction === null ? (
         <View style={styles.otaTrack}>
           <View style={[styles.otaFill, { width: `${Math.max(0, Math.min(percent, 100))}%` }]} />
         </View>

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -320,9 +320,6 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaPendingAction === 'verify') {
     return 'checking for remaining updates';
   }
-  if (sdk.otaPendingAction === 'continue') {
-    return 'continuing update';
-  }
   if (sdk.otaPendingAction === 'start') {
     return 'starting update';
   }
@@ -341,9 +338,6 @@ function otaStatusLine(sdk: BluetoothSdkExampleModel) {
 function otaCardTitle(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaPendingAction === 'verify') {
     return 'Checking for updates';
-  }
-  if (sdk.otaPendingAction === 'continue') {
-    return 'Continuing update';
   }
   if (sdk.otaPendingAction === 'start') {
     return 'Starting update';
@@ -369,9 +363,6 @@ function otaCardTitle(sdk: BluetoothSdkExampleModel) {
 function otaCardDetail(sdk: BluetoothSdkExampleModel) {
   if (sdk.otaPendingAction === 'verify') {
     return 'Checking whether any firmware components still need to be updated.';
-  }
-  if (sdk.otaPendingAction === 'continue') {
-    return 'Starting the next required firmware update pass.';
   }
   if (sdk.otaPendingAction === 'start') {
     return 'Sending the OTA start request to the glasses.';

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -881,6 +881,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
       setOtaStartInFlight(false);
+      setOtaPendingActionValue(null);
       setOtaStatus(null);
       clearOtaDisplayProgress();
       hideOtaNoUpdateCard();
@@ -1361,7 +1362,11 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   function setOtaStartInFlight(inFlight: boolean, action: Exclude<OtaPendingAction, null> = 'start') {
     otaStartInFlightRef.current = inFlight;
     setOtaStartPending(inFlight);
-    setOtaPendingActionValue(inFlight ? action : null);
+    if (inFlight) {
+      setOtaPendingActionValue(action);
+    } else if (otaPendingActionRef.current === 'start') {
+      setOtaPendingActionValue(null);
+    }
   }
 
   function updateOtaDisplayPercent(payload: OtaStatusEvent) {

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -77,26 +77,14 @@ type PhotoCaptureOptions = {
   scanBarcode: boolean;
   textMode: boolean;
 };
-export type OtaPendingAction = 'start' | 'verify' | 'continue' | null;
+export type OtaPendingAction = 'start' | 'verify' | null;
 
-// A single user-initiated update may need several OTA passes (e.g. legacy
-// glasses first hop to an intermediate ASG client before the firmware pass).
-// Bound the automatic continuations so a misbehaving manifest cannot loop.
-const MAX_OTA_CHAIN_PASSES = 4;
 const OTA_NO_UPDATE_CARD_DURATION_MS = 10_000;
 
 // The SDK gives up waiting for a wifi connect ack after 15s, but the glasses
 // often finish associating shortly after; keep the connecting state alive a
 // little longer before declaring failure.
 const WIFI_CONNECT_GRACE_MS = 20_000;
-
-// An armed OTA chain survives the reboots an update itself causes, but a
-// device that stays away longer than this needs a fresh user tap.
-const OTA_CHAIN_RESUME_WINDOW_MS = 5 * 60_000;
-
-// A failed chain-start dispatch does not consume a pass, but this many
-// consecutive failures end the run instead of retrying on every check.
-const MAX_OTA_CHAIN_START_FAILURES = 3;
 
 function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
@@ -732,11 +720,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaStartingAppIdentityRef = useRef<string | null>(null);
   const postOtaCheckInProgressRef = useRef(false);
   const postOtaCheckedSessionRef = useRef<string | null>(null);
-  const otaChainRemainingRef = useRef(0);
-  const otaChainDeviceKeyRef = useRef<string | null>(null);
-  const otaChainDisconnectedAtRef = useRef<number | null>(null);
-  const otaChainStartFailuresRef = useRef(0);
-  const otaChainGenerationRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
   const otaPendingActionRef = useRef<OtaPendingAction>(null);
   const otaCheckGenerationRef = useRef(0);
@@ -898,21 +881,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       otaStatusRef.current = null;
       otaStartingAppIdentityRef.current = null;
       setOtaStartInFlight(false);
-      if (otaChainRemainingRef.current > 0 && otaChainDisconnectedAtRef.current === null) {
-        otaChainDisconnectedAtRef.current = Date.now();
-      }
       setOtaStatus(null);
       clearOtaDisplayProgress();
       hideOtaNoUpdateCard();
       setOtaStatusMessage(null);
       setOtaUpdateAvailable(false);
       return;
-    }
-    if (otaChainDisconnectedAtRef.current !== null) {
-      if (Date.now() - otaChainDisconnectedAtRef.current > OTA_CHAIN_RESUME_WINDOW_MS) {
-        cancelOtaChain();
-      }
-      otaChainDisconnectedAtRef.current = null;
     }
     if (
       !autoOtaCheckKey ||
@@ -1341,12 +1315,10 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       otaStatusRef.current = null;
       setOtaStatus(null);
       setOtaStatusMessage(null);
-      const continuing = maybeContinueOtaChain();
-      setOtaUpdateAvailable(!continuing);
-      addEvent('LIVE', continuing ? 'OTA update still available; continuing automatically' : 'OTA update available');
+      setOtaUpdateAvailable(true);
+      addEvent('LIVE', 'OTA update available');
       return true;
     }
-    cancelOtaChain();
     setOtaPendingActionValue(null);
     otaStatusRef.current = null;
     setOtaStatus(null);
@@ -1374,70 +1346,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       otaNoUpdateTimerRef.current = null;
     }
     setOtaNoUpdateVisible(false);
-  }
-
-  // Cancel the armed run; bumping the generation invalidates any pending
-  // continuation dispatch so its failure handling cannot re-arm the chain.
-  function cancelOtaChain() {
-    otaChainGenerationRef.current += 1;
-    otaChainRemainingRef.current = 0;
-  }
-
-  // One user-initiated update run may span several OTA passes: legacy
-  // glasses can finish a pass on an intermediate ASG client (or reboot
-  // after a BES flash) while still being behind the manifest. Whenever a
-  // post-pass or reconnect check reports another update during an armed
-  // run, start the next pass without requiring another tap.
-  function maybeContinueOtaChain(): boolean {
-    if (otaChainRemainingRef.current <= 0) {
-      setOtaPendingActionValue(null);
-      return false;
-    }
-    if (otaChainDeviceKeyRef.current && otaChainDeviceKeyRef.current !== connectedDeviceKeyRef.current) {
-      // The armed run belongs to another device/connection; require a fresh tap.
-      cancelOtaChain();
-      setOtaPendingActionValue(null);
-      return false;
-    }
-    if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
-      setOtaPendingActionValue(null);
-      return false;
-    }
-    if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
-      return false;
-    }
-    const generation = otaChainGenerationRef.current;
-    otaChainRemainingRef.current -= 1;
-    setOtaStartInFlight(true, 'continue');
-    void runAction('Continue OTA', async () => {
-      try {
-        postOtaCheckedSessionRef.current = null;
-        otaStartingAppIdentityRef.current = otaAppIdentityRef.current;
-        clearOtaDisplayProgress();
-        await BluetoothSdk.startOtaUpdate();
-        if (otaChainGenerationRef.current === generation) {
-          otaChainStartFailuresRef.current = 0;
-        }
-        addEvent('LIVE', 'OTA continuing with next update pass');
-      } catch (error) {
-        setOtaStartInFlight(false);
-        setOtaUpdateAvailable(true);
-        // Nothing started, so the failed dispatch should not consume a
-        // pass — but stop the run after repeated failures rather than
-        // retrying on every subsequent check. If the run was cancelled or
-        // re-armed while the dispatch was pending, leave it alone.
-        if (otaChainGenerationRef.current === generation) {
-          otaChainStartFailuresRef.current += 1;
-          if (otaChainStartFailuresRef.current >= MAX_OTA_CHAIN_START_FAILURES) {
-            cancelOtaChain();
-          } else {
-            otaChainRemainingRef.current += 1;
-          }
-        }
-        throw error;
-      }
-    });
-    return true;
   }
 
   function clearOtaDisplayProgress() {
@@ -1530,18 +1438,12 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         setOtaStartInFlight(false);
         throw error;
       }
-      // Arm the auto-chain only once the start is acknowledged.
-      otaChainGenerationRef.current += 1;
-      otaChainRemainingRef.current = MAX_OTA_CHAIN_PASSES;
-      otaChainDeviceKeyRef.current = connectedDeviceKeyRef.current;
-      otaChainStartFailuresRef.current = 0;
       addEvent('LIVE', 'OTA start acknowledged');
     });
   }
 
   async function disconnect() {
     await runAction('Disconnect', async () => {
-      cancelOtaChain();
       stopDirectStreamFrameWatchdog();
       await bluetooth.disconnect();
       applyDisconnectedState('Disconnected');
@@ -3977,9 +3879,6 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     if (payload.status === 'complete' || payload.status === 'failed') {
       otaStartingAppIdentityRef.current = null;
       setOtaUpdateAvailable(false);
-    }
-    if (payload.status === 'failed') {
-      cancelOtaChain();
     }
     addEvent('LIVE', `OTA ${payload.status} ${payload.overall_percent ?? 0}%`);
     schedulePostOtaCheck(payload);

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -77,6 +77,7 @@ type PhotoCaptureOptions = {
   scanBarcode: boolean;
   textMode: boolean;
 };
+export type OtaPendingAction = 'start' | 'verify' | 'continue' | null;
 
 // A single user-initiated update may need several OTA passes (e.g. legacy
 // glasses first hop to an intermediate ASG client before the firmware pass).
@@ -407,6 +408,7 @@ export type BluetoothSdkExampleState = {
   micRecording: boolean;
   otaDisplayPercent: number | null;
   otaNoUpdateVisible: boolean;
+  otaPendingAction: OtaPendingAction;
   otaStartPending: boolean;
   otaStatus: OtaStatusEvent | null;
   otaStatusMessage: string | null;
@@ -658,6 +660,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const [otaStatus, setOtaStatus] = useState<OtaStatusEvent | null>(null);
   const [otaDisplayPercent, setOtaDisplayPercent] = useState<number | null>(null);
   const [otaNoUpdateVisible, setOtaNoUpdateVisible] = useState(false);
+  const [otaPendingAction, setOtaPendingAction] = useState<OtaPendingAction>(null);
   const [otaStartPending, setOtaStartPending] = useState(false);
   const [otaStatusMessage, setOtaStatusMessage] = useState<string | null>(null);
   const [otaUpdateAvailable, setOtaUpdateAvailable] = useState(false);
@@ -735,6 +738,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   const otaChainStartFailuresRef = useRef(0);
   const otaChainGenerationRef = useRef(0);
   const otaStartInFlightRef = useRef(false);
+  const otaPendingActionRef = useRef<OtaPendingAction>(null);
   const otaCheckGenerationRef = useRef(0);
   const otaNoUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectedDeviceKeyRef = useRef<string | null>(null);
@@ -1337,12 +1341,13 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       otaStatusRef.current = null;
       setOtaStatus(null);
       setOtaStatusMessage(null);
-      setOtaUpdateAvailable(true);
-      addEvent('LIVE', 'OTA update available');
-      maybeContinueOtaChain();
+      const continuing = maybeContinueOtaChain();
+      setOtaUpdateAvailable(!continuing);
+      addEvent('LIVE', continuing ? 'OTA update still available; continuing automatically' : 'OTA update available');
       return true;
     }
     cancelOtaChain();
+    setOtaPendingActionValue(null);
     otaStatusRef.current = null;
     setOtaStatus(null);
     setOtaStatusMessage('Glasses firmware is up to date');
@@ -1383,24 +1388,27 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   // after a BES flash) while still being behind the manifest. Whenever a
   // post-pass or reconnect check reports another update during an armed
   // run, start the next pass without requiring another tap.
-  function maybeContinueOtaChain() {
+  function maybeContinueOtaChain(): boolean {
     if (otaChainRemainingRef.current <= 0) {
-      return;
+      setOtaPendingActionValue(null);
+      return false;
     }
     if (otaChainDeviceKeyRef.current && otaChainDeviceKeyRef.current !== connectedDeviceKeyRef.current) {
       // The armed run belongs to another device/connection; require a fresh tap.
       cancelOtaChain();
-      return;
+      setOtaPendingActionValue(null);
+      return false;
     }
     if (!glassesConnectedRef.current || !glassesWifiConnectedRef.current) {
-      return;
+      setOtaPendingActionValue(null);
+      return false;
     }
     if (otaStartInFlightRef.current || isOtaEventInProgress(otaStatusRef.current)) {
-      return;
+      return false;
     }
     const generation = otaChainGenerationRef.current;
     otaChainRemainingRef.current -= 1;
-    setOtaStartInFlight(true);
+    setOtaStartInFlight(true, 'continue');
     void runAction('Continue OTA', async () => {
       try {
         postOtaCheckedSessionRef.current = null;
@@ -1413,6 +1421,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         addEvent('LIVE', 'OTA continuing with next update pass');
       } catch (error) {
         setOtaStartInFlight(false);
+        setOtaUpdateAvailable(true);
         // Nothing started, so the failed dispatch should not consume a
         // pass — but stop the run after repeated failures rather than
         // retrying on every subsequent check. If the run was cancelled or
@@ -1428,6 +1437,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
         throw error;
       }
     });
+    return true;
   }
 
   function clearOtaDisplayProgress() {
@@ -1435,9 +1445,15 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     setOtaDisplayPercent(null);
   }
 
-  function setOtaStartInFlight(inFlight: boolean) {
+  function setOtaPendingActionValue(action: OtaPendingAction) {
+    otaPendingActionRef.current = action;
+    setOtaPendingAction(action);
+  }
+
+  function setOtaStartInFlight(inFlight: boolean, action: Exclude<OtaPendingAction, null> = 'start') {
     otaStartInFlightRef.current = inFlight;
     setOtaStartPending(inFlight);
+    setOtaPendingActionValue(inFlight ? action : null);
   }
 
   function updateOtaDisplayPercent(payload: OtaStatusEvent) {
@@ -1469,6 +1485,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
     postOtaCheckInProgressRef.current = true;
     autoOtaCheckInProgressRef.current = true;
+    setOtaPendingActionValue('verify');
     void runAction('Verify OTA', async () => {
       let checkSucceeded = false;
       try {
@@ -1480,6 +1497,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       } finally {
         postOtaCheckInProgressRef.current = false;
         autoOtaCheckInProgressRef.current = false;
+        if (otaPendingActionRef.current === 'verify') {
+          setOtaPendingActionValue(null);
+        }
         if (checkSucceeded) {
           postOtaCheckedSessionRef.current = sessionId;
           if (latestAutoOtaCheckKeyRef.current) {
@@ -1495,7 +1515,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       addEvent('TX', 'OTA start skipped; a start is already in flight');
       return;
     }
-    setOtaStartInFlight(true);
+    setOtaStartInFlight(true, 'start');
     await runAction('Start OTA', async () => {
       try {
         if (!glassesConnected) {
@@ -4067,6 +4087,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     otaStatus,
     otaDisplayPercent,
     otaNoUpdateVisible,
+    otaPendingAction,
     otaStartPending,
     otaStatusMessage,
     otaUpdateAvailable,


### PR DESCRIPTION
## Root cause

`startOtaUpdate()` / `ota_start` begins one complete glasses-side OTA session. The ASG client persists that session, resumes it after an APK restart, and advances through the required APK, MTK, and BES steps itself.

The React Native example had a second, phone-side concept of a bounded "OTA chain." After a completed session or reconnect, it checked the manifest and, when another update appeared available, called `BluetoothSdk.startOtaUpdate()` again automatically. That overloaded `ota_start` as a step-continuation command even though continuation belongs to the active ASG session.

The extra start was not guaranteed to be harmless: depending on timing, ASG could acknowledge it as a duplicate or re-enter version checking and OTA bookkeeping. It also caused the visible symptoms reported in the example app: stale 100% progress, a briefly visible update prompt, and an update apparently starting without a user tap.

## Change

- Remove the React Native automatic OTA pass chain, including its reconnect window, pass budget, retry bookkeeping, and `Continue OTA` dispatch.
- Keep exactly one `BluetoothSdk.startOtaUpdate()` call, reached only from the user-approved Start OTA action.
- Preserve immediate "Starting update" feedback while that initial command is awaiting acknowledgement.
- Preserve post-completion manifest verification, showing "Checking for updates" instead of leaving the completed 100% card onscreen.
- If verification reports another update after the previous session is complete, show the update-available card and require a new explicit user decision; do not send another start automatically.
- Keep the existing ten-second no-update confirmation card.

Native Android and iOS already issue `startOtaUpdate()` only from their user actions, so no equivalent auto-chain removal was needed there.

This PR changes example-app orchestration only. It does not change the Bluetooth SDK or glasses-side OTA implementation.

## Validation

- `bunx tsc --noEmit`
- `NODE_ENV=production bunx expo export --platform android --output-dir /tmp/mentra-rn-ota-single-start-export`
- Audited all three examples: each now has one SDK OTA-start call, reachable from its user Start action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app OTA orchestration and UI only; no SDK, auth, or production firmware paths touched.
> 
> **Overview**
> The React Native example **stops auto-chaining** `BluetoothSdk.startOtaUpdate()` after a finished pass or reconnect. **Only the user’s Start OTA action** starts an update; glasses-side session handling is left to ASG.
> 
> **`otaPendingAction`** (`start` | `verify`) replaces the old chain refs and **`otaStartPending`**-only UI. The OTA card shows **“Starting update”** while the start is in flight and **“Checking for updates”** after completion during manifest verification—without firing another start. If verification finds another update, the **update-available** card appears and waits for an explicit tap.
> 
> Example-app orchestration only; no SDK or native changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280756c6d88530f9d9a08a0c9fefdebc193d306f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->