### PR TITLE
fix(ci): accept coordinated repository dispatches

### DIFF
--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -53,6 +53,12 @@ test("reconciles completed releases from immutable PR and tag provenance", () =>
   assert.doesNotMatch(releaseWorkflow, /\.starterKit\.baseCommit "\$result"\)" == "\$EXPECTED_STARTER_KIT_HEAD"/)
 })
 
+test("accepts coordinated releases from manual or cross-repository dispatch", () => {
+  assert.match(releaseWorkflow, /repository_dispatch:\n    types:\n      - coordinated_example_release/)
+  assert.match(releaseWorkflow, /inputs\.payload \|\| github\.event\.client_payload\.payload/)
+  assert.match(releaseWorkflow, /inputs\.channel \|\| github\.event\.client_payload\.channel/)
+})
+
 test("synchronizes all maintained example manifests", () => {
   const root = mkdtempSync(path.join(tmpdir(), "starter-kit-sync-"))
   mkdirSync(path.join(root, "examples/android"), {recursive: true})

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -1,7 +1,10 @@
 name: Coordinated Example Release
-run-name: Coordinated example ${{ inputs.channel }} ${{ fromJSON(inputs.payload).releaseIdentity }}
+run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.channel }} ${{ fromJSON(inputs.payload || github.event.client_payload.payload).releaseIdentity }}
 
 "on":
+  repository_dispatch:
+    types:
+      - coordinated_example_release
   workflow_dispatch:
     inputs:
       channel:
@@ -25,11 +28,13 @@ permissions:
 concurrency:
   # Dev and beta for one train share a GitHub release container, so serialize
   # the family even though their source branches are independent.
-  group: coordinated-example-release-${{ fromJSON(inputs.payload).familyBaseVersion }}
+  group: coordinated-example-release-${{ fromJSON(inputs.payload || github.event.client_payload.payload).familyBaseVersion }}
   cancel-in-progress: false
 
 env:
   CI: true
+  COORDINATED_CHANNEL: ${{ inputs.channel || github.event.client_payload.channel }}
+  COORDINATED_PAYLOAD: ${{ inputs.payload || github.event.client_payload.payload }}
   GH_TOKEN: ${{ github.token }}
   STARTER_KIT_REPOSITORY: Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit
 
@@ -52,8 +57,7 @@ jobs:
       - name: Validate the coordinated payload
         id: release
         env:
-          COORDINATED_PAYLOAD: ${{ inputs.payload }}
-          DISPATCH_CHANNEL: ${{ inputs.channel }}
+          DISPATCH_CHANNEL: ${{ env.COORDINATED_CHANNEL }}
         run: |
           set -euo pipefail
           printf '%s' "$COORDINATED_PAYLOAD" > coordinated-payload.json
@@ -66,8 +70,8 @@ jobs:
         id: existing
         env:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
-          RELEASE_SET_ID: ${{ fromJSON(inputs.payload).releaseSetId }}
-          MENTRAOS_SOURCE_COMMIT: ${{ fromJSON(inputs.payload).mentraos.sourceCommit }}
+          RELEASE_SET_ID: ${{ fromJSON(env.COORDINATED_PAYLOAD).releaseSetId }}
+          MENTRAOS_SOURCE_COMMIT: ${{ fromJSON(env.COORDINATED_PAYLOAD).mentraos.sourceCommit }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           ARTIFACT_CONTAINER_TAG: ${{ steps.release.outputs.artifactContainerTag }}
         run: |
@@ -106,8 +110,8 @@ jobs:
         if: steps.existing.outputs.already_published != 'true'
         env:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
-          OTA_MANIFEST_URL: ${{ fromJSON(inputs.payload).ota.manifestUrl }}
-          OTA_MANIFEST_SHA256: ${{ fromJSON(inputs.payload).ota.manifestSha256 }}
+          OTA_MANIFEST_URL: ${{ fromJSON(env.COORDINATED_PAYLOAD).ota.manifestUrl }}
+          OTA_MANIFEST_SHA256: ${{ fromJSON(env.COORDINATED_PAYLOAD).ota.manifestSha256 }}
         run: |
           set -euo pipefail
           retry() {
@@ -143,7 +147,7 @@ jobs:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
-          EXPECTED_HEAD: ${{ fromJSON(inputs.payload).expectedStarterKitHead }}
+          EXPECTED_HEAD: ${{ fromJSON(env.COORDINATED_PAYLOAD).expectedStarterKitHead }}
         run: |
           set -euo pipefail
           git fetch origin "$TARGET_BRANCH" "$CANDIDATE_BRANCH" 2>/dev/null || git fetch origin "$TARGET_BRANCH"
@@ -207,7 +211,7 @@ jobs:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
-          MENTRAOS_RUN_URL: ${{ fromJSON(inputs.payload).mentraos.coordinatorRunUrl }}
+          MENTRAOS_RUN_URL: ${{ fromJSON(env.COORDINATED_PAYLOAD).mentraos.coordinatorRunUrl }}
         run: |
           set -euo pipefail
           pr_url=""


### PR DESCRIPTION
## Why

The MentraOS coordinator GitHub App has the Starter Kit Contents permission needed to synchronize and release examples, but GitHub rejects `workflow_dispatch` without a separate Actions write permission. The first coordinated dev release therefore reached the Starter Kit gate and failed with HTTP 403 before any example workflow could start.

GitHub documents `repository_dispatch` as the cross-repository trigger and requires Contents write, matching the coordinator app's existing least-privilege grant.

## Changes

- accept `coordinated_example_release` repository dispatches
- normalize manual and repository dispatch inputs into the same validated payload/channel contract
- retain manual `workflow_dispatch` for operator use
- add a focused workflow contract test

## Validation

- `node --test .github/scripts/coordinated-example-release.test.mjs`
- `actionlint .github/workflows/coordinated-example-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and input wiring only; release validation and publish logic are unchanged aside from reading the same payload from a shared env variable.
> 
> **Overview**
> Enables the MentraOS coordinator to trigger coordinated example releases via **`repository_dispatch`** (`coordinated_example_release`) instead of relying only on **`workflow_dispatch`**, which required Actions write the app does not have.
> 
> The workflow now **unifies** manual and cross-repo triggers by resolving channel and payload from `inputs.*` or `github.event.client_payload.*`, exposing them as **`COORDINATED_CHANNEL`** / **`COORDINATED_PAYLOAD`** for run naming, concurrency, validation, and downstream steps. Manual **`workflow_dispatch`** is unchanged for operators.
> 
> A **contract test** asserts the workflow declares the dispatch type and the fallback expressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb235ab907a235aa70fa8895be120fc5a991d00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->