### PR TITLE
Update example apps to Bluetooth SDK 0.1.21-beta.5

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -17,7 +17,7 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 The example reads the SDK version from `gradle.properties`:
 
 ```properties
-mentraSdkVersion=0.1.21-beta.3
+mentraSdkVersion=0.1.21-beta.5
 ```
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=0.1.21-beta.3
+mentraSdkVersion=0.1.21-beta.5

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.21-beta.3;
+				version = 0.1.21-beta.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,7 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `0.1.21-beta.3`:
+The Xcode project pins the public Swift package to `0.1.21-beta.5`:
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 0.1.21-beta.3
+    exactVersion: 0.1.21-beta.5
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.3",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.5",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.3", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-l9vsXXhTLw/ipye3TpZo/tbrskV5ZROP+21sa4jit6DgIMe2i/Pl9+SmL9Nz5Ntv4Ag9+HOEUvADElyqODgIOA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.5", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-8ZfiZJR9aR/Llo6YyTFXRIkEhNlEHh34TvBPLz7fUcEiQggQhVDwNYKhFP3TE9hRLqPaXWIag/cohBZZLa1KQg=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.3",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.5",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -24,7 +24,7 @@ bun install
 The example depends on the SDK version pinned in `package.json`, for example:
 
 ```json
-"@mentra/bluetooth-sdk": "0.1.21-beta.3"
+"@mentra/bluetooth-sdk": "0.1.21-beta.5"
 ```
 
 Use the latest SDK version published by Mentra. When validating unreleased SDK

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "0.1.21-beta.3",
+        "@mentra/bluetooth-sdk": "0.1.21-beta.5",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -301,7 +301,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.3", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-l9vsXXhTLw/ipye3TpZo/tbrskV5ZROP+21sa4jit6DgIMe2i/Pl9+SmL9Nz5Ntv4Ag9+HOEUvADElyqODgIOA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@0.1.21-beta.5", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-8ZfiZJR9aR/Llo6YyTFXRIkEhNlEHh34TvBPLz7fUcEiQggQhVDwNYKhFP3TE9hRLqPaXWIag/cohBZZLa1KQg=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -13,7 +13,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "0.1.21-beta.3",
+    "@mentra/bluetooth-sdk": "0.1.21-beta.5",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
## Summary

- pin the native Android example to `com.mentraglass:bluetooth-sdk:0.1.21-beta.5`
- pin the native iOS example to the exact `0.1.21-beta.5` Swift package tag
- update both React Native examples to `@mentra/bluetooth-sdk@0.1.21-beta.5`
- refresh the Bun lockfiles and example README version snippets

## Why

Keeps every Starter Kit example aligned with the promoted Bluetooth SDK `0.1.21-beta.5` release.

## Impact

Fresh installs and CI builds for all example apps will consume the same beta.5 SDK release across Maven, Swift Package Manager, and npm.

## Validation

- `git diff --check`
- `CI=true bun install --frozen-lockfile` in both React Native examples
- `bunx tsc --noEmit` in `examples/react-native`
- `bun run typecheck` in `examples/react-native-elevenlabs-audio`
- `./gradlew :app:compileDebugKotlin --no-daemon` in `examples/android`
- `xcodebuild -resolvePackageDependencies ...` resolved `MentraBluetoothSDK` at `0.1.21-beta.5`

The Maven artifact became resolvable during local validation and the native Android Kotlin compile completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps only in example apps and docs; no production app or SDK source changes.
> 
> **Overview**
> Bumps every Starter Kit example from Bluetooth SDK **0.1.21-beta.3** to **0.1.21-beta.5** so installs and CI pull the same promoted release.
> 
> **Android** updates `mentraSdkVersion` in `gradle.properties` (and the README snippet). **iOS** pins `MentraBluetoothSDK` to exact **0.1.21-beta.5** in `project.pbxproj`, `project.yml`, and README. **React Native** (`examples/react-native` and `examples/react-native-elevenlabs-audio`) bumps `@mentra/bluetooth-sdk` in `package.json`, refreshes both `bun.lock` files, and updates the RN README example dependency line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b35bf4cdc6a57da9e1e9e1f9dfe2f0e47d7c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->