### PR TITLE
Prevent Android foreground service timeout crash

### DIFF
--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,16 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!--
+        The SDK declares dataSync for compatibility, but Android 15 limits that
+        foreground-service type to six hours. This app always qualifies for
+        connectedDevice via CHANGE_NETWORK_STATE, so exclude dataSync from the
+        merged manifest instead of allowing the system timeout to crash it.
+    -->
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+        tools:node="remove" />
+
     <application
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
@@ -37,5 +47,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name="com.mentra.bluetoothsdk.services.ForegroundService"
+            android:foregroundServiceType="connectedDevice|location|mediaPlayback|microphone"
+            tools:replace="android:foregroundServiceType" />
     </application>
 </manifest>


### PR DESCRIPTION
## Summary

- remove the SDK's `FOREGROUND_SERVICE_DATA_SYNC` permission from the native Android example's merged manifest
- override the SDK foreground service declaration to use `connectedDevice`, `location`, `mediaPlayback`, and `microphone` only
- keep background BLE eligible through the app's existing normal `CHANGE_NETWORK_STATE` permission

Android 15 limits `dataSync` foreground services to six hours and terminates apps that do not stop in time. The example does not need that type because it qualifies for `connectedDevice`.

Fixes [OS-1719](https://linear.app/mentralabs/issue/OS-1719/native-android-example-app-crash-report-in-the-background).

## Test evidence

- `./gradlew :app:processDebugMainManifest -x :app:installGStreamerAndroidSdk`
- inspected the merged debug manifest: `FOREGROUND_SERVICE_DATA_SYNC` is absent and `ForegroundService` declares `connectedDevice|location|mediaPlayback|microphone`

## Note

A first Gradle run attempted the optional GStreamer SDK setup and hit a transient upstream HTTP 503. The manifest-only validation succeeds when that unrelated download task is excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only changes in the example app; no SDK or runtime logic changes, with low blast radius beyond the sample’s background service behavior.
> 
> **Overview**
> Stops the native **Android example** from inheriting the Bluetooth SDK’s **`dataSync`** foreground-service type, which Android 15 caps at six hours and can kill the process if the service keeps running.
> 
> The example manifest **strips** `FOREGROUND_SERVICE_DATA_SYNC` from the merged manifest (`tools:node="remove"`) and **replaces** the SDK `ForegroundService` declaration so `foregroundServiceType` is **`connectedDevice|location|mediaPlayback|microphone`** only. Background BLE stays valid via the app’s existing **`CHANGE_NETWORK_STATE`** permission, which qualifies for `connectedDevice` without `dataSync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9316bec0bbf5dce2c2342c312897593b2e1619ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents six-hour Android 15 foreground service timeout crashes in the native Android example app by removing the dataSync foreground service type and restricting `com.mentra.bluetoothsdk.services.ForegroundService` to `connectedDevice|location|mediaPlayback|microphone`. Addresses OS-1719.

- Removes `android.permission.FOREGROUND_SERVICE_DATA_SYNC` from the merged manifest and replaces the service’s foregroundServiceType via tools:replace.
- Behavior: no more timeout-based process kills; background BLE eligibility is unchanged via existing `CHANGE_NETWORK_STATE`; no runtime code changes.
- Verify: run ./gradlew :app:processDebugMainManifest and inspect the merged manifest; `FOREGROUND_SERVICE_DATA_SYNC` is absent and the service lists `connectedDevice|location|mediaPlayback|microphone`.

<sup>Written for commit 9316bec0bbf5dce2c2342c312897593b2e1619ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

