### PR TITLE
chore(release): synchronize examples to 3.1.0-dev.49

### DIFF
--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "dev",
-  "correlationId": "mentraos-33115411802",
-  "expectedStarterKitHead": "05fb088179f8cb7d0bf23d37ef92cb88c94242b9",
+  "correlationId": "mentraos-33127377752",
+  "expectedStarterKitHead": "91d2de9dc902707ff5c2e0c1c5d1c193f74c0c31",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33115411802",
-    "sourceCommit": "f94478f24d12b7cd6c9f430dd8ebdb74358f46ef"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33127377752",
+    "sourceCommit": "778baa14bdccbe1ab484cc16b66a914ebcd7e471"
   },
   "ota": {
-    "manifestSha256": "a7dafdf212e34f0971292158cc2e63ec4c7ffd220afe1bdd0336911b82171593",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.44.json"
+    "manifestSha256": "30c3117d08f9e9995e664ad22f17b41d8d52ca586cd77619923bd52f5c0d22f9",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.49.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
-    "@mentra/engine": "3.1.0-dev.44"
+    "@mentra/bluetooth-sdk": "3.1.0-dev.49",
+    "@mentra/engine": "3.1.0-dev.49"
   },
-  "releaseIdentity": "3.1.0-dev.44",
-  "releaseSetId": "mentra-3.1.0-dev.44",
+  "releaseIdentity": "3.1.0-dev.49",
+  "releaseSetId": "mentra-3.1.0-dev.49",
   "schemaVersion": 1
 }

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-dev.44
+mentraSdkVersion=3.1.0-dev.49

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-dev.44;
+				version = 3.1.0-dev.49;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-dev.44
+    exactVersion: 3.1.0-dev.49
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.44",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.49",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.44", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-1x2KqQE+0e886chKJDtIYhOEZG+qFsrBA6m5bNQMWLWt+570POqKXcC5bY2fcmNhYh52zlODR17eiv3ibg1JnA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.49", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PDOe10v9Y9R3thudgFu24XqFa+qmxnRHS8VFVfXeWEkuanrBoK3BYgWu+5MlgzgxDJOUb67M1cyssobpk+aGgw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.49",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.44",
-        "@mentra/engine": "3.1.0-dev.44",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.49",
+        "@mentra/engine": "3.1.0-dev.49",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -341,19 +341,19 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.44", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-1x2KqQE+0e886chKJDtIYhOEZG+qFsrBA6m5bNQMWLWt+570POqKXcC5bY2fcmNhYh52zlODR17eiv3ibg1JnA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.49", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PDOe10v9Y9R3thudgFu24XqFa+qmxnRHS8VFVfXeWEkuanrBoK3BYgWu+5MlgzgxDJOUb67M1cyssobpk+aGgw=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.44", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.44", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-0dV9CwnFaVcC17wA36e5KNyvBHPXqZwHTE3GQtBhuJHKHC8u7NTWt/GbsxAVhtOilULXn08Gk055QVbLW4hw/g=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.49", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.49", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-U4+Syk2sZmba7S1J2g8GbLJJqruBqLOAcYhoWolkYlV5Tb36eBLR35n20wNd2gJYQai+ERzQZOUSjnXE5ezX0Q=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.44", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-sXeYShrNoBkOUbLgl1j9BCyQeYTO+GBfxmjpK/uI8AmBvbyUe9ddBqRk0txIpR1Ik8v3mJchJLEBSxNgZhrSNw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.49", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-oODVcaA9znQhr9zl2ESYTbFPKfnwrJeCzDpqCmVRwXFe9rckGLg/hAsEr88lFwdKIClNtBAf31PZmtfV08zFzw=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-dev.44", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.44" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-p9d0BbphTZ8j4fFaLsJPN3Q40wmoDHYS1DoCOOduvz3r8bOlxgYuF1G6HEXgyD5mP/wCK5SNbh2orJoaED4V1g=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-dev.49", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.49" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qWF713jwGvmondB4WdiLQEAH4c/7E14v8OkM036a2+Qk+awYF6451f+VMfBpwSLWCuD6jKpnamQlE413/6L1yw=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-dev.44", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.44", "@mentra/cloud-client": "3.1.0-dev.44", "@mentra/cloud-protocol": "3.1.0-dev.44", "@mentra/crust": "3.1.0-dev.44", "@mentra/miniapp": "3.1.0-dev.44", "buffer": "^6.0.3", "events": "^3.3.0", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-1b5Aoq0p+R5kC7hp6MnjExvGBIdKUmKYriojjo/XEPR/R4BK5qAtsaJ9qCR5iP/fCh5DTOhHFwmDLMMe/k0rjQ=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-dev.49", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.49", "@mentra/cloud-client": "3.1.0-dev.49", "@mentra/cloud-protocol": "3.1.0-dev.49", "@mentra/crust": "3.1.0-dev.49", "@mentra/miniapp": "3.1.0-dev.49", "buffer": "^6.0.3", "events": "^3.3.0", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-6/t5k6yi32T1vBzTgxOWIr+5ykKlYyNGrWsMyHVfnnPk9L9luNyEx5HJhJGMSEM7B7c1NREJOm/N2MhEh0M+kg=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.44", "", {}, "sha512-jgTl8S+TuMCzAxVbPlocNS26H8O4/bhTWghEyIqd0IS1xDf1RbhVu5E2J7CEjPSfcnbfX/TclFWwbL39X7VYOQ=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.49", "", {}, "sha512-jFliDTNmcwyMaQHZ1GhOZ/qWDIjstA4hWAA89FfN3f4WZzgtNTmK4T/YlOvqW7ifpJCzGtpWv5ebChl9ByhOCQ=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.44", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.44", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Pwc35FTxxfYPzTm4+x1lKGGVhqyaO/c9rmPuju73rjY2n3KtVz8TxCWq6Nr+cX52ZmsLOQ4yce4dGS17rGRopA=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.49", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.49", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Oqo8dyZNe3EqVZYGm14fFPF4Td4Iu9QK4c1uOrTPEVjg8PQjQsc6zlu2G4cT5VPmwli6AxREgH9bam3J4ozurw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
-    "@mentra/engine": "3.1.0-dev.44",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.49",
+    "@mentra/engine": "3.1.0-dev.49",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -4,6 +4,7 @@ import type {MentraLiveOtaState} from '@mentra/engine/ota';
 import {otaPresentation} from './otaPresentation';
 
 const baseState: MentraLiveOtaState = {
+  batteryLevel: 80,
   canDiscard: false,
   canDismiss: false,
   canFinish: false,
@@ -11,6 +12,7 @@ const baseState: MentraLiveOtaState = {
   canOpenWifiSetup: false,
   canRetry: false,
   connected: true,
+  completedUpdate: false,
   continueDisabled: false,
   currentStep: null,
   error: null,

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -112,6 +112,13 @@ export function otaPresentation(
         title: `Checking ${deviceName}`,
         tone: 'active',
       };
+    case 'finishing':
+      return {
+        indeterminate: true,
+        message: 'Checking whether any additional update steps are required.',
+        title: 'Finishing update',
+        tone: 'active',
+      };
     case 'update_available':
       return {
         detail: transportDetail(state),
@@ -128,6 +135,21 @@ export function otaPresentation(
           : undefined,
         title: state.versionChange ? 'Version change required' : 'Update available',
         tone: 'active',
+        versionLabel: updateVersionLabel(releaseTransition),
+      };
+    case 'battery_required':
+      return {
+        message: `Charge ${deviceName} to at least 25% before updating. Current battery: ${state.batteryLevel ?? 'unknown'}%.`,
+        primary: {
+          action: 'install',
+          disabled: true,
+          label: 'Update now',
+        },
+        secondary: state.canDismiss
+          ? {action: 'finish', label: 'Later'}
+          : undefined,
+        title: 'Battery level too low',
+        tone: 'neutral',
         versionLabel: updateVersionLabel(releaseTransition),
       };
     case 'wifi_required':


### PR DESCRIPTION
Automated dependency synchronization for coordinated release `3.1.0-dev.49`.

Coordinator: https://github.com/Mentra-Community/MentraOS/actions/runs/33127377752
Starter Kit workflow: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33129715880

Operator-created to recover the first end-to-end verification after the configured coordinator credential lacked `Pull requests: write`; candidate SHA `d68068c742e5798ae7323f13a3ce8b2f97caf248` remains exact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and example-only OTA copy changes; no production app or security-sensitive logic in this repo slice.
> 
> **Overview**
> Bumps the coordinated dev release from **3.1.0-dev.44** to **3.1.0-dev.49** across `.github/coordinated-example-release.json`, Android/iOS examples, and both React Native example apps (including lockfiles and OTA manifest metadata).
> 
> The React Native example’s custom OTA UI now handles two additional Engine screens: a **`finishing`** indeterminate “Finishing update” step and **`battery_required`**, which blocks install until glasses are charged to 25% and shows the current battery level. Test fixtures add **`batteryLevel`** and **`completedUpdate`** so `MentraLiveOtaState` matches the updated SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0b75d137de88991c0c199f58ec393ab194d6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->