### PR TITLE
chore(release): synchronize examples to 3.1.0-dev.52

### DIFF
--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "dev",
-  "correlationId": "mentraos-33115411802",
-  "expectedStarterKitHead": "05fb088179f8cb7d0bf23d37ef92cb88c94242b9",
+  "correlationId": "mentraos-33133150461",
+  "expectedStarterKitHead": "4257d89b9999a389710dab80b0fed9d84fc50e68",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33115411802",
-    "sourceCommit": "f94478f24d12b7cd6c9f430dd8ebdb74358f46ef"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33133150461",
+    "sourceCommit": "c2a48c816c4304a9b2c5441f0ba52883ad0d006c"
   },
   "ota": {
-    "manifestSha256": "a7dafdf212e34f0971292158cc2e63ec4c7ffd220afe1bdd0336911b82171593",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.44.json"
+    "manifestSha256": "fcef234b128e03f1e27f3d643b188e5e06450af2aeba768b5643e496040e9c16",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.52.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.44",
-    "@mentra/engine": "3.1.0-dev.44"
+    "@mentra/bluetooth-sdk": "3.1.0-dev.52",
+    "@mentra/engine": "3.1.0-dev.52"
   },
-  "releaseIdentity": "3.1.0-dev.44",
-  "releaseSetId": "mentra-3.1.0-dev.44",
+  "releaseIdentity": "3.1.0-dev.52",
+  "releaseSetId": "mentra-3.1.0-dev.52",
   "schemaVersion": 1
 }

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-dev.49
+mentraSdkVersion=3.1.0-dev.52

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-dev.49;
+				version = 3.1.0-dev.52;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-dev.49
+    exactVersion: 3.1.0-dev.52
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.49",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.52",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.49", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PDOe10v9Y9R3thudgFu24XqFa+qmxnRHS8VFVfXeWEkuanrBoK3BYgWu+5MlgzgxDJOUb67M1cyssobpk+aGgw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.52", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PzGD568EY9yJuyadELCdijkJ3KewaGRuvgniA/OLMGaeCHNMlY3y5zlszMOLTg1j6SY7z8v5Y59Kpcmhy1Wvsw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.49",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.52",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.49",
-        "@mentra/engine": "3.1.0-dev.49",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.52",
+        "@mentra/engine": "3.1.0-dev.52",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -341,19 +341,23 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.49", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PDOe10v9Y9R3thudgFu24XqFa+qmxnRHS8VFVfXeWEkuanrBoK3BYgWu+5MlgzgxDJOUb67M1cyssobpk+aGgw=="],
+    "@jsamr/counter-style": ["@jsamr/counter-style@2.0.2", "", {}, "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.49", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.49", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-U4+Syk2sZmba7S1J2g8GbLJJqruBqLOAcYhoWolkYlV5Tb36eBLR35n20wNd2gJYQai+ERzQZOUSjnXE5ezX0Q=="],
+    "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.49", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-oODVcaA9znQhr9zl2ESYTbFPKfnwrJeCzDpqCmVRwXFe9rckGLg/hAsEr88lFwdKIClNtBAf31PZmtfV08zFzw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.52", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-PzGD568EY9yJuyadELCdijkJ3KewaGRuvgniA/OLMGaeCHNMlY3y5zlszMOLTg1j6SY7z8v5Y59Kpcmhy1Wvsw=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-dev.49", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.49" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qWF713jwGvmondB4WdiLQEAH4c/7E14v8OkM036a2+Qk+awYF6451f+VMfBpwSLWCuD6jKpnamQlE413/6L1yw=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.52", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.52", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-wtdUoDte0HfTUyTOiDuF6hzW9u/T1ilfyz/xI+PqOmFeV4d2EgS7Xzg/QCUr/TRNTfXFNAymfPr5fmrwvsMCNA=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-dev.49", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.49", "@mentra/cloud-client": "3.1.0-dev.49", "@mentra/cloud-protocol": "3.1.0-dev.49", "@mentra/crust": "3.1.0-dev.49", "@mentra/miniapp": "3.1.0-dev.49", "buffer": "^6.0.3", "events": "^3.3.0", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-6/t5k6yi32T1vBzTgxOWIr+5ykKlYyNGrWsMyHVfnnPk9L9luNyEx5HJhJGMSEM7B7c1NREJOm/N2MhEh0M+kg=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.52", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-tP/q1htYd6OZUZ+0P5424TqYZ5ChpFVc1N8HFhKCZX1tAT/9aVfpatE+EaEplQA4EUyeOlddHLm+RkNba5imjg=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.49", "", {}, "sha512-jFliDTNmcwyMaQHZ1GhOZ/qWDIjstA4hWAA89FfN3f4WZzgtNTmK4T/YlOvqW7ifpJCzGtpWv5ebChl9ByhOCQ=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-dev.52", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.52" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-1wmP4kdpp+FvPpRp2P1CUU7CQSX5zUMib/QKt3Zb3gkmqRd3yI9opVyel1VpBa/4iYkE+XHKoaIs1S2KpXVl5A=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.49", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.49", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Oqo8dyZNe3EqVZYGm14fFPF4Td4Iu9QK4c1uOrTPEVjg8PQjQsc6zlu2G4cT5VPmwli6AxREgH9bam3J4ozurw=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-dev.52", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.52", "@mentra/cloud-client": "3.1.0-dev.52", "@mentra/cloud-protocol": "3.1.0-dev.52", "@mentra/crust": "3.1.0-dev.52", "@mentra/miniapp": "3.1.0-dev.52", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-hpmje8VJRCBo8UGEo+ZqOIEBURW402rj3LnfnDlSr6NwiIjnCbK+MuogytdQErwKaszj6zv9Ear0DmDc5aQ3cg=="],
+
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.52", "", {}, "sha512-c6EXat4az+lEOox9p84ChoNmIIF+XviiOwqyl0+dpvGExPJwFKaDVbH58k1J5wiF/P9SvJKRtpq8wIAvYvkDCw=="],
+
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.52", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.52", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-VphFC47CyWq33369kdMDXRn3dwjA/blWhRi01hw8IvvvVpX4PQ42XngjqVx9wY092Ravp6XXNVDC7KEw6zadHA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 
@@ -783,6 +787,8 @@
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
@@ -806,6 +812,8 @@
     "hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -932,6 +940,8 @@
     "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
+
+    "marked": ["marked@18.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w=="],
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
@@ -1093,6 +1103,8 @@
 
     "react-native-localize": ["react-native-localize@3.7.0", "", { "peerDependencies": { "@expo/config-plugins": "*", "react": "*", "react-native": "*", "react-native-macos": "*" }, "optionalPeers": ["@expo/config-plugins", "react-native-macos"] }, "sha512-6Ohx+zZzycC6zhNVBGM/u1U+O6Ww29YIFseeyXqsKcO/pTfjLcdE40IUJF4SVVwrdh00IMJwy90HjLGUaeqK7Q=="],
 
+    "react-native-marked": ["react-native-marked@8.1.1", "", { "dependencies": { "@jsamr/counter-style": "2.0.2", "@jsamr/react-native-li": "2.3.1", "github-slugger": "2.0.0", "html-entities": "2.6.0", "marked": "18.0.6", "react-native-reanimated-table": "0.0.2", "svg-parser": "2.0.4" }, "peerDependencies": { "react": ">=16.8.6", "react-native": ">=0.76.0", "react-native-svg": ">=12.3.0" } }, "sha512-J1f5oB6oq/REYlOXoYUDWGCS++MFjk2dXfiFS7CxolQW14WiMqM/J5A1GKdCrOiRGayRD41sEs9q/rRtAG0kPQ=="],
+
     "react-native-mmkv": ["react-native-mmkv@4.3.2", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-49OAyfkg0/TMWiWELZN6VuVQPZPhizwL4DTmp8b7B1md3dB/s3LH3mGfC3T+lp9W0y/rqxZMEnotLFTIbOAenQ=="],
 
     "react-native-nitro-bg-timer": ["react-native-nitro-bg-timer@1.0.0", "", { "dependencies": { "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-latn4C6WoFM2Whj/bzq2VsZkvs03VfWKJEKYkzKGpG/91FGyhgKYlpl6yyIO7HjKdsYScBGj0iPsB5DYW8AR7g=="],
@@ -1104,6 +1116,8 @@
     "react-native-quick-base64": ["react-native-quick-base64@3.0.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-EjUP2U7WqKmlMmoY7XGyHomy8bM0q4+yCDCRg4ZezQ6zedYRwc7yVk4V2O/iSftKaLEzhuW98lpyPMdk1iPHXQ=="],
 
     "react-native-reanimated": ["react-native-reanimated@4.2.1", "", { "dependencies": { "react-native-is-edge-to-edge": "1.2.1", "semver": "7.7.3" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-worklets": ">=0.7.0" } }, "sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg=="],
+
+    "react-native-reanimated-table": ["react-native-reanimated-table@0.0.2", "", { "peerDependencies": { "react": ">=16.8.0", "react-native": ">=0.6.0" } }, "sha512-OeuqfU1AFEmHNTJlEOLWrV78JgAXnM0/ZrCm0Ab+9e5nwYJ+xab/UFXkNKz3Gyf08ZfLSNzwMQRjt3eZWPWoGA=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 
@@ -1208,6 +1222,8 @@
     "supports-hyperlinks": ["supports-hyperlinks@2.3.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
     "terminal-link": ["terminal-link@2.1.1", "", { "dependencies": { "ansi-escapes": "^4.2.1", "supports-hyperlinks": "^2.0.0" } }, "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ=="],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.49",
-    "@mentra/engine": "3.1.0-dev.49",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.52",
+    "@mentra/engine": "3.1.0-dev.52",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
Automated dependency synchronization for coordinated release `3.1.0-dev.52`.

Coordinator: https://github.com/Mentra-Community/MentraOS/actions/runs/33133150461
Starter Kit workflow: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33133772143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and lockfile-only changes for examples and release metadata; no application or production runtime logic is modified in this repo.
> 
> **Overview**
> Automated coordinated-release bump aligns sample apps and release metadata with **`3.1.0-dev.52`**.
> 
> **`.github/coordinated-example-release.json`** now records the new coordinator run, source commit, starter-kit head, OTA manifest URL/SHA, and package pins for `@mentra/bluetooth-sdk` and `@mentra/engine`. **Android** (`mentraSdkVersion`), **iOS** (Swift package exact version in `project.yml` / `project.pbxproj`), and **React Native** examples (ElevenLabs audio and main RN example) all move from **`3.1.0-dev.49`** (and prior dev.44 release identity in the manifest) to **`3.1.0-dev.52`**, with matching **`bun.lock`** updates—including transitive packages pulled in by the newer `@mentra/engine` (e.g. markdown rendering deps in the main RN lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741cf031cf1052606f09bc9c69bbcced2c81e7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->