### PR TITLE
ci: raise React Native release build heap

### DIFF
--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -334,7 +334,7 @@ jobs:
       - name: Build release Android app
         working-directory: examples/react-native/android
         run: |
-          ./gradlew :app:assembleRelease --no-daemon
+          ./gradlew :app:assembleRelease --no-daemon -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g"
 
       - name: Verify Android 16 KB page-size support
         run: examples/react-native/scripts/check-android-16kb.sh examples/react-native/android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
The coordinated `3.1.0-dev.52` example validation compiled the React Native project successfully but exhausted the default Gradle Java heap during release D8 dex merging (`java.lang.OutOfMemoryError: Java heap space`). Native Android, native iOS, the ElevenLabs RN release APK, and the coordinated contract all passed.

Give only the main React Native release Gradle invocation a 6 GB heap and 1 GB metaspace cap. This preserves the runner and build matrix while giving the larger application enough memory for release dex merging.

Validation: `actionlint .github/workflows/example-app-builds.yml`; `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Gradle JVM tuning for one workflow step; no application or runtime behavior changes.
> 
> **Overview**
> Fixes CI failures where the **React Native example** release build runs out of memory during D8 dex merging (`Java heap space`).
> 
> The **Build release Android app** step in `example-app-builds.yml` now passes `-Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g"` on `./gradlew :app:assembleRelease`. Only that job’s release assemble is affected; other Gradle steps (e.g. debug Kotlin compile) and the ElevenLabs RN release build keep the default JVM settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81eef171900131f6bc5ad78e7c375ca941dc7043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->