### PR TITLE
fix(examples): handle current Engine OTA states

### DIFF
--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -4,6 +4,7 @@ import type {MentraLiveOtaState} from '@mentra/engine/ota';
 import {otaPresentation} from './otaPresentation';
 
 const baseState: MentraLiveOtaState = {
+  batteryLevel: 80,
   canDiscard: false,
   canDismiss: false,
   canFinish: false,
@@ -11,6 +12,7 @@ const baseState: MentraLiveOtaState = {
   canOpenWifiSetup: false,
   canRetry: false,
   connected: true,
+  completedUpdate: false,
   continueDisabled: false,
   currentStep: null,
   error: null,

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -112,6 +112,13 @@ export function otaPresentation(
         title: `Checking ${deviceName}`,
         tone: 'active',
       };
+    case 'finishing':
+      return {
+        indeterminate: true,
+        message: 'Checking whether any additional update steps are required.',
+        title: 'Finishing update',
+        tone: 'active',
+      };
     case 'update_available':
       return {
         detail: transportDetail(state),
@@ -128,6 +135,21 @@ export function otaPresentation(
           : undefined,
         title: state.versionChange ? 'Version change required' : 'Update available',
         tone: 'active',
+        versionLabel: updateVersionLabel(releaseTransition),
+      };
+    case 'battery_required':
+      return {
+        message: `Charge ${deviceName} to at least 25% before updating. Current battery: ${state.batteryLevel ?? 'unknown'}%.`,
+        primary: {
+          action: 'install',
+          disabled: true,
+          label: 'Update now',
+        },
+        secondary: state.canDismiss
+          ? {action: 'finish', label: 'Later'}
+          : undefined,
+        title: 'Battery level too low',
+        tone: 'neutral',
         versionLabel: updateVersionLabel(releaseTransition),
       };
     case 'wifi_required':


### PR DESCRIPTION
## Summary

- handle the Engine `finishing` and `battery_required` OTA presentation states in the React Native example
- update the typed OTA state fixture for `batteryLevel` and `completedUpdate`

## Why

The coordinated `3.1.0-dev.49` dependency update exposed the current Engine OTA contract and failed the React Native example TypeScript check because the custom presenter still modeled the previous state union.

## Validation

- `bunx tsc --noEmit`
- `bun test src/ota/otaPresentation.test.ts` (11 passing)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI copy and test fixtures only; no auth, data, or production runtime paths.
> 
> **Overview**
> Aligns the React Native example’s custom OTA presenter with the current **@mentra/engine/ota** screen union after the coordinated SDK bump.
> 
> **`otaPresentation`** now maps **`finishing`** to an indeterminate “Finishing update” state while Engine checks for more steps, and **`battery_required`** to a neutral screen that blocks install until battery is at least 25%, shows the current level from **`batteryLevel`**, keeps “Update now” disabled, and still offers “Later” when **`canDismiss`** is true (with the same version label as other pre-install screens).
> 
> The test **`baseState`** fixture adds **`batteryLevel`** and **`completedUpdate`** so **`MentraLiveOtaState`** type-checks against the updated Engine contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c769738a13ea3ad5586546595f7c6df3d60b85c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->