### PR TITLE
Update example apps to Bluetooth SDK 0.1.21-beta.3

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.21-beta.2
+mentraSdkVersion=0.1.21-beta.3
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.21-beta.2
+mentraSdkVersion=0.1.21-beta.3

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.21-beta.2;
+				version = 0.1.21-beta.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.21-beta.2`:
+The Xcode project pins the public Swift package to `0.1.21-beta.3`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.21-beta.2
+    exactVersion: 0.1.21-beta.3
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.2",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.3",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.2", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yvKUGq2fCSBj4yydEkmeyoD+MKHQPXOaru07eriiyuWOCq0W8qmxQef3V1fO5YNZggfTEJ4V/KMPa60nGpEheQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.3", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-l9vsXXhTLw/ipye3TpZo/tbrskV5ZROP+21sa4jit6DgIMe2i/Pl9+SmL9Nz5Ntv4Ag9+HOEUvADElyqODgIOA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.2",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.3",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.21-beta.2"
+"@mentra/bluetooth-sdk": "0.1.21-beta.3"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.2",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.3",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.2", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yvKUGq2fCSBj4yydEkmeyoD+MKHQPXOaru07eriiyuWOCq0W8qmxQef3V1fO5YNZggfTEJ4V/KMPa60nGpEheQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.3", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-l9vsXXhTLw/ipye3TpZo/tbrskV5ZROP+21sa4jit6DgIMe2i/Pl9+SmL9Nz5Ntv4Ag9+HOEUvADElyqODgIOA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.2",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.3",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
## Summary

- update the native Android example dependency and README to `0.1.21-beta.3`
- update the native iOS SwiftPM pin, XcodeGen source, and README to `0.1.21-beta.3`
- update the React Native and ElevenLabs audio example package pins to `0.1.21-beta.3`

## Publication status

This PR is opened in advance of the release. At preparation time:

- npm: `@mentra/bluetooth-sdk@0.1.21-beta.3` returns 404
- SwiftPM: the `0.1.21-beta.3` tag is not present yet
- Maven Central: `com.mentraglass:bluetooth-sdk:0.1.21-beta.3` is not listed yet

The two Bun lockfiles are intentionally not modified with guessed integrity data. Once npm publishes the package, regenerate both lockfiles and run the full example validation before marking this PR ready.

## Remaining verification

- regenerate `examples/react-native/bun.lock`
- regenerate `examples/react-native-elevenlabs-audio/bun.lock`
- run frozen Bun installs and TypeScript checks for both React Native examples
- resolve and build the native iOS example against the published SwiftPM tag
- compile the native Android example against the published Maven artifact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation version bumps only; no application or SDK source changes in this repo.
> 
> **Overview**
> Bumps all starter-kit example apps from **0.1.21-beta.2** to **0.1.21-beta.3** so they track the same Bluetooth SDK release across platforms.
> 
> **Android** updates `mentraSdkVersion` in `gradle.properties` and the README snippet. **iOS** updates the SwiftPM exact pin in `project.pbxproj`, `project.yml`, and the README. **React Native** (`examples/react-native` and `examples/react-native-elevenlabs-audio`) updates `@mentra/bluetooth-sdk` in `package.json`, regenerates both `bun.lock` files (including the `@mentra/bluetooth-sdk` integrity entry), and refreshes the RN README example version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d78cb8bc40ec468b78961765dc0f1028c92e2ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->