### PR TITLE
chore(release): synchronize examples to 3.1.0-dev.44

### DIFF
--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,0 +1,21 @@
+{
+  "channel": "dev",
+  "correlationId": "mentraos-33115411802",
+  "expectedStarterKitHead": "05fb088179f8cb7d0bf23d37ef92cb88c94242b9",
+  "familyBaseVersion": "3.1.0",
+  "mentraos": {
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33115411802",
+    "sourceCommit": "f94478f24d12b7cd6c9f430dd8ebdb74358f46ef"
+  },
+  "ota": {
+    "manifestSha256": "a7dafdf212e34f0971292158cc2e63ec4c7ffd220afe1bdd0336911b82171593",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.44.json"
+  },
+  "packages": {
+    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
+    "@mentra/engine": "3.1.0-dev.44"
+  },
+  "releaseIdentity": "3.1.0-dev.44",
+  "releaseSetId": "mentra-3.1.0-dev.44",
+  "schemaVersion": 1
+}

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-dev.9
+mentraSdkVersion=3.1.0-dev.44

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-dev.9;
+				version = 3.1.0-dev.44;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-dev.9
+    exactVersion: 3.1.0-dev.44
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.9",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.44",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.9", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-yqgdOIPjG4uLKSuVhmFsgaeXXzw2OVoJKupAPWK2+yaDADX0dyqLfD5a93sFmewPtkwpar7Tj4eXKwzfRSsW6w=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.44", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-1x2KqQE+0e886chKJDtIYhOEZG+qFsrBA6m5bNQMWLWt+570POqKXcC5bY2fcmNhYh52zlODR17eiv3ibg1JnA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.9",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.37",
-        "@mentra/engine": "3.1.0-dev.37",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.44",
+        "@mentra/engine": "3.1.0-dev.44",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -341,19 +341,19 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.37", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Yrw/CWoaoWyDaIBYuhDF9MOcJzIkoerOSWXJMmIxuhtHsFlLSPhZJ7b7Bax1nFBrAqewDi/F9a6TAQMhWP+IcA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.44", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-1x2KqQE+0e886chKJDtIYhOEZG+qFsrBA6m5bNQMWLWt+570POqKXcC5bY2fcmNhYh52zlODR17eiv3ibg1JnA=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.37", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.37", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-gHm2YmKNFfxxwrp+mDjvVImylozq110SGElP888M1s+qID63JWoConYWpRG5jrMkd8FsjaKV0CNrXcgi4koM0g=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.44", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.44", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-0dV9CwnFaVcC17wA36e5KNyvBHPXqZwHTE3GQtBhuJHKHC8u7NTWt/GbsxAVhtOilULXn08Gk055QVbLW4hw/g=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.37", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-HWlhFiJrPIcIUksi2GZglUmBfBlR2PSDS22lMQj68xajSfJt2obaGZhIiOJEskgillRqrXMbYL8VOsWzOI26mw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.44", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-sXeYShrNoBkOUbLgl1j9BCyQeYTO+GBfxmjpK/uI8AmBvbyUe9ddBqRk0txIpR1Ik8v3mJchJLEBSxNgZhrSNw=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-dev.37", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.37" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-cfkCoxLBAnlJctHgdpmXHHmSdwZZ9pVvsfrkXmj6U68SYfxZ24fo26Bk7IXsoK/cDhUQ1nw7xxdt2p8P3HtgZQ=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-dev.44", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.44" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-p9d0BbphTZ8j4fFaLsJPN3Q40wmoDHYS1DoCOOduvz3r8bOlxgYuF1G6HEXgyD5mP/wCK5SNbh2orJoaED4V1g=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-dev.37", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.37", "@mentra/cloud-client": "3.1.0-dev.37", "@mentra/cloud-protocol": "3.1.0-dev.37", "@mentra/crust": "3.1.0-dev.37", "@mentra/miniapp": "3.1.0-dev.37", "buffer": "^6.0.3", "events": "^3.3.0", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-it9o25svZqHH6FbTVp+tB5fqK+LYYzaL/RwmhvCH34CbJZmwkRP+EIBXZmD4n0bNTqWlIyUz+x0GuTY1/U10BA=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-dev.44", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.44", "@mentra/cloud-client": "3.1.0-dev.44", "@mentra/cloud-protocol": "3.1.0-dev.44", "@mentra/crust": "3.1.0-dev.44", "@mentra/miniapp": "3.1.0-dev.44", "buffer": "^6.0.3", "events": "^3.3.0", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-1b5Aoq0p+R5kC7hp6MnjExvGBIdKUmKYriojjo/XEPR/R4BK5qAtsaJ9qCR5iP/fCh5DTOhHFwmDLMMe/k0rjQ=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.37", "", {}, "sha512-IPgtrwVWRPjFr6DPwp4OOHE+9wlJr87+ZRi/nGf4UY4EU2ncNg6nvtak5RvkMZDu5STGSyM9nfdCXSj0dbBShA=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.44", "", {}, "sha512-jgTl8S+TuMCzAxVbPlocNS26H8O4/bhTWghEyIqd0IS1xDf1RbhVu5E2J7CEjPSfcnbfX/TclFWwbL39X7VYOQ=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.37", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.37", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-328Qa1MRmXSUTvIJXzo8C2RtR7DxJrQQKiPzBLCxJ7MEzzpcy1p2U2ZOI/RSo5RbiDI1q6L1SqQKdnU+ZcTPwA=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.44", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.44", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Pwc35FTxxfYPzTm4+x1lKGGVhqyaO/c9rmPuju73rjY2n3KtVz8TxCWq6Nr+cX52ZmsLOQ4yce4dGS17rGRopA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.37",
-    "@mentra/engine": "3.1.0-dev.37",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
+    "@mentra/engine": "3.1.0-dev.44",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
Automated dependency synchronization for coordinated release `3.1.0-dev.44`.

Coordinator: https://github.com/Mentra-Community/MentraOS/actions/runs/33115411802
Starter Kit workflow: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33119938599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only updates for example apps and release metadata; no production runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Aligns all starter-kit **examples** with coordinated dev release **`3.1.0-dev.44`** (no SDK or app logic changes).
> 
> Adds **`.github/coordinated-example-release.json`** as the canonical release manifest (package pins, OTA manifest URL/hash, coordinator correlation, expected starter-kit head).
> 
> Bumps Mentra dependency versions across **Android** (`mentraSdkVersion` in `gradle.properties`), **iOS** (`mentra-bluetooth-sdk-ios` exact version in `project.yml` / `project.pbxproj`), and **React Native** examples (`@mentra/bluetooth-sdk` and, where used, `@mentra/engine` in `package.json` with matching **`bun.lock`** updates). Prior pins were mixed (`3.1.0-dev.9`, `3.1.0-dev.37`) and are now unified on **`.44`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b4526a328b1d7234d6642e07bb5f22403d6453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->