### PR TITLE
Bound stalled OTA progress in React Native example

### DIFF
--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -24,6 +24,7 @@
         "react-native-wifi-reborn": "^4.13.6",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/react": "^19.1.0",
         "typescript": "~5.9.2",
         "ws": "^8.20.1",
@@ -345,6 +346,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
@@ -442,6 +445,8 @@
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -10,6 +10,7 @@
     "ios:setup": "bash ./modules/mentra-video-stream-receiver/scripts/setup-gstreamer-ios.sh",
     "android": "node ./scripts/android-run.mjs",
     "android:dev": "node ./scripts/android-dev.mjs",
+    "test": "bun test",
     "web": "expo start --web"
   },
   "dependencies": {
@@ -32,6 +33,7 @@
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/react": "^19.1.0",
     "typescript": "~5.9.2",
     "ws": "^8.20.1"

--- a/examples/react-native/src/otaProgressPolicy.test.ts
+++ b/examples/react-native/src/otaProgressPolicy.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, test} from 'bun:test';
+import type {OtaStatusEvent} from '@mentra/bluetooth-sdk';
+import {
+  buildStalledOtaFailure,
+  isOtaProgressActive,
+  otaProgressFingerprint,
+} from './otaProgressPolicy';
+
+const status: OtaStatusEvent = {
+  type: 'ota_status',
+  session_id: 'session-1',
+  total_steps: 2,
+  current_step: 1,
+  step_type: 'apk',
+  phase: 'install',
+  step_percent: 0,
+  overall_percent: 20,
+  status: 'in_progress',
+};
+
+describe('OTA progress policy', () => {
+  test('does not treat duplicate events as progress', () => {
+    expect(otaProgressFingerprint({...status})).toBe(otaProgressFingerprint(status));
+  });
+
+  test('rearms for meaningful progress and phase changes', () => {
+    expect(otaProgressFingerprint({...status, step_percent: 1})).not.toBe(
+      otaProgressFingerprint(status),
+    );
+    expect(otaProgressFingerprint({...status, step_type: 'bes', current_step: 2})).not.toBe(
+      otaProgressFingerprint(status),
+    );
+  });
+
+  test('watches only nonterminal OTA states', () => {
+    expect(isOtaProgressActive(status)).toBe(true);
+    expect(isOtaProgressActive({...status, status: 'step_complete'})).toBe(true);
+    expect(isOtaProgressActive({...status, status: 'complete'})).toBe(false);
+    expect(isOtaProgressActive({...status, status: 'failed'})).toBe(false);
+    expect(isOtaProgressActive({...status, status: 'idle'})).toBe(false);
+  });
+
+  test('preserves session and progress context in a synthetic stall failure', () => {
+    const failed = buildStalledOtaFailure(status, 'The manifest still reports an update.');
+
+    expect(failed).toMatchObject({
+      session_id: 'session-1',
+      current_step: 1,
+      step_type: 'apk',
+      overall_percent: 20,
+      status: 'failed',
+    });
+    expect(failed.error_message).toContain('The manifest still reports an update.');
+  });
+});

--- a/examples/react-native/src/otaProgressPolicy.ts
+++ b/examples/react-native/src/otaProgressPolicy.ts
@@ -1,0 +1,33 @@
+import type {OtaStatusEvent} from '@mentra/bluetooth-sdk';
+
+// Match the Mentra App's progress-stall threshold while keeping this example independent
+// from the app-only OTA coordinator.
+export const OTA_PROGRESS_TIMEOUT_MS = 120_000;
+
+export function isOtaProgressActive(status: OtaStatusEvent | null) {
+  return status?.status === 'in_progress' || status?.status === 'step_complete';
+}
+
+export function otaProgressFingerprint(status: OtaStatusEvent) {
+  return [
+    status.session_id || 'current-ota',
+    status.current_step,
+    status.total_steps,
+    status.step_type,
+    status.phase,
+    status.step_percent,
+    status.overall_percent,
+    status.status,
+  ].join('|');
+}
+
+export function buildStalledOtaFailure(
+  status: OtaStatusEvent,
+  detail: string,
+): OtaStatusEvent {
+  return {
+    ...status,
+    status: 'failed',
+    error_message: `No OTA progress was received for two minutes. ${detail}`,
+  };
+}

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -60,6 +60,12 @@ import {
   isGlassesWifiConnected,
   supportsDisplay,
 } from './sdkFormat';
+import {
+  buildStalledOtaFailure,
+  isOtaProgressActive,
+  otaProgressFingerprint,
+  OTA_PROGRESS_TIMEOUT_MS,
+} from './otaProgressPolicy';
 
 export type ExampleTabKey = 'device' | 'camera' | 'stream' | 'system' | 'console';
 export type BluetoothSdkExampleOptions = {
@@ -90,9 +96,7 @@ function isDisplayableOtaStatus(payload: OtaStatusEvent) {
   return payload.status !== 'idle' || Boolean(payload.error_message);
 }
 
-function isOtaEventInProgress(payload: OtaStatusEvent | null) {
-  return payload?.status === 'in_progress' || payload?.status === 'step_complete';
-}
+const isOtaEventInProgress = isOtaProgressActive;
 
 function otaVersionSignature(glasses: GlassesRuntimeState) {
   if (!glasses.connected) {
@@ -763,6 +767,9 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     ? `${connectedDeviceKey}|${latestVersionInfoSignature ?? otaVersionSignature(glasses)}`
     : null;
   const otaInProgress = isOtaEventInProgress(otaStatus);
+  const otaProgressKey = otaStatus && otaInProgress
+    ? otaProgressFingerprint(otaStatus)
+    : null;
   const phone = bluetooth.sdk;
   const scanActive = bluetooth.scan.active;
   const galleryModeEnabled = phone.galleryMode.enabled;
@@ -882,6 +889,23 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       await bluetooth.connectDefault();
     });
   }, [defaultDevice, glassesConnected]);
+
+  useEffect(() => {
+    if (!otaProgressKey || !otaStatus) {
+      return;
+    }
+
+    let cancelled = false;
+    const stalledStatus = otaStatus;
+    const timer = setTimeout(() => {
+      void reconcileStalledOta(stalledStatus, otaProgressKey, () => cancelled);
+    }, OTA_PROGRESS_TIMEOUT_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [otaProgressKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!glassesConnected) {
@@ -1367,6 +1391,83 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
   function clearOtaDisplayProgress() {
     otaDisplayProgressRef.current = null;
     setOtaDisplayPercent(null);
+  }
+
+  function isCurrentStalledOta(fingerprint: string, cancelled: () => boolean) {
+    const current = otaStatusRef.current;
+    return (
+      !cancelled() &&
+      glassesConnectedRef.current &&
+      current != null &&
+      isOtaProgressActive(current) &&
+      otaProgressFingerprint(current) === fingerprint
+    );
+  }
+
+  async function reconcileStalledOta(
+    stalledStatus: OtaStatusEvent,
+    fingerprint: string,
+    cancelled: () => boolean,
+  ) {
+    if (!isCurrentStalledOta(fingerprint, cancelled)) {
+      return;
+    }
+
+    addEvent('LIVE', 'OTA progress stalled; reconciling glasses versions and manifest');
+    try {
+      const versionInfo = await BluetoothSdk.requestVersionInfo();
+      if (!isCurrentStalledOta(fingerprint, cancelled)) {
+        return;
+      }
+      applyVersionInfo(versionInfo);
+    } catch (error) {
+      addEvent('TX', `OTA stall version refresh failed: ${formatError(error)}`);
+    }
+
+    if (!isCurrentStalledOta(fingerprint, cancelled)) {
+      return;
+    }
+
+    try {
+      const updateAvailable = await BluetoothSdk.checkForOtaUpdate();
+      if (!isCurrentStalledOta(fingerprint, cancelled)) {
+        return;
+      }
+      if (!updateAvailable) {
+        otaStatusRef.current = null;
+        otaStartingAppIdentityRef.current = null;
+        setOtaStatus(null);
+        clearOtaDisplayProgress();
+        setOtaStatusMessage('Glasses firmware is up to date');
+        setOtaUpdateAvailable(false);
+        showOtaNoUpdateCard();
+        addEvent('LIVE', 'OTA stall reconciled: no update remains');
+        return;
+      }
+
+      failStalledOta(
+        stalledStatus,
+        'The OTA manifest still reports that an update is required. Reconnect the glasses and retry.',
+      );
+    } catch (error) {
+      if (!isCurrentStalledOta(fingerprint, cancelled)) {
+        return;
+      }
+      failStalledOta(
+        stalledStatus,
+        `Current firmware could not be verified: ${formatError(error)}`,
+      );
+    }
+  }
+
+  function failStalledOta(status: OtaStatusEvent, detail: string) {
+    const failedStatus = buildStalledOtaFailure(status, detail);
+    otaStatusRef.current = failedStatus;
+    otaStartingAppIdentityRef.current = null;
+    setOtaStatus(failedStatus);
+    setOtaStatusMessage(null);
+    setOtaUpdateAvailable(false);
+    addEvent('LIVE', `OTA failed after progress timeout: ${detail}`);
   }
 
   function setOtaPendingActionValue(action: OtaPendingAction) {


### PR DESCRIPTION
## Summary

- add a two-minute meaningful-progress watchdog to the React Native example OTA UI
- reconcile a stalled install with fresh version information and the SDK-pinned OTA manifest
- clear the stale session when no update remains, otherwise show a bounded failure instead of spinning forever
- keep duplicate `ota_status` events from extending the watchdog
- add focused Bun tests and a React Native example test script

## Root cause

The Mentra App already has OTA coordinator recovery and timeout handling. The Starter Kit example only cleared its local `in_progress` state after a terminal `ota_status`, a disconnect, or an observed ASG identity change.

During hardware validation, the glasses had already cleared the OTA session, but the BES UART baud-recovery loop prevented the terminal/idle response from reaching the phone. The example therefore retained its last `apk/install/in_progress` event and displayed **Installing update** indefinitely.

## Hardware evidence

Phone received its final progress event:

```text
1786417338.556 Bridge: sendOtaStatus: {phase=install, step_percent=0, step_type=apk, overall_percent=0, session_id=50c4b490, total_steps=2, current_step=1, status=in_progress}
```

A targeted status query proved that the glasses no longer had an active OTA, but the response could not be delivered:

```text
1786418875.397 OtaCommandHandler: Received ota_query_status from phone
1786418875.397 OtaCommandHandler: Sent ota_status response: idle
1786418875.398 MentraBleTrace: type=ota_status ... payloadBytes=144 ... success=false
```

The transport was concurrently cycling through failed fast-baud verification:

```text
1786418793.832 BES-UART: Starting UART recovery: fast_probe_timeout
1786418795.197 BES-UART: Recovery probing baud 460800
1786418795.255 BES-UART: Requested fast UART baud 1152000
1786418797.323 BES-UART: Reopened fast UART; verifying link (reason=sr_baud_timeout)
```

This PR does not change the Mentra App OTA flow or glasses firmware. It gives the shared React Native example a bounded fallback when a terminal event cannot arrive.

## Recovery behavior

After two minutes without a meaningful phase, step, or percentage change, the example:

1. requests fresh glasses version information;
2. re-checks the OTA manifest pinned to the installed SDK;
3. clears the stale progress state if no update remains;
4. otherwise reports a timeout failure with the retained session and progress context.

## Validation

- `bun install --frozen-lockfile`
- `bun test` — 4 passing tests
- `bunx tsc --noEmit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only OTA UI recovery; no changes to production app OTA or firmware paths.
> 
> **Overview**
> Adds a **two-minute meaningful-progress watchdog** so the React Native example OTA UI does not spin forever when terminal `ota_status` events never arrive (e.g. transport loss during BES UART recovery).
> 
> New `otaProgressPolicy` helpers define the 120s threshold (aligned with the Mentra App), which OTA states count as active, a **fingerprint** of session/step/phase/percent so duplicate `ota_status` events do not reset the timer, and a synthetic `failed` payload for stall timeouts. `useBluetoothSdkExample` starts the watchdog from `otaProgressKey`; on expiry it refreshes version info, re-checks the SDK-pinned OTA manifest, **clears** stale UI if no update remains, or surfaces a bounded failure with context.
> 
> Also wires **`bun test`** and `@types/bun`, with unit tests for the policy module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa59b7c87bf675e4a5a0f48e361d1dae7c66d942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->