### PR TITLE
chore(release): synchronize examples to 3.1.0-dev.55

### DIFF
--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "dev",
-  "correlationId": "mentraos-33135102532",
-  "expectedStarterKitHead": "02e31cd62147deba0dab73fcb661ae0217e694d4",
+  "correlationId": "mentraos-33135789781",
+  "expectedStarterKitHead": "24b36bab33b65d9d952c4535dc92dee9dd9dc177",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33135102532",
-    "sourceCommit": "532670ade277528e92e87e37476df25d59cff222"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/33135789781",
+    "sourceCommit": "f4c45ebd1c5d9e59609b1a502c8ca8a85657637c"
   },
   "ota": {
-    "manifestSha256": "5b83fc2082916e527e4188252d0e4efed4c5c8f7812dd93dd5f4db9605b64cfa",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.54.json"
+    "manifestSha256": "1c2ca08261b5c2c89deacb9979924b8625a3dfb1ade8a431367b13290cfcf1f2",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-dev.55.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.54",
-    "@mentra/engine": "3.1.0-dev.54"
+    "@mentra/bluetooth-sdk": "3.1.0-dev.55",
+    "@mentra/engine": "3.1.0-dev.55"
   },
-  "releaseIdentity": "3.1.0-dev.54",
-  "releaseSetId": "mentra-3.1.0-dev.54",
+  "releaseIdentity": "3.1.0-dev.55",
+  "releaseSetId": "mentra-3.1.0-dev.55",
   "schemaVersion": 1
 }

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-dev.54
+mentraSdkVersion=3.1.0-dev.55

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-dev.54;
+				version = 3.1.0-dev.55;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-dev.54
+    exactVersion: 3.1.0-dev.55
 
 targets:
   MentraExample:

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.54",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.55",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.54", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-jiS8z7mg4XUC5Tp2akGIUPRNK5zW0FNU7pwr8ApP9pmj305VLDtk8p+NYxSARzkcYFOWBf9CJz1AEjbvFneN4A=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.55", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-UkBp+UMqNfBbs2olU1+D+OjjCBUNKj7gB9krYRU4+I2qh+a6gRHvookjPX9QrRRpvFwKOwYj6xtQUo7IdDvuAw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.54",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.55",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-dev.54",
-        "@mentra/engine": "3.1.0-dev.54",
+        "@mentra/bluetooth-sdk": "3.1.0-dev.55",
+        "@mentra/engine": "3.1.0-dev.55",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -345,19 +345,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.54", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-jiS8z7mg4XUC5Tp2akGIUPRNK5zW0FNU7pwr8ApP9pmj305VLDtk8p+NYxSARzkcYFOWBf9CJz1AEjbvFneN4A=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-dev.55", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-UkBp+UMqNfBbs2olU1+D+OjjCBUNKj7gB9krYRU4+I2qh+a6gRHvookjPX9QrRRpvFwKOwYj6xtQUo7IdDvuAw=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.54", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.54", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-mItN/XDmBqhoyJ+WaVOJyeS1plD3y18J1rfGg+GKjbkU2P4uoGKv/xApvMqQWar24zQCnUkGgWLksl0dSQQgFQ=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-dev.55", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.55", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-LxkYzyBUs1ZjK9qC47C1R39Q9FFlCS+a2lDhKAzs+iMvN0XEVRutq7132OuC+cnp299H4pxR6g+bHRHKyj+wbQ=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.54", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-0eaJA/Ls/aQrl09ackG5ULl4XqdRo7j51pQzsr9WFGBR96PfJBY7NnrcjEiJfnzo7IqKN6diZv0kgM6T4aUcnw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-dev.55", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-zOBgHZ7KsyfOiavei4tCN+YUTS8FaDJ56ZkR5SrquBoAJ8I+ZNtyPvQYdr+KemA6u9vgSgUjxuJSY6j3JZa+lw=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-dev.54", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.54" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-kTllEd5dMsFH1W6HjnlmBJn0SCQGDKABmIOy9dojvmUwWxlGyTG7CGABN14c0IA5aXS6j3BbJUFDCwfXAv5lkQ=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-dev.55", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-dev.55" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-R1WipUOtg7K4b3CuSKzh3XLoeUUyOdhbUurUilP4ositJHncdr2nD4crIzGF6yvUuCBNpH+LC/npuY0wHTnfrQ=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-dev.54", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.54", "@mentra/cloud-client": "3.1.0-dev.54", "@mentra/cloud-protocol": "3.1.0-dev.54", "@mentra/crust": "3.1.0-dev.54", "@mentra/miniapp": "3.1.0-dev.54", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-CV/pU5rUE7Ji78hsjnEy/tpzPM21GBTxqlapflijVkjNEtLJ6RLwemzHl69S8x2o6P16MgIu11R9oi9zxrlMjQ=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-dev.55", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-dev.55", "@mentra/cloud-client": "3.1.0-dev.55", "@mentra/cloud-protocol": "3.1.0-dev.55", "@mentra/crust": "3.1.0-dev.55", "@mentra/miniapp": "3.1.0-dev.55", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "*", "zustand": "*" } }, "sha512-gX0e8nP1uHDoM16Lgfc7k7+Y5Qfzt6ch1MTFgTG2gI742r41/6FKbrhCSaRKP02hg4YNv0+FrtBh8C/ATX2Jzg=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.54", "", {}, "sha512-qMQmKTplIssNruQG+rTilPDJAXGarSJXnAwr0lUmJ6IGyF5tQYnyCOUPaxYX0+sRZhhHvmviWMOLEhHFBiAJfw=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-dev.55", "", {}, "sha512-9xOmvSRHOaCFdfizjrFbxYeZin3J2SsiygqS77g30KNa37W3OJObQ6trrQVRy1vIbqUTjvo8HSRQUFBirHFVbw=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.54", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.54", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-UmRUrfT0GOV1BrgOQmJC2TSrppRctX2ANTT+RuKH3NGgF9ZcNG43QKAEMeXEwdJwcktmfVqUOZqnchMZ1V88+w=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-dev.55", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-dev.55", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-705G29dDatx4bN1yjf10aTNmvtp4tSTlK9kxn4MdFTPO4JW/tHT7FBj2eqYZKodTIK1ZT+pnMxrZhGMIIfbu3g=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-dev.54",
-    "@mentra/engine": "3.1.0-dev.54",
+    "@mentra/bluetooth-sdk": "3.1.0-dev.55",
+    "@mentra/engine": "3.1.0-dev.55",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",


### PR DESCRIPTION
Automated dependency synchronization for coordinated release `3.1.0-dev.55`.

Coordinator: https://github.com/Mentra-Community/MentraOS/actions/runs/33135789781
Starter Kit workflow: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33136449579

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes in example projects and release metadata; no production or SDK source changes in this diff.
> 
> **Overview**
> Bumps the coordinated dev release from **3.1.0-dev.54** to **3.1.0-dev.55** so examples and release metadata stay aligned with the latest MentraOS coordinator run.
> 
> `.github/coordinated-example-release.json` is refreshed with the new `releaseIdentity`, package pins (`@mentra/bluetooth-sdk` / `@mentra/engine`), OTA manifest URL and hash, coordinator run URL, source commit, and starter-kit head. Example apps pick up the same SDK: Android `mentraSdkVersion`, iOS `mentra-bluetooth-sdk-ios` exact version in `project.yml` / `project.pbxproj`, and React Native `package.json` plus `bun.lock` (including transitive `@mentra/*` packages in the main RN example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558c0fcd517bb4a39a10e94a4bd9075427a0d11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->