### PR TITLE
Fix React Native 16 KB page-size packaging

### DIFF
--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -272,6 +272,9 @@ jobs:
         run: |
           ./gradlew :app:assembleRelease --no-daemon
 
+      - name: Verify Android 16 KB page-size support
+        run: examples/react-native/scripts/check-android-16kb.sh examples/react-native/android/app/build/outputs/apk/release/app-release.apk
+
       - name: Collect APK
         run: cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk mentra-example-react-native.apk
 

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -42,6 +42,7 @@
       ]
     },
     "plugins": [
+      "./plugins/withAndroid16KbPageSize",
       [
         "@mentra/bluetooth-sdk",
         {
@@ -55,6 +56,9 @@
             "minSdkVersion": 28,
             "usesCleartextTraffic": true,
             "packagingOptions": {
+              "exclude": [
+                "**/libcoder.so"
+              ],
               "pickFirst": [
                 "**/libc++_shared.so",
                 "**/libonnxruntime.so",

--- a/examples/react-native/modules/mentra-video-stream-receiver/android/build.gradle
+++ b/examples/react-native/modules/mentra-video-stream-receiver/android/build.gradle
@@ -48,6 +48,7 @@ android {
           "GSTREAMER_ASSETS_DIR=src/main/assets",
           "GSTREAMER_INCLUDE_FONTS=no",
           "GSTREAMER_INCLUDE_CA_CERTIFICATES=no",
+          "APP_SUPPORT_FLEXIBLE_PAGE_SIZES=true",
         )
         abiFilters "arm64-v8a"
         targets "mentra_android_webrtc_receiver"

--- a/examples/react-native/modules/mentra-video-stream-receiver/android/src/main/jni/Android.mk
+++ b/examples/react-native/modules/mentra-video-stream-receiver/android/src/main/jni/Android.mk
@@ -42,4 +42,8 @@ GSTREAMER_PLUGINS := \
 	rswebrtc
 GSTREAMER_EXTRA_DEPS := gstreamer-app-1.0 gstreamer-video-1.0
 
+# GStreamer's custom link rule does not consume LOCAL_LDFLAGS from ndk-build.
+# Feed the 16 KB maximum page size through the target flags it does consume.
+TARGET_LDFLAGS += -Wl,-z,max-page-size=16384
+
 include $(GSTREAMER_NDK_BUILD_PATH)/gstreamer-1.0.mk

--- a/examples/react-native/plugins/withAndroid16KbPageSize.js
+++ b/examples/react-native/plugins/withAndroid16KbPageSize.js
@@ -1,0 +1,39 @@
+const { withGradleProperties, withProjectBuildGradle } = require("expo/config-plugins");
+
+const CONFIG_BLOCK = `
+// Keep release APK native libraries compatible with Android's 16 KB page-size devices.
+subprojects { subproject ->
+  subproject.plugins.withId("com.android.library") {
+    if (subproject.name == "lc3Lib") {
+      subproject.android.defaultConfig.externalNativeBuild.cmake.arguments(
+        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+      )
+    }
+  }
+}
+`;
+
+module.exports = function withAndroid16KbPageSize(config) {
+  config = withGradleProperties(config, (gradleConfig) => {
+    const property = gradleConfig.modResults.find(
+      (item) => item.type === "property" && item.key === "reactNativeArchitectures"
+    );
+    if (property) {
+      property.value = "arm64-v8a,x86_64";
+    } else {
+      gradleConfig.modResults.push({
+        type: "property",
+        key: "reactNativeArchitectures",
+        value: "arm64-v8a,x86_64",
+      });
+    }
+    return gradleConfig;
+  });
+
+  return withProjectBuildGradle(config, (gradleConfig) => {
+    if (!gradleConfig.modResults.contents.includes(CONFIG_BLOCK.trim())) {
+      gradleConfig.modResults.contents += CONFIG_BLOCK;
+    }
+    return gradleConfig;
+  });
+};

--- a/examples/react-native/scripts/check-android-16kb.sh
+++ b/examples/react-native/scripts/check-android-16kb.sh
@@ -34,9 +34,9 @@ audit_dir=$(mktemp -d "${TMPDIR:-/tmp}/android-16kb.XXXXXX")
 unzip -q "$apk" 'lib/*/*.so' -d "$audit_dir"
 
 libraries=()
-while IFS= read -r -d '' library; do
+while IFS= read -r library; do
   libraries+=("$library")
-done < <(find "$audit_dir/lib" -type f -name '*.so' -print0 | sort -z)
+done < <(find "$audit_dir/lib" -type f -name '*.so' -print | sort)
 if [[ ${#libraries[@]} -eq 0 ]]; then
   echo "No packaged native libraries found in $apk" >&2
   exit 1
@@ -45,12 +45,28 @@ fi
 failures=0
 for library in "${libraries[@]}"; do
   relative=${library#"$audit_dir/"}
-  bad_alignments=()
+  if ! program_headers=$("$readelf" -lW "$library"); then
+    printf 'FAIL %s (llvm-readelf could not inspect the library)\n' "$relative" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  alignments=()
   while IFS= read -r alignment; do
+    alignments+=("$alignment")
+  done < <(printf '%s\n' "$program_headers" | awk '$1 == "LOAD" { print $NF }')
+  if [[ ${#alignments[@]} -eq 0 ]]; then
+    printf 'FAIL %s (no ELF LOAD segments found)\n' "$relative" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  bad_alignments=()
+  for alignment in "${alignments[@]}"; do
     if (( alignment < 0x4000 )); then
       bad_alignments+=("$alignment")
     fi
-  done < <("$readelf" -lW "$library" | awk '$1 == "LOAD" { print $NF }')
+  done
 
   if [[ ${#bad_alignments[@]} -gt 0 ]]; then
     printf 'FAIL %s (LOAD alignment: %s)\n' "$relative" "${bad_alignments[*]}" >&2

--- a/examples/react-native/scripts/check-android-16kb.sh
+++ b/examples/react-native/scripts/check-android-16kb.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apk=${1:?Usage: check-android-16kb.sh path/to/app.apk}
+android_sdk=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}
+
+if [[ -z "$android_sdk" ]]; then
+  echo "ANDROID_HOME or ANDROID_SDK_ROOT must point to the Android SDK." >&2
+  exit 2
+fi
+
+build_tools=$(find "$android_sdk/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)
+ndk_root=$(find "$android_sdk/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) host=darwin-x86_64 ;;
+  Darwin-*) host=darwin-x86_64 ;;
+  Linux-x86_64) host=linux-x86_64 ;;
+  Linux-aarch64) host=linux-x86_64 ;;
+  *) echo "Unsupported build host: $(uname -s)-$(uname -m)" >&2; exit 2 ;;
+esac
+
+zipalign="$build_tools/zipalign"
+readelf="$ndk_root/toolchains/llvm/prebuilt/$host/bin/llvm-readelf"
+
+[[ -x "$zipalign" ]] || { echo "zipalign not found under $build_tools" >&2; exit 2; }
+[[ -x "$readelf" ]] || { echo "llvm-readelf not found under $ndk_root" >&2; exit 2; }
+[[ -f "$apk" ]] || { echo "APK not found: $apk" >&2; exit 2; }
+
+echo "Checking 16 KB ZIP alignment: $apk"
+"$zipalign" -c -P 16 -v 4 "$apk" >/dev/null
+
+audit_dir=$(mktemp -d "${TMPDIR:-/tmp}/android-16kb.XXXXXX")
+unzip -q "$apk" 'lib/*/*.so' -d "$audit_dir"
+
+libraries=()
+while IFS= read -r -d '' library; do
+  libraries+=("$library")
+done < <(find "$audit_dir/lib" -type f -name '*.so' -print0 | sort -z)
+if [[ ${#libraries[@]} -eq 0 ]]; then
+  echo "No packaged native libraries found in $apk" >&2
+  exit 1
+fi
+
+failures=0
+for library in "${libraries[@]}"; do
+  relative=${library#"$audit_dir/"}
+  bad_alignments=()
+  while IFS= read -r alignment; do
+    if (( alignment < 0x4000 )); then
+      bad_alignments+=("$alignment")
+    fi
+  done < <("$readelf" -lW "$library" | awk '$1 == "LOAD" { print $NF }')
+
+  if [[ ${#bad_alignments[@]} -gt 0 ]]; then
+    printf 'FAIL %s (LOAD alignment: %s)\n' "$relative" "${bad_alignments[*]}" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS %s\n' "$relative"
+  fi
+done
+
+if (( failures > 0 )); then
+  echo "$failures native libraries are not 16 KB ELF-aligned." >&2
+  exit 1
+fi
+
+echo "Verified ${#libraries[@]} packaged native libraries for 16 KB page-size support."


### PR DESCRIPTION
Closes #38

## What changed

- keeps the React Native example on `@mentra/bluetooth-sdk` `0.1.21-beta.2` and packages only the 64-bit Android ABIs used by 16 KB devices
- excludes the SDK optional legacy `libcoder.so`; Android 12+ retains the platform AVIF decoder fallback
- enables flexible page-size linking for LC3 and the local GStreamer receiver, including GStreamer's custom shared-library link rule
- adds a release APK guard that checks both 16 KB ZIP alignment and every packaged ELF `LOAD` segment

## Root cause

The SDK upgrade alone still packaged the JitPack AVIF decoder with 4 KB ELF segments. The example also built its LC3 and GStreamer receiver outputs without flexible-page linker settings, and its release APK retained 32-bit libraries that are not relevant to 16 KB devices.

## Validation

- `NODE_ENV=production ./android/gradlew -p android clean :app:assembleRelease --no-daemon --console plain`
- `examples/react-native/scripts/check-android-16kb.sh examples/react-native/android/app/build/outputs/apk/release/app-release.apk`
- verified ZIP alignment and all 52 packaged `.so` files across `arm64-v8a` and `x86_64`
- Expo prebuild rerun successfully to confirm the config plugin is idempotent
- `git diff --check`

The source checkout's unrelated local log files were not touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release native linking, ABI set, and excludes an optional SDK `.so`; misconfiguration could break installs on 16 KB devices or AVIF decoding, but scope is the example app and CI enforces alignment checks.
> 
> **Overview**
> Brings the **React Native example** release APK in line with **Android 16 KB page-size** requirements by tightening which native libraries are built, how they are linked, and what gets packaged.
> 
> A new Expo config plugin **`withAndroid16KbPageSize`** limits **`reactNativeArchitectures`** to **`arm64-v8a`** and **`x86_64`**, and injects Gradle so **`lc3Lib`** builds with **`ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`**. **`expo-build-properties`** now **excludes `libcoder.so`** (legacy AVIF decoder with 4 KB ELF segments) while keeping existing **`pickFirst`** rules for other shared libs. The local **GStreamer video receiver** enables **`APP_SUPPORT_FLEXIBLE_PAGE_SIZES`** and adds **`-Wl,-z,max-page-size=16384`** via **`TARGET_LDFLAGS`** because GStreamer’s ndk-build link path ignores **`LOCAL_LDFLAGS`**.
> 
> CI runs **`check-android-16kb.sh`** on the release APK after **`assembleRelease`**, checking **16 KB ZIP alignment** (`zipalign -P 16`) and that every packaged **`.so`** has **ELF LOAD** segments aligned to at least **16 KB**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c1fdbc85237cba591da6cbf0d0b207efc04b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->