### PR TITLE
Coordinate example app releases

### DIFF
--- a/.github/scripts/coordinated-example-release.mjs
+++ b/.github/scripts/coordinated-example-release.mjs
@@ -125,6 +125,15 @@ export function synchronizeExampleVersions(rootDir, releaseIdentity) {
   )
   writeFileSync(projectPath, updatedProject)
 
+  const projectDefinitionPath = path.join(rootDir, "examples/ios/project.yml")
+  const projectDefinition = replaceExactlyOnce(
+    readFileSync(projectDefinitionPath, "utf8"),
+    /^    exactVersion: .*$/gm,
+    `    exactVersion: ${releaseIdentity}`,
+    "XcodeGen iOS SDK version",
+  )
+  writeFileSync(projectDefinitionPath, projectDefinition)
+
   updateJsonDependency(path.join(rootDir, "examples/react-native/package.json"), {
     "@mentra/bluetooth-sdk": releaseIdentity,
     "@mentra/engine": releaseIdentity,

--- a/.github/scripts/coordinated-example-release.mjs
+++ b/.github/scripts/coordinated-example-release.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import {createHash} from "node:crypto"
+import {readdirSync, readFileSync, statSync, writeFileSync} from "node:fs"
+import path from "node:path"
+import {pathToFileURL} from "node:url"
+
+const VERSION_PATTERN = /^(\d+\.\d+\.\d+)(?:-(dev|beta)\.([1-9]\d*))?$/
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+
+const EXAMPLE_ARTIFACTS = [
+  {key: "android", prefix: "mentra-example-android", suffix: ".apk", contentType: "application/vnd.android.package-archive"},
+  {key: "ios", prefix: "mentra-example-ios", suffix: "-unsigned.ipa", contentType: "application/octet-stream"},
+  {
+    key: "reactNative",
+    prefix: "mentra-example-react-native",
+    suffix: ".apk",
+    contentType: "application/vnd.android.package-archive",
+  },
+  {
+    key: "reactNativeElevenLabsAudio",
+    prefix: "mentra-example-rn-elevenlabs-audio",
+    suffix: ".apk",
+    contentType: "application/vnd.android.package-archive",
+  },
+]
+
+function parseArgs(args) {
+  const [command, ...rest] = args
+  const values = {}
+  for (let index = 0; index < rest.length; index += 2) {
+    const option = rest[index]
+    const value = rest[index + 1]
+    if (!option?.startsWith("--") || value === undefined) throw new Error("Expected --name value pairs")
+    values[option.slice(2)] = value
+  }
+  return {command, values}
+}
+
+function assertString(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`)
+  return value
+}
+
+export function validatePayload(payload) {
+  if (payload?.schemaVersion !== 1) throw new Error("Unsupported coordinated example payload schema")
+
+  const releaseIdentity = assertString(payload.releaseIdentity, "releaseIdentity")
+  const match = VERSION_PATTERN.exec(releaseIdentity)
+  if (!match) throw new Error(`Invalid coordinated release identity ${JSON.stringify(releaseIdentity)}`)
+
+  const familyBaseVersion = assertString(payload.familyBaseVersion, "familyBaseVersion")
+  if (match[1] !== familyBaseVersion) throw new Error("releaseIdentity does not match familyBaseVersion")
+  if (payload.releaseSetId !== `mentra-${releaseIdentity}`) throw new Error("releaseSetId does not match releaseIdentity")
+
+  const expectedChannel = match[2] === "dev" ? "dev" : match[2] === "beta" ? "beta" : "production"
+  if (payload.channel !== expectedChannel) throw new Error("releaseIdentity does not match channel")
+
+  const targetBranch = expectedChannel === "dev" ? "dev" : expectedChannel === "beta" ? "staging" : "main"
+  if (!SHA_PATTERN.test(payload.mentraos?.sourceCommit || "")) throw new Error("Invalid MentraOS source commit")
+  if (!/^https:\/\//.test(payload.mentraos?.coordinatorRunUrl || "")) {
+    throw new Error("Invalid MentraOS coordinator run URL")
+  }
+  if (!/^https:\/\//.test(payload.ota?.manifestUrl || "")) throw new Error("Invalid OTA manifest URL")
+  if (!SHA256_PATTERN.test(payload.ota?.manifestSha256 || "")) throw new Error("Invalid OTA manifest SHA-256")
+  if (!SHA_PATTERN.test(payload.expectedStarterKitHead || "")) throw new Error("Invalid expected Starter Kit head")
+
+  for (const packageName of ["@mentra/bluetooth-sdk", "@mentra/engine"]) {
+    if (payload.packages?.[packageName] !== releaseIdentity) {
+      throw new Error(`${packageName} must match the coordinated release identity`)
+    }
+  }
+
+  return {
+    releaseIdentity,
+    familyBaseVersion,
+    channel: expectedChannel,
+    targetBranch,
+    candidateBranch: `coordinated/${releaseIdentity}`,
+    sourceTag: `sdk-${releaseIdentity}`,
+    artifactContainerTag:
+      expectedChannel === "production" ? `sdk-${releaseIdentity}` : `sdk-builds-v${familyBaseVersion}`,
+  }
+}
+
+function replaceExactlyOnce(contents, pattern, replacement, label) {
+  const matches = contents.match(pattern)
+  if (!matches || matches.length !== 1) throw new Error(`Expected exactly one ${label}`)
+  return contents.replace(pattern, replacement)
+}
+
+function updateJsonDependency(filePath, dependencies) {
+  const packageJson = JSON.parse(readFileSync(filePath, "utf8"))
+  for (const [name, version] of Object.entries(dependencies)) {
+    if (typeof packageJson.dependencies?.[name] !== "string") {
+      throw new Error(`${filePath} does not declare ${name}`)
+    }
+    packageJson.dependencies[name] = version
+  }
+  writeFileSync(filePath, `${JSON.stringify(packageJson, null, 2)}\n`)
+}
+
+export function synchronizeExampleVersions(rootDir, releaseIdentity) {
+  if (!VERSION_PATTERN.test(releaseIdentity)) throw new Error(`Invalid release identity ${releaseIdentity}`)
+
+  const gradlePath = path.join(rootDir, "examples/android/gradle.properties")
+  const gradle = replaceExactlyOnce(
+    readFileSync(gradlePath, "utf8"),
+    /^mentraSdkVersion=.*$/gm,
+    `mentraSdkVersion=${releaseIdentity}`,
+    "native Android SDK version",
+  )
+  writeFileSync(gradlePath, gradle)
+
+  const projectPath = path.join(rootDir, "examples/ios/MentraExample.xcodeproj/project.pbxproj")
+  const project = readFileSync(projectPath, "utf8")
+  const packageBlockPattern = /(repositoryURL = "https:\/\/github\.com\/Mentra-Community\/mentra-bluetooth-sdk-ios\.git";[\s\S]*?requirement = \{[\s\S]*?kind = exactVersion;[\s\S]*?version = )[^;]+(;[\s\S]*?\};)/g
+  const updatedProject = replaceExactlyOnce(
+    project,
+    packageBlockPattern,
+    `$1${releaseIdentity}$2`,
+    "native iOS SDK version",
+  )
+  writeFileSync(projectPath, updatedProject)
+
+  updateJsonDependency(path.join(rootDir, "examples/react-native/package.json"), {
+    "@mentra/bluetooth-sdk": releaseIdentity,
+    "@mentra/engine": releaseIdentity,
+  })
+  updateJsonDependency(path.join(rootDir, "examples/react-native-elevenlabs-audio/package.json"), {
+    "@mentra/bluetooth-sdk": releaseIdentity,
+  })
+}
+
+function listFilesRecursively(directory) {
+  return readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    return entry.isDirectory() ? listFilesRecursively(entryPath) : [entryPath]
+  })
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex")
+}
+
+export function createReleaseResult({payload, repository, releaseCommit, mergeCommit, pullRequestUrl, validationRunUrl, artifactDir}) {
+  const release = validatePayload(payload)
+  if (!REPOSITORY_PATTERN.test(repository)) throw new Error(`Invalid repository ${JSON.stringify(repository)}`)
+  if (!SHA_PATTERN.test(releaseCommit)) throw new Error("Invalid Starter Kit release commit")
+  if (!SHA_PATTERN.test(mergeCommit)) throw new Error("Invalid Starter Kit merge commit")
+  if (!/^https:\/\//.test(pullRequestUrl)) throw new Error("Invalid Starter Kit pull request URL")
+  if (!/^https:\/\//.test(validationRunUrl)) throw new Error("Invalid Starter Kit validation run URL")
+
+  const files = listFilesRecursively(artifactDir)
+  const assetBaseUrl = `https://github.com/${repository}/releases/download/${release.artifactContainerTag}`
+  const artifacts = EXAMPLE_ARTIFACTS.map(({key, prefix, suffix, contentType}) => {
+    const name = `${prefix}-${release.releaseIdentity}${suffix}`
+    const matches = files.filter((filePath) => path.basename(filePath) === name)
+    if (matches.length !== 1) throw new Error(`Expected exactly one built artifact named ${name}`)
+    return {
+      key,
+      name,
+      url: `${assetBaseUrl}/${name}`,
+      size: statSync(matches[0]).size,
+      sha256: sha256(matches[0]),
+      contentType,
+    }
+  })
+
+  return {
+    schemaVersion: 1,
+    releaseSetId: payload.releaseSetId,
+    releaseIdentity: release.releaseIdentity,
+    familyBaseVersion: release.familyBaseVersion,
+    channel: release.channel,
+    mentraos: payload.mentraos,
+    ota: payload.ota,
+    starterKit: {
+      baseCommit: payload.expectedStarterKitHead,
+      releaseCommit,
+      mergeCommit,
+      sourceTag: release.sourceTag,
+      artifactContainerTag: release.artifactContainerTag,
+      releaseUrl: `https://github.com/${repository}/releases/tag/${release.artifactContainerTag}`,
+      pullRequestUrl,
+      validationRunUrl,
+    },
+    packages: payload.packages,
+    artifacts,
+    testflight: null,
+  }
+}
+
+function appendGitHubOutput(filePath, values) {
+  if (!filePath) return
+  const lines = Object.entries(values).map(([name, value]) => `${name}=${value}`)
+  writeFileSync(filePath, `${lines.join("\n")}\n`, {flag: "a"})
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(path.resolve(filePath), "utf8"))
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+if (isMain) {
+  const {command, values} = parseArgs(process.argv.slice(2))
+  if (command === "validate") {
+    const release = validatePayload(readJson(values.payload))
+    appendGitHubOutput(values["github-output"], release)
+    console.log(JSON.stringify(release))
+  } else if (command === "sync") {
+    synchronizeExampleVersions(path.resolve(values.root || "."), values.identity)
+  } else if (command === "result") {
+    const result = createReleaseResult({
+      payload: readJson(values.payload),
+      repository: values.repository,
+      releaseCommit: values["release-commit"],
+      mergeCommit: values["merge-commit"],
+      pullRequestUrl: values["pull-request-url"],
+      validationRunUrl: values["validation-run-url"],
+      artifactDir: path.resolve(values["artifact-dir"]),
+    })
+    writeFileSync(path.resolve(values.output), `${JSON.stringify(result, null, 2)}\n`)
+  } else {
+    throw new Error(`Unknown command ${JSON.stringify(command)}`)
+  }
+}

--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import {mkdtempSync, mkdirSync, readFileSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {createReleaseResult, synchronizeExampleVersions, validatePayload} from "./coordinated-example-release.mjs"
+
+const sha = "a".repeat(40)
+const manifestSha = "b".repeat(64)
+
+function payload(identity = "3.1.0-beta.57") {
+  const [base, prerelease] = identity.split("-")
+  const channel = prerelease?.startsWith("dev.") ? "dev" : prerelease?.startsWith("beta.") ? "beta" : "production"
+  return {
+    schemaVersion: 1,
+    releaseSetId: `mentra-${identity}`,
+    familyBaseVersion: base,
+    releaseIdentity: identity,
+    channel,
+    mentraos: {sourceCommit: sha, coordinatorRunUrl: "https://github.com/Mentra/MentraOS/actions/runs/1"},
+    ota: {manifestUrl: "https://example.com/ota.json", manifestSha256: manifestSha},
+    packages: {"@mentra/bluetooth-sdk": identity, "@mentra/engine": identity},
+    expectedStarterKitHead: sha,
+  }
+}
+
+test("validates channel and derives Starter Kit release coordinates", () => {
+  assert.deepEqual(validatePayload(payload()), {
+    releaseIdentity: "3.1.0-beta.57",
+    familyBaseVersion: "3.1.0",
+    channel: "beta",
+    targetBranch: "staging",
+    candidateBranch: "coordinated/3.1.0-beta.57",
+    sourceTag: "sdk-3.1.0-beta.57",
+    artifactContainerTag: "sdk-builds-v3.1.0",
+  })
+  assert.equal(validatePayload(payload("3.1.0-dev.42")).targetBranch, "dev")
+  assert.equal(validatePayload(payload("3.1.0")).artifactContainerTag, "sdk-3.1.0")
+})
+
+test("rejects mismatched package versions", () => {
+  const invalid = payload()
+  invalid.packages["@mentra/engine"] = "3.1.0-beta.56"
+  assert.throws(() => validatePayload(invalid), /must match/)
+})
+
+test("synchronizes all maintained example manifests", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "starter-kit-sync-"))
+  mkdirSync(path.join(root, "examples/android"), {recursive: true})
+  mkdirSync(path.join(root, "examples/ios/MentraExample.xcodeproj"), {recursive: true})
+  mkdirSync(path.join(root, "examples/react-native"), {recursive: true})
+  mkdirSync(path.join(root, "examples/react-native-elevenlabs-audio"), {recursive: true})
+  writeFileSync(path.join(root, "examples/android/gradle.properties"), "mentraSdkVersion=1.0.0\n")
+  writeFileSync(
+    path.join(root, "examples/ios/MentraExample.xcodeproj/project.pbxproj"),
+    'repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";\nrequirement = {\nkind = exactVersion;\nversion = 1.0.0;\n};\n',
+  )
+  writeFileSync(
+    path.join(root, "examples/react-native/package.json"),
+    JSON.stringify({dependencies: {"@mentra/bluetooth-sdk": "1.0.0", "@mentra/engine": "1.0.0"}}),
+  )
+  writeFileSync(
+    path.join(root, "examples/react-native-elevenlabs-audio/package.json"),
+    JSON.stringify({dependencies: {"@mentra/bluetooth-sdk": "1.0.0"}}),
+  )
+
+  synchronizeExampleVersions(root, "3.1.0-dev.42")
+
+  assert.match(readFileSync(path.join(root, "examples/android/gradle.properties"), "utf8"), /3\.1\.0-dev\.42/)
+  assert.match(
+    readFileSync(path.join(root, "examples/ios/MentraExample.xcodeproj/project.pbxproj"), "utf8"),
+    /version = 3\.1\.0-dev\.42/,
+  )
+  assert.equal(
+    JSON.parse(readFileSync(path.join(root, "examples/react-native/package.json"))).dependencies["@mentra/engine"],
+    "3.1.0-dev.42",
+  )
+})
+
+test("creates a deterministic result for all four artifacts", () => {
+  const artifactDir = mkdtempSync(path.join(tmpdir(), "starter-kit-artifacts-"))
+  const identity = "3.1.0-beta.57"
+  for (const name of [
+    `mentra-example-android-${identity}.apk`,
+    `mentra-example-ios-${identity}-unsigned.ipa`,
+    `mentra-example-react-native-${identity}.apk`,
+    `mentra-example-rn-elevenlabs-audio-${identity}.apk`,
+  ]) {
+    writeFileSync(path.join(artifactDir, name), name)
+  }
+
+  const result = createReleaseResult({
+    payload: payload(identity),
+    repository: "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit",
+    releaseCommit: sha,
+    mergeCommit: "c".repeat(40),
+    pullRequestUrl: "https://github.com/Mentra/pr/1",
+    validationRunUrl: "https://github.com/Mentra/actions/1",
+    artifactDir,
+  })
+
+  assert.equal(result.starterKit.artifactContainerTag, "sdk-builds-v3.1.0")
+  assert.equal(result.artifacts.length, 4)
+  assert.ok(result.artifacts.every((artifact) => artifact.sha256.length === 64 && artifact.size > 0))
+})

--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -56,6 +56,7 @@ test("synchronizes all maintained example manifests", () => {
     path.join(root, "examples/ios/MentraExample.xcodeproj/project.pbxproj"),
     'repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";\nrequirement = {\nkind = exactVersion;\nversion = 1.0.0;\n};\n',
   )
+  writeFileSync(path.join(root, "examples/ios/project.yml"), "packages:\n  MentraBluetoothSDK:\n    exactVersion: 1.0.0\n")
   writeFileSync(
     path.join(root, "examples/react-native/package.json"),
     JSON.stringify({dependencies: {"@mentra/bluetooth-sdk": "1.0.0", "@mentra/engine": "1.0.0"}}),
@@ -72,6 +73,7 @@ test("synchronizes all maintained example manifests", () => {
     readFileSync(path.join(root, "examples/ios/MentraExample.xcodeproj/project.pbxproj"), "utf8"),
     /version = 3\.1\.0-dev\.42/,
   )
+  assert.match(readFileSync(path.join(root, "examples/ios/project.yml"), "utf8"), /exactVersion: 3\.1\.0-dev\.42/)
   assert.equal(
     JSON.parse(readFileSync(path.join(root, "examples/react-native/package.json"))).dependencies["@mentra/engine"],
     "3.1.0-dev.42",

--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -9,6 +9,8 @@ import {createReleaseResult, synchronizeExampleVersions, validatePayload} from "
 const sha = "a".repeat(40)
 const manifestSha = "b".repeat(64)
 
+const releaseWorkflow = readFileSync(new URL("../workflows/coordinated-example-release.yml", import.meta.url), "utf8")
+
 function payload(identity = "3.1.0-beta.57") {
   const [base, prerelease] = identity.split("-")
   const channel = prerelease?.startsWith("dev.") ? "dev" : prerelease?.startsWith("beta.") ? "beta" : "production"
@@ -43,6 +45,12 @@ test("rejects mismatched package versions", () => {
   const invalid = payload()
   invalid.packages["@mentra/engine"] = "3.1.0-beta.56"
   assert.throws(() => validatePayload(invalid), /must match/)
+})
+
+test("reconciles completed releases from immutable PR and tag provenance", () => {
+  assert.match(releaseWorkflow, /gh pr view "\$pull_request_url"[^]*--json url,state,headRefOid,baseRefName,mergeCommit/)
+  assert.match(releaseWorkflow, /git\/ref\/tags\/sdk-\$RELEASE_IDENTITY/)
+  assert.doesNotMatch(releaseWorkflow, /\.starterKit\.baseCommit "\$result"\)" == "\$EXPECTED_STARTER_KIT_HEAD"/)
 })
 
 test("synchronizes all maintained example manifests", () => {

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -23,7 +23,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: coordinated-example-release-${{ inputs.channel }}
+  # Dev and beta for one train share a GitHub release container, so serialize
+  # the family even though their source branches are independent.
+  group: coordinated-example-release-${{ fromJSON(inputs.payload).familyBaseVersion }}
   cancel-in-progress: false
 
 env:
@@ -180,6 +182,7 @@ jobs:
             git add \
               .github/coordinated-example-release.json \
               examples/android/gradle.properties \
+              examples/ios/project.yml \
               examples/ios/MentraExample.xcodeproj/project.pbxproj \
               examples/react-native/package.json \
               examples/react-native/bun.lock \
@@ -259,7 +262,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$(gh pr view "$PR_URL" --json state --jq .state)" != "MERGED" ]]; then
-            gh pr merge "$PR_URL" --merge
+            gh pr merge "$PR_URL" --merge --match-head-commit "$RELEASE_COMMIT"
           fi
           merge_commit=$(gh pr view "$PR_URL" --json mergeCommit --jq .mergeCommit.oid)
           git fetch origin "$TARGET_BRANCH"

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -18,7 +18,7 @@ run-name: Coordinated example ${{ inputs.channel }} ${{ fromJSON(inputs.payload)
         type: string
 
 permissions:
-  actions: write
+  actions: read
   contents: write
   pull-requests: read
 
@@ -228,7 +228,7 @@ jobs:
           fi
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch validation for the candidate commit
+      - name: Wait for pull request validation of the candidate commit
         if: steps.existing.outputs.already_published != 'true'
         id: validation
         env:
@@ -237,20 +237,15 @@ jobs:
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
         run: |
           set -euo pipefail
-          dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          gh workflow run example-app-builds.yml \
-            --ref "$CANDIDATE_BRANCH" \
-            -f "artifact_suffix=$RELEASE_IDENTITY"
-
           run_id=""
-          for _ in {1..30}; do
+          for _ in {1..60}; do
             run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
-              --event workflow_dispatch --limit 20 \
-              --json databaseId,headSha,createdAt \
-              --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\" and .createdAt >= \"$dispatched_at\") | .databaseId" \
+              --event pull_request --limit 20 \
+              --json databaseId,headSha \
+              --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
               | head -1)
             [[ -n "$run_id" ]] && break
-            sleep 2
+            sleep 10
           done
           [[ -n "$run_id" ]]
           gh run watch "$run_id" --exit-status

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -68,7 +68,7 @@ jobs:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           RELEASE_SET_ID: ${{ fromJSON(inputs.payload).releaseSetId }}
           MENTRAOS_SOURCE_COMMIT: ${{ fromJSON(inputs.payload).mentraos.sourceCommit }}
-          EXPECTED_STARTER_KIT_HEAD: ${{ fromJSON(inputs.payload).expectedStarterKitHead }}
+          TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           ARTIFACT_CONTAINER_TAG: ${{ steps.release.outputs.artifactContainerTag }}
         run: |
           set -euo pipefail
@@ -80,7 +80,18 @@ jobs:
             [[ "$(jq -er .releaseSetId "$result")" == "$RELEASE_SET_ID" ]]
             [[ "$(jq -er .releaseIdentity "$result")" == "$RELEASE_IDENTITY" ]]
             [[ "$(jq -er .mentraos.sourceCommit "$result")" == "$MENTRAOS_SOURCE_COMMIT" ]]
-            [[ "$(jq -er .starterKit.baseCommit "$result")" == "$EXPECTED_STARTER_KIT_HEAD" ]]
+            release_commit=$(jq -er '.starterKit.releaseCommit | select(test("^[0-9a-f]{40}$"))' "$result")
+            merge_commit=$(jq -er '.starterKit.mergeCommit | select(test("^[0-9a-f]{40}$"))' "$result")
+            pull_request_url=$(jq -er .starterKit.pullRequestUrl "$result")
+            [[ "$(jq -er .starterKit.sourceTag "$result")" == "sdk-$RELEASE_IDENTITY" ]]
+            pr_provenance=$(gh pr view "$pull_request_url" \
+              --json url,state,headRefOid,baseRefName,mergeCommit)
+            [[ "$(jq -r .url <<< "$pr_provenance")" == "$pull_request_url" ]]
+            [[ "$(jq -r .state <<< "$pr_provenance")" == "MERGED" ]]
+            [[ "$(jq -r .headRefOid <<< "$pr_provenance")" == "$release_commit" ]]
+            [[ "$(jq -r .baseRefName <<< "$pr_provenance")" == "$TARGET_BRANCH" ]]
+            [[ "$(jq -r .mergeCommit.oid <<< "$pr_provenance")" == "$merge_commit" ]]
+            [[ "$(gh api "repos/$STARTER_KIT_REPOSITORY/git/ref/tags/sdk-$RELEASE_IDENTITY" --jq .object.sha)" == "$release_commit" ]]
             [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
             while IFS= read -r url; do
               curl --fail --silent --show-error --location --head "$url" >/dev/null

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -1,4 +1,5 @@
 name: Coordinated Example Release
+run-name: Coordinated example ${{ inputs.channel }} ${{ fromJSON(inputs.payload).releaseIdentity }}
 
 "on":
   workflow_dispatch:

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -20,7 +20,7 @@ run-name: Coordinated example ${{ inputs.channel }} ${{ fromJSON(inputs.payload)
 permissions:
   actions: write
   contents: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   # Dev and beta for one train share a GitHub release container, so serialize
@@ -195,7 +195,7 @@ jobs:
 
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
 
-      - name: Create or reuse the synchronization pull request
+      - name: Wait for the coordinator synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
         id: pull-request
         env:
@@ -205,21 +205,26 @@ jobs:
           MENTRAOS_RUN_URL: ${{ fromJSON(inputs.payload).mentraos.coordinatorRunUrl }}
         run: |
           set -euo pipefail
-          pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
-            --limit 1 --json number,url,state,mergedAt)
-          if [[ "$(jq 'length' <<<"$pr_json")" == "0" ]]; then
-            pr_url=$(gh pr create \
-              --base "$TARGET_BRANCH" \
-              --head "$CANDIDATE_BRANCH" \
-              --title "Synchronize examples to $RELEASE_IDENTITY" \
-              --body "Automated coordinated example release for \`$RELEASE_IDENTITY\`.\n\nMentraOS coordinator: $MENTRAOS_RUN_URL")
-          else
-            pr_url=$(jq -r '.[0].url' <<<"$pr_json")
-            state=$(jq -r '.[0].state' <<<"$pr_json")
-            merged_at=$(jq -r '.[0].mergedAt // empty' <<<"$pr_json")
-            if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
-              gh pr reopen "$pr_url"
+          pr_url=""
+          for _ in {1..60}; do
+            pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
+              --limit 1 --json number,url,state,mergedAt)
+            if [[ "$(jq 'length' <<<"$pr_json")" != "0" ]]; then
+              pr_url=$(jq -r '.[0].url' <<<"$pr_json")
+              state=$(jq -r '.[0].state' <<<"$pr_json")
+              merged_at=$(jq -r '.[0].mergedAt // empty' <<<"$pr_json")
+              if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+                echo "Coordinator PR $pr_url was closed without merging." >&2
+                exit 1
+              fi
+              break
             fi
+            sleep 10
+          done
+          if [[ -z "$pr_url" ]]; then
+            echo "MentraOS did not create the synchronization PR for $RELEASE_IDENTITY." >&2
+            echo "Coordinator: $MENTRAOS_RUN_URL" >&2
+            exit 1
           fi
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
@@ -252,7 +257,7 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Merge the validated synchronization pull request
+      - name: Wait for the coordinator to merge the validated pull request
         if: steps.existing.outputs.already_published != 'true'
         id: merge
         env:
@@ -261,9 +266,18 @@ jobs:
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
         run: |
           set -euo pipefail
-          if [[ "$(gh pr view "$PR_URL" --json state --jq .state)" != "MERGED" ]]; then
-            gh pr merge "$PR_URL" --merge --match-head-commit "$RELEASE_COMMIT"
-          fi
+          for _ in {1..60}; do
+            pr_json=$(gh pr view "$PR_URL" --json state,headRefOid,mergeCommit)
+            [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
+            state=$(jq -r .state <<< "$pr_json")
+            if [[ "$state" == "MERGED" ]]; then break; fi
+            if [[ "$state" == "CLOSED" ]]; then
+              echo "Coordinator closed $PR_URL without merging it." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          [[ "$state" == "MERGED" ]]
           merge_commit=$(gh pr view "$PR_URL" --json mergeCommit --jq .mergeCommit.oid)
           git fetch origin "$TARGET_BRANCH"
           git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$TARGET_BRANCH"

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -1,0 +1,358 @@
+name: Coordinated Example Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Coordinated release channel
+        required: true
+        type: choice
+        options:
+          - dev
+          - beta
+          - production
+      payload:
+        description: Compact coordinated example release payload JSON
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: coordinated-example-release-${{ inputs.channel }}
+  cancel-in-progress: false
+
+env:
+  CI: true
+  GH_TOKEN: ${{ github.token }}
+  STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
+
+jobs:
+  release:
+    name: Synchronize, validate, and publish examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout the Starter Kit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Validate the coordinated payload
+        id: release
+        env:
+          COORDINATED_PAYLOAD: ${{ inputs.payload }}
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$COORDINATED_PAYLOAD" > coordinated-payload.json
+          node .github/scripts/coordinated-example-release.mjs validate \
+            --payload coordinated-payload.json \
+            --github-output "$GITHUB_OUTPUT"
+          [[ "$(jq -er .channel coordinated-payload.json)" == "$DISPATCH_CHANNEL" ]]
+
+      - name: Reconcile an already published result
+        id: existing
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          RELEASE_SET_ID: ${{ fromJSON(inputs.payload).releaseSetId }}
+          MENTRAOS_SOURCE_COMMIT: ${{ fromJSON(inputs.payload).mentraos.sourceCommit }}
+          EXPECTED_STARTER_KIT_HEAD: ${{ fromJSON(inputs.payload).expectedStarterKitHead }}
+          ARTIFACT_CONTAINER_TAG: ${{ steps.release.outputs.artifactContainerTag }}
+        run: |
+          set -euo pipefail
+          result_name="starter-kit-release-$RELEASE_IDENTITY.json"
+          mkdir -p existing-result
+          if gh release download "$ARTIFACT_CONTAINER_TAG" \
+            --pattern "$result_name" --dir existing-result >/dev/null 2>&1; then
+            result="existing-result/$result_name"
+            [[ "$(jq -er .releaseSetId "$result")" == "$RELEASE_SET_ID" ]]
+            [[ "$(jq -er .releaseIdentity "$result")" == "$RELEASE_IDENTITY" ]]
+            [[ "$(jq -er .mentraos.sourceCommit "$result")" == "$MENTRAOS_SOURCE_COMMIT" ]]
+            [[ "$(jq -er .starterKit.baseCommit "$result")" == "$EXPECTED_STARTER_KIT_HEAD" ]]
+            [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
+            while IFS= read -r url; do
+              curl --fail --silent --show-error --location --head "$url" >/dev/null
+            done < <(jq -r '.artifacts[].url' "$result")
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "result_url=https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$ARTIFACT_CONTAINER_TAG/$result_name" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify public package and OTA inputs
+        if: steps.existing.outputs.already_published != 'true'
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          OTA_MANIFEST_URL: ${{ fromJSON(inputs.payload).ota.manifestUrl }}
+          OTA_MANIFEST_SHA256: ${{ fromJSON(inputs.payload).ota.manifestSha256 }}
+        run: |
+          set -euo pipefail
+          retry() {
+            local attempts="$1"
+            local delay="$2"
+            shift 2
+            for ((attempt = 1; attempt <= attempts; attempt++)); do
+              if "$@"; then return 0; fi
+              if (( attempt == attempts )); then return 1; fi
+              sleep "$delay"
+            done
+          }
+
+          check_npm() {
+            [[ "$(npm view "@mentra/bluetooth-sdk@$RELEASE_IDENTITY" version 2>/dev/null)" == "$RELEASE_IDENTITY" ]] &&
+              [[ "$(npm view "@mentra/engine@$RELEASE_IDENTITY" version 2>/dev/null)" == "$RELEASE_IDENTITY" ]]
+          }
+          check_maven() {
+            curl --fail --silent --show-error --head \
+              "https://repo1.maven.org/maven2/com/mentraglass/bluetooth-sdk/$RELEASE_IDENTITY/bluetooth-sdk-$RELEASE_IDENTITY.pom" \
+              >/dev/null
+          }
+          check_swiftpm() {
+            git ls-remote --exit-code --tags \
+              https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git \
+              "refs/tags/$RELEASE_IDENTITY" >/dev/null
+          }
+
+          retry 30 20 check_npm
+          retry 30 20 check_maven
+          retry 30 20 check_swiftpm
+          curl --fail --silent --show-error --location "$OTA_MANIFEST_URL" --output ota-manifest.json
+          echo "$OTA_MANIFEST_SHA256  ota-manifest.json" | sha256sum --check --status
+
+      - name: Create or reuse the version synchronization candidate
+        if: steps.existing.outputs.already_published != 'true'
+        id: candidate
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
+          CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
+          EXPECTED_HEAD: ${{ fromJSON(inputs.payload).expectedStarterKitHead }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$TARGET_BRANCH" "$CANDIDATE_BRANCH" 2>/dev/null || git fetch origin "$TARGET_BRANCH"
+          actual_head=$(git rev-parse "origin/$TARGET_BRANCH")
+          candidate_exists=false
+          if git show-ref --verify --quiet "refs/remotes/origin/$CANDIDATE_BRANCH"; then
+            candidate_exists=true
+          fi
+          if [[ "$actual_head" != "$EXPECTED_HEAD" ]]; then
+            if [[ "$candidate_exists" != "true" ]] ||
+              [[ "$(git rev-parse "origin/$CANDIDATE_BRANCH^")" != "$EXPECTED_HEAD" ]] ||
+              ! git merge-base --is-ancestor "origin/$CANDIDATE_BRANCH" "origin/$TARGET_BRANCH"; then
+              echo "Expected $TARGET_BRANCH at $EXPECTED_HEAD, found unrelated head $actual_head" >&2
+              exit 1
+            fi
+          fi
+
+          canonical_payload=$(mktemp)
+          jq --sort-keys . coordinated-payload.json > "$canonical_payload"
+          if [[ "$candidate_exists" == "true" ]]; then
+            release_commit=$(git rev-parse "origin/$CANDIDATE_BRANCH")
+            git show "$release_commit:.github/coordinated-example-release.json" > candidate-payload.json
+            cmp --silent "$canonical_payload" candidate-payload.json
+            [[ "$(git rev-parse "$release_commit^")" == "$EXPECTED_HEAD" ]]
+          else
+            git checkout -b "$CANDIDATE_BRANCH" "origin/$TARGET_BRANCH"
+            node .github/scripts/coordinated-example-release.mjs sync \
+              --root . \
+              --identity "$RELEASE_IDENTITY"
+            (
+              cd examples/react-native
+              bun install --lockfile-only
+            )
+            (
+              cd examples/react-native-elevenlabs-audio
+              bun install --lockfile-only
+            )
+            cp "$canonical_payload" .github/coordinated-example-release.json
+            git config user.name "mentra-release-bot"
+            git config user.email "actions@users.noreply.github.com"
+            git add \
+              .github/coordinated-example-release.json \
+              examples/android/gradle.properties \
+              examples/ios/MentraExample.xcodeproj/project.pbxproj \
+              examples/react-native/package.json \
+              examples/react-native/bun.lock \
+              examples/react-native-elevenlabs-audio/package.json \
+              examples/react-native-elevenlabs-audio/bun.lock
+            git commit -m "chore(release): synchronize examples to $RELEASE_IDENTITY [skip coordinated request]"
+            release_commit=$(git rev-parse HEAD)
+            git push origin "HEAD:refs/heads/$CANDIDATE_BRANCH"
+          fi
+
+          echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse the synchronization pull request
+        if: steps.existing.outputs.already_published != 'true'
+        id: pull-request
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
+          CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
+          MENTRAOS_RUN_URL: ${{ fromJSON(inputs.payload).mentraos.coordinatorRunUrl }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
+            --limit 1 --json number,url,state,mergedAt)
+          if [[ "$(jq 'length' <<<"$pr_json")" == "0" ]]; then
+            pr_url=$(gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$CANDIDATE_BRANCH" \
+              --title "Synchronize examples to $RELEASE_IDENTITY" \
+              --body "Automated coordinated example release for \`$RELEASE_IDENTITY\`.\n\nMentraOS coordinator: $MENTRAOS_RUN_URL")
+          else
+            pr_url=$(jq -r '.[0].url' <<<"$pr_json")
+            state=$(jq -r '.[0].state' <<<"$pr_json")
+            merged_at=$(jq -r '.[0].mergedAt // empty' <<<"$pr_json")
+            if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+              gh pr reopen "$pr_url"
+            fi
+          fi
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch validation for the candidate commit
+        if: steps.existing.outputs.already_published != 'true'
+        id: validation
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+          dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run example-app-builds.yml \
+            --ref "$CANDIDATE_BRANCH" \
+            -f "artifact_suffix=$RELEASE_IDENTITY"
+
+          run_id=""
+          for _ in {1..30}; do
+            run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
+              --event workflow_dispatch --limit 20 \
+              --json databaseId,headSha,createdAt \
+              --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\" and .createdAt >= \"$dispatched_at\") | .databaseId" \
+              | head -1)
+            [[ -n "$run_id" ]] && break
+            sleep 2
+          done
+          [[ -n "$run_id" ]]
+          gh run watch "$run_id" --exit-status
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Merge the validated synchronization pull request
+        if: steps.existing.outputs.already_published != 'true'
+        id: merge
+        env:
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
+          TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
+        run: |
+          set -euo pipefail
+          if [[ "$(gh pr view "$PR_URL" --json state --jq .state)" != "MERGED" ]]; then
+            gh pr merge "$PR_URL" --merge
+          fi
+          merge_commit=$(gh pr view "$PR_URL" --json mergeCommit --jq .mergeCommit.oid)
+          git fetch origin "$TARGET_BRANCH"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$TARGET_BRANCH"
+          echo "merge_commit=$merge_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Download validated artifacts
+        if: steps.existing.outputs.already_published != 'true'
+        run: gh run download "${{ steps.validation.outputs.run_id }}" --dir validated-artifacts
+
+      - name: Create source tag and deterministic result
+        if: steps.existing.outputs.already_published != 'true'
+        id: result
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          SOURCE_TAG: ${{ steps.release.outputs.sourceTag }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
+          MERGE_COMMIT: ${{ steps.merge.outputs.merge_commit }}
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+          VALIDATION_RUN_URL: ${{ steps.validation.outputs.url }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$SOURCE_TAG" >/dev/null 2>&1; then
+            [[ "$(git ls-remote --tags origin "refs/tags/$SOURCE_TAG" | cut -f1)" == "$RELEASE_COMMIT" ]]
+          else
+            git tag "$SOURCE_TAG" "$RELEASE_COMMIT"
+            git push origin "refs/tags/$SOURCE_TAG"
+          fi
+
+          result_name="starter-kit-release-$RELEASE_IDENTITY.json"
+          node .github/scripts/coordinated-example-release.mjs result \
+            --payload coordinated-payload.json \
+            --repository "$STARTER_KIT_REPOSITORY" \
+            --release-commit "$RELEASE_COMMIT" \
+            --merge-commit "$MERGE_COMMIT" \
+            --pull-request-url "$PR_URL" \
+            --validation-run-url "$VALIDATION_RUN_URL" \
+            --artifact-dir validated-artifacts \
+            --output "$result_name"
+          echo "name=$result_name" >> "$GITHUB_OUTPUT"
+
+      - name: Publish immutable artifacts and result
+        if: steps.existing.outputs.already_published != 'true'
+        id: publish
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          FAMILY_BASE_VERSION: ${{ steps.release.outputs.familyBaseVersion }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          ARTIFACT_CONTAINER_TAG: ${{ steps.release.outputs.artifactContainerTag }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
+          RESULT_NAME: ${{ steps.result.outputs.name }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$ARTIFACT_CONTAINER_TAG" >/dev/null 2>&1; then
+            args=(--target "$RELEASE_COMMIT" --title "Bluetooth SDK $FAMILY_BASE_VERSION example builds")
+            if [[ "$CHANNEL" != "production" ]]; then args+=(--prerelease); fi
+            gh release create "$ARTIFACT_CONTAINER_TAG" "${args[@]}" \
+              --notes "Validated example applications for the $FAMILY_BASE_VERSION release family. Asset filenames identify the exact coordinated release."
+          fi
+
+          upload_immutable() {
+            local file="$1"
+            local name
+            name=$(basename "$file")
+            if gh release view "$ARTIFACT_CONTAINER_TAG" --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
+              mkdir -p existing-assets
+              gh release download "$ARTIFACT_CONTAINER_TAG" --pattern "$name" --dir existing-assets
+              cmp --silent "$file" "existing-assets/$name"
+            else
+              gh release upload "$ARTIFACT_CONTAINER_TAG" "$file"
+            fi
+          }
+
+          while IFS= read -r file; do upload_immutable "$file"; done < <(find validated-artifacts -type f | sort)
+          # Publish the result last. Its presence is the cross-repository completion signal.
+          upload_immutable "$RESULT_NAME"
+          result_url="https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$ARTIFACT_CONTAINER_TAG/$RESULT_NAME"
+          curl --fail --silent --show-error --location --head "$result_url" >/dev/null
+          echo "result_url=$result_url" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize the coordinated example release
+        env:
+          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
+          EXISTING_RESULT_URL: ${{ steps.existing.outputs.result_url }}
+          PUBLISHED_RESULT_URL: ${{ steps.publish.outputs.result_url }}
+        run: |
+          result_url="${PUBLISHED_RESULT_URL:-$EXISTING_RESULT_URL}"
+          {
+            echo "## Coordinated example release"
+            echo
+            echo "- Release: \`$RELEASE_IDENTITY\`"
+            echo "- Result: $result_url"
+            if [[ "${{ steps.existing.outputs.already_published }}" != "true" ]]; then
+              echo "- Pull request: ${{ steps.pull-request.outputs.url }}"
+              echo "- Validation: ${{ steps.validation.outputs.url }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -110,7 +110,11 @@ jobs:
         env:
           ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
         run: |
-          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          artifact_suffix="$ARTIFACT_SUFFIX"
+          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
+            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
+          fi
+          suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-android${suffix}.apk"
           cp examples/android/app/build/outputs/apk/debug/app-debug.apk "$output"
           echo "path=$output" >> "$GITHUB_OUTPUT"
@@ -199,7 +203,11 @@ jobs:
           fi
           mkdir Payload
           cp -R "$app_path" Payload/
-          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          artifact_suffix="$ARTIFACT_SUFFIX"
+          if [[ -z "$artifact_suffix" && -f ../../.github/coordinated-example-release.json ]]; then
+            artifact_suffix=$(jq -er .releaseIdentity ../../.github/coordinated-example-release.json)
+          fi
+          suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-ios${suffix}-unsigned.ipa"
           zip -qry "$output" Payload
           echo "path=examples/ios/$output" >> "$GITHUB_OUTPUT"
@@ -306,7 +314,11 @@ jobs:
         env:
           ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
         run: |
-          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          artifact_suffix="$ARTIFACT_SUFFIX"
+          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
+            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
+          fi
+          suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-react-native${suffix}.apk"
           cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk "$output"
           echo "path=$output" >> "$GITHUB_OUTPUT"
@@ -404,7 +416,11 @@ jobs:
         env:
           ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
         run: |
-          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          artifact_suffix="$ARTIFACT_SUFFIX"
+          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
+            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
+          fi
+          suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-rn-elevenlabs-audio${suffix}.apk"
           cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/release/app-release.apk "$output"
           echo "path=$output" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -1,20 +1,23 @@
 name: Example App Builds
 
 "on":
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+      - dev
+      - staging
   workflow_dispatch:
+    inputs:
+      artifact_suffix:
+        description: Optional coordinated release identity appended to filenames
+        required: false
+        type: string
 
 permissions:
   contents: read
 
-# Newest run per ref wins: cancels superseded PR builds and prevents an
-# older main run from finishing after a newer one and rolling back the
-# per-SDK-version release assets.
+# Newest validation per ref wins. Coordinated publication has separate
+# non-canceling channel concurrency in coordinated-example-release.yml.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,6 +27,16 @@ env:
   GSTREAMER_VERSION: 1.28.2
 
 jobs:
+  release-contract:
+    name: Coordinated release contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test coordinated release scripts
+        run: node --test .github/scripts/coordinated-example-release.test.mjs
+
   android:
     name: Native Android example
     runs-on: ubuntu-latest
@@ -93,13 +106,20 @@ jobs:
           ./gradlew :app:assembleDebug --no-daemon
 
       - name: Collect APK
-        run: cp examples/android/app/build/outputs/apk/debug/app-debug.apk mentra-example-android.apk
+        id: collect
+        env:
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+        run: |
+          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          output="mentra-example-android${suffix}.apk"
+          cp examples/android/app/build/outputs/apk/debug/app-debug.apk "$output"
+          echo "path=$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-android
-          path: mentra-example-android.apk
+          path: ${{ steps.collect.outputs.path }}
           if-no-files-found: error
 
   ios:
@@ -167,7 +187,10 @@ jobs:
             build
 
       - name: Package unsigned IPA
+        id: collect
         working-directory: examples/ios
+        env:
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
         run: |
           app_path=$(find build/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -print -quit)
           if [ -z "$app_path" ]; then
@@ -176,13 +199,16 @@ jobs:
           fi
           mkdir Payload
           cp -R "$app_path" Payload/
-          zip -qry mentra-example-ios-unsigned.ipa Payload
+          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          output="mentra-example-ios${suffix}-unsigned.ipa"
+          zip -qry "$output" Payload
+          echo "path=examples/ios/$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-ios
-          path: examples/ios/mentra-example-ios-unsigned.ipa
+          path: ${{ steps.collect.outputs.path }}
           if-no-files-found: error
 
   react-native:
@@ -276,13 +302,20 @@ jobs:
         run: examples/react-native/scripts/check-android-16kb.sh examples/react-native/android/app/build/outputs/apk/release/app-release.apk
 
       - name: Collect APK
-        run: cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk mentra-example-react-native.apk
+        id: collect
+        env:
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+        run: |
+          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          output="mentra-example-react-native${suffix}.apk"
+          cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk "$output"
+          echo "path=$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-react-native
-          path: mentra-example-react-native.apk
+          path: ${{ steps.collect.outputs.path }}
           if-no-files-found: error
 
   react-native-elevenlabs-audio:
@@ -367,76 +400,18 @@ jobs:
           ./gradlew :app:assembleRelease --no-daemon
 
       - name: Collect APK
-        run: cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/release/app-release.apk mentra-example-rn-elevenlabs-audio.apk
+        id: collect
+        env:
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+        run: |
+          suffix="${ARTIFACT_SUFFIX:+-$ARTIFACT_SUFFIX}"
+          output="mentra-example-rn-elevenlabs-audio${suffix}.apk"
+          cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/release/app-release.apk "$output"
+          echo "path=$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-rn-elevenlabs-audio
-          path: mentra-example-rn-elevenlabs-audio.apk
+          path: ${{ steps.collect.outputs.path }}
           if-no-files-found: error
-
-  publish:
-    name: Publish per-SDK-version release
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-    needs:
-      - android
-      - ios
-      - react-native
-      - react-native-elevenlabs-audio
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Publish artifacts to per-version releases
-        run: |
-          set -euo pipefail
-
-          # Each app publishes to the release matching its own pinned SDK
-          # version, so the releases stay correct even if one example
-          # temporarily pins an older SDK than the others.
-          publish() {
-            local version="$1"
-            local file="$2"
-            local tag="sdk-$version"
-
-            if ! gh release view "$tag" --json tagName >/dev/null 2>&1; then
-              gh release create "$tag" \
-                --prerelease \
-                --target "$GITHUB_SHA" \
-                --title "Bluetooth SDK $version example builds" \
-                --notes ""
-            fi
-
-            gh release upload "$tag" "$file" --clobber
-
-            # Re-point the tag at the commit whose artifacts the release now carries.
-            git tag -f "$tag" "$GITHUB_SHA"
-            git push -f origin "refs/tags/$tag"
-
-            local notes
-            notes="Latest example app builds for Mentra Bluetooth SDK $version."
-            notes+=$'\n\n'"Android APKs install directly (allow installs from unknown sources)."
-            notes+=$'\n'"The iOS IPA is unsigned: install it with a sideloading tool such as Sideloadly or AltStore, which re-signs it with your own Apple ID."
-            notes+=$'\n\n'"Assets last updated from commit $GITHUB_SHA on $(date -u +%Y-%m-%d)."
-            gh release edit "$tag" --notes "$notes"
-          }
-
-          publish "${{ needs.android.outputs.sdk-version }}" \
-            artifacts/mentra-example-android/mentra-example-android.apk
-          publish "${{ needs.ios.outputs.sdk-version }}" \
-            artifacts/mentra-example-ios/mentra-example-ios-unsigned.ipa
-          publish "${{ needs.react-native.outputs.sdk-version }}" \
-            artifacts/mentra-example-react-native/mentra-example-react-native.apk
-          publish "${{ needs.react-native-elevenlabs-audio.outputs.sdk-version }}" \
-            artifacts/mentra-example-rn-elevenlabs-audio/mentra-example-rn-elevenlabs-audio.apk

--- a/README.md
+++ b/README.md
@@ -29,14 +29,20 @@ Read the first-party [Mentra Live Bluetooth SDK docs](https://docs.mentraglass.c
 
 ## Install Prebuilt Example Apps
 
-Every commit on `main` publishes installable builds of the example apps to [GitHub Releases](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases), grouped by Bluetooth SDK version: the `sdk-<version>` release always carries the latest build of each example for that SDK version.
+Each completed coordinated Mentra release publishes matching installable example
+apps to [GitHub Releases](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases).
+Development and beta builds for one release train share the
+`sdk-builds-v<X.Y.Z>` release; stable builds use `sdk-<X.Y.Z>`. Every filename
+contains its exact coordinated identity, and the immutable `sdk-<version>`
+source tag identifies the commit that produced it.
 
-From the release matching your SDK version (e.g. `sdk-0.1.20`), download:
+From the release containing your SDK version, such as `sdk-builds-v3.1.0`,
+download the files carrying the same full version:
 
-- `mentra-example-android.apk` — native Android example
-- `mentra-example-react-native.apk` — React Native example
-- `mentra-example-rn-elevenlabs-audio.apk` — React Native ElevenLabs audio example
-- `mentra-example-ios-unsigned.ipa` — native iOS example
+- `mentra-example-android-<version>.apk` — native Android example
+- `mentra-example-react-native-<version>.apk` — React Native example
+- `mentra-example-rn-elevenlabs-audio-<version>.apk` — React Native ElevenLabs audio example
+- `mentra-example-ios-<version>-unsigned.ipa` — native iOS example
 
 Android APKs install directly from the phone browser (enable installs from unknown sources when prompted). The iOS IPA is unsigned; install it with a sideloading tool such as [Sideloadly](https://sideloadly.io/) or [AltStore](https://altstore.io/), which re-signs it with your own Apple ID. Pull-request builds are also available for 90 days as run artifacts on each [workflow run](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/workflows/example-app-builds.yml).
 


### PR DESCRIPTION
## Summary

- retain one shared validation workflow for all four maintained example applications
- add exact coordinated version synchronization across native Android, native iOS, React Native, and ElevenLabs lockfiles
- create and validate automated channel synchronization PRs before publishing example artifacts
- publish immutable, base-version-grouped artifacts and a machine-readable result for MentraOS
- remove force-moved tags, asset clobbering, and independent per-example publication

## Release behavior

A coordinated dispatch waits for the exact npm, Maven, SwiftPM, and OTA inputs, creates a candidate from the expected channel head, explicitly dispatches the shared validation workflow on that commit, merges its PR only after validation succeeds, and publishes the result JSON last. Retries reconcile an existing result or resume a partially completed synchronization without replacing different bytes.

TestFlight remains deferred until the cross-repository dev and staging pipeline is proven end to end.

## Validation

- `node --test .github/scripts/coordinated-example-release.test.mjs`
- `actionlint .github/workflows/*.yml`
- real dependency/lockfile synchronization fixture against `3.1.0-dev.37`
- existing PR CI builds all example applications

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and branch triggers for all example builds; mistakes could block coordinated publishes or leave consumers on outdated install docs, but validation and immutable asset checks reduce rollout risk.
> 
> **Overview**
> Replaces **per-commit `main` publication** with a **MentraOS-driven coordinated release** path: a new dispatch workflow validates a JSON payload, waits for npm/Maven/SwiftPM and OTA inputs, syncs all four example apps to one release identity, and only publishes after PR validation and merge.
> 
> A Node script (`coordinated-example-release.mjs`) **pins versions** across Android Gradle, iOS SPM/XcodeGen, and React Native lockfiles, and emits **`starter-kit-release-<identity>.json`** with artifact URLs, SHA-256s, and PR/tag provenance. **Immutable uploads** go to `sdk-builds-v<X.Y.Z>` for dev/beta or `sdk-<version>` for production; retries reconcile existing results without clobbering bytes.
> 
> **Example App Builds** now runs on PRs to `main`, `dev`, and `staging` (no push-triggered publish), names APK/IPA files with the coordinated identity when present, and runs the coordinated script tests in CI. **README** documents the new release layout and versioned filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1841a09cde7937070430600bf317b75a687f8bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->