### PR TITLE
ci: make native Android example conditional on Maven

### DIFF
--- a/.github/scripts/coordinated-example-release.mjs
+++ b/.github/scripts/coordinated-example-release.mjs
@@ -11,7 +11,13 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
 
 const EXAMPLE_ARTIFACTS = [
-  {key: "android", prefix: "mentra-example-android", suffix: ".apk", contentType: "application/vnd.android.package-archive"},
+  {
+    key: "android",
+    prefix: "mentra-example-android",
+    suffix: ".apk",
+    contentType: "application/vnd.android.package-archive",
+    required: false,
+  },
   {key: "ios", prefix: "mentra-example-ios", suffix: "-unsigned.ipa", contentType: "application/octet-stream"},
   {
     key: "reactNative",
@@ -164,18 +170,19 @@ export function createReleaseResult({payload, repository, releaseCommit, mergeCo
 
   const files = listFilesRecursively(artifactDir)
   const assetBaseUrl = `https://github.com/${repository}/releases/download/${release.artifactContainerTag}`
-  const artifacts = EXAMPLE_ARTIFACTS.map(({key, prefix, suffix, contentType}) => {
+  const artifacts = EXAMPLE_ARTIFACTS.flatMap(({key, prefix, suffix, contentType, required = true}) => {
     const name = `${prefix}-${release.releaseIdentity}${suffix}`
     const matches = files.filter((filePath) => path.basename(filePath) === name)
+    if (matches.length === 0 && !required) return []
     if (matches.length !== 1) throw new Error(`Expected exactly one built artifact named ${name}`)
-    return {
+    return [{
       key,
       name,
       url: `${assetBaseUrl}/${name}`,
       size: statSync(matches[0]).size,
       sha256: sha256(matches[0]),
       contentType,
-    }
+    }]
   })
 
   return {

--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -88,11 +88,10 @@ test("synchronizes all maintained example manifests", () => {
   )
 })
 
-test("creates a deterministic result for all four artifacts", () => {
+test("creates a deterministic result when optional native Android is unavailable", () => {
   const artifactDir = mkdtempSync(path.join(tmpdir(), "starter-kit-artifacts-"))
   const identity = "3.1.0-beta.57"
   for (const name of [
-    `mentra-example-android-${identity}.apk`,
     `mentra-example-ios-${identity}-unsigned.ipa`,
     `mentra-example-react-native-${identity}.apk`,
     `mentra-example-rn-elevenlabs-audio-${identity}.apk`,
@@ -111,6 +110,23 @@ test("creates a deterministic result for all four artifacts", () => {
   })
 
   assert.equal(result.starterKit.artifactContainerTag, "sdk-builds-v3.1.0")
-  assert.equal(result.artifacts.length, 4)
+  assert.equal(result.artifacts.length, 3)
   assert.ok(result.artifacts.every((artifact) => artifact.sha256.length === 64 && artifact.size > 0))
+
+  writeFileSync(
+    path.join(artifactDir, `mentra-example-android-${identity}.apk`),
+    `mentra-example-android-${identity}.apk`,
+  )
+  assert.equal(
+    createReleaseResult({
+      payload: payload(identity),
+      repository: "Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit",
+      releaseCommit: sha,
+      mergeCommit: "c".repeat(40),
+      pullRequestUrl: "https://github.com/Mentra/pr/1",
+      validationRunUrl: "https://github.com/Mentra/actions/1",
+      artifactDir,
+    }).artifacts.length,
+    4,
+  )
 })

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -92,7 +92,7 @@ jobs:
             [[ "$(jq -r .baseRefName <<< "$pr_provenance")" == "$TARGET_BRANCH" ]]
             [[ "$(jq -r .mergeCommit.oid <<< "$pr_provenance")" == "$merge_commit" ]]
             [[ "$(gh api "repos/$STARTER_KIT_REPOSITORY/git/ref/tags/sdk-$RELEASE_IDENTITY" --jq .object.sha)" == "$release_commit" ]]
-            [[ "$(jq -er '.artifacts | length' "$result")" == "4" ]]
+            [[ "$(jq -er '.artifacts | length' "$result")" =~ ^(3|4)$ ]]
             while IFS= read -r url; do
               curl --fail --silent --show-error --location --head "$url" >/dev/null
             done < <(jq -r '.artifacts[].url' "$result")
@@ -125,11 +125,6 @@ jobs:
             [[ "$(npm view "@mentra/bluetooth-sdk@$RELEASE_IDENTITY" version 2>/dev/null)" == "$RELEASE_IDENTITY" ]] &&
               [[ "$(npm view "@mentra/engine@$RELEASE_IDENTITY" version 2>/dev/null)" == "$RELEASE_IDENTITY" ]]
           }
-          check_maven() {
-            curl --fail --silent --show-error --head \
-              "https://repo1.maven.org/maven2/com/mentraglass/bluetooth-sdk/$RELEASE_IDENTITY/bluetooth-sdk-$RELEASE_IDENTITY.pom" \
-              >/dev/null
-          }
           check_swiftpm() {
             git ls-remote --exit-code --tags \
               https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git \
@@ -137,7 +132,6 @@ jobs:
           }
 
           retry 30 20 check_npm
-          retry 30 20 check_maven
           retry 30 20 check_swiftpm
           curl --fail --silent --show-error --location "$OTA_MANIFEST_URL" --output ota-manifest.json
           echo "$OTA_MANIFEST_SHA256  ota-manifest.json" | sha256sum --check --status

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -56,7 +56,29 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Check exact Maven release availability
+        id: availability
+        env:
+          RELEASE_IDENTITY: ${{ steps.sdk-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          base="https://repo.maven.apache.org/maven2/com/mentraglass"
+          sdk_status=$(curl --silent --show-error --head --location --output /dev/null --write-out '%{http_code}' \
+            "$base/bluetooth-sdk/$RELEASE_IDENTITY/bluetooth-sdk-$RELEASE_IDENTITY.pom" || true)
+          lc3_status=$(curl --silent --show-error --head --location --output /dev/null --write-out '%{http_code}' \
+            "$base/lc3Lib/$RELEASE_IDENTITY/lc3Lib-$RELEASE_IDENTITY.pom" || true)
+          if [[ "$sdk_status" == "200" && "$lc3_status" == "200" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$sdk_status" == "404" || "$lc3_status" == "404" ]]; then
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "Native Android example skipped because $RELEASE_IDENTITY is not yet available from Maven Central."
+          else
+            echo "Unexpected Maven Central status (SDK $sdk_status, LC3 $lc3_status)." >&2
+            exit 1
+          fi
+
       - name: Set up Java
+        if: steps.availability.outputs.available == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -64,9 +86,11 @@ jobs:
           cache: gradle
 
       - name: Set up Android SDK
+        if: steps.availability.outputs.available == 'true'
         uses: android-actions/setup-android@v3
 
       - name: Free disk space
+        if: steps.availability.outputs.available == 'true'
         run: |
           df -h
           sudo apt-get clean
@@ -83,29 +107,34 @@ jobs:
           df -h
 
       - name: Install Android SDK packages
+        if: steps.availability.outputs.available == 'true'
         run: |
           # build-tools;34.0.0 is the AGP 8.7 default; install it up front so
           # Gradle does not have to auto-install it mid-build.
           sdkmanager "platforms;android-35" "build-tools;35.0.0" "build-tools;34.0.0" "ndk;27.1.12297006"
 
       - name: Cache GStreamer Android SDK
+        if: steps.availability.outputs.available == 'true'
         uses: actions/cache@v4
         with:
           path: examples/android/.gstreamer/Android.sdk
           key: gstreamer-android-${{ env.GSTREAMER_VERSION }}
 
       - name: Type check Kotlin
+        if: steps.availability.outputs.available == 'true'
         working-directory: examples/android
         run: |
           chmod +x ./gradlew
           ./gradlew :app:compileDebugKotlin --no-daemon
 
       - name: Build
+        if: steps.availability.outputs.available == 'true'
         working-directory: examples/android
         run: |
           ./gradlew :app:assembleDebug --no-daemon
 
       - name: Collect APK
+        if: steps.availability.outputs.available == 'true'
         id: collect
         env:
           ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
@@ -120,6 +149,7 @@ jobs:
           echo "path=$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload APK artifact
+        if: steps.availability.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-android

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ source tag identifies the commit that produced it.
 From the release containing your SDK version, such as `sdk-builds-v3.1.0`,
 download the files carrying the same full version:
 
-- `mentra-example-android-<version>.apk` — native Android example
+- `mentra-example-android-<version>.apk` — native Android example, when that
+  exact SDK version is already available from Maven Central
 - `mentra-example-react-native-<version>.apk` — React Native example
 - `mentra-example-rn-elevenlabs-audio-<version>.apk` — React Native ElevenLabs audio example
 - `mentra-example-ios-<version>-unsigned.ipa` — native iOS example


### PR DESCRIPTION
## Summary

- probe the exact Bluetooth SDK and LC3 Maven coordinates once before native Android CI
- build and publish the native Android example when both are available
- otherwise keep native Android optional while requiring native iOS and both React Native examples
- remove Maven Central propagation from the coordinated Starter Kit gate

This lets coordinated releases proceed while Sonatype is still publishing without pretending that the native Android example was built.

## Validation

- `node --test .github/scripts/coordinated-example-release.test.mjs`
- `actionlint .github/workflows/coordinated-example-release.yml .github/workflows/example-app-builds.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coordinated release gates and artifact expectations; mis-timed Maven probes could skip Android builds or accept incomplete releases, but iOS and React Native examples remain required.
> 
> **Overview**
> Coordinated example releases no longer assume the native Android APK is always built. **Release result assembly** treats the Android artifact as optional (`required: false`), so `createReleaseResult` can emit **3 or 4** artifacts when Maven-backed native Android was skipped.
> 
> **Example app builds** probe Maven Central for the exact `bluetooth-sdk` and `lc3Lib` POMs before running the native Android job; if either is missing (404), the job skips setup/build/upload instead of failing. **Coordinated release** validation accepts 3–4 artifacts on reconcile and **drops the Maven Central wait** from the npm/SwiftPM/OTA gate so Starter Kit publication is not blocked on Sonatype propagation.
> 
> Tests and **README** were updated to match optional Android APK availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fa3427a65f964580469c5156cc90111fccc88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->