### PR TITLE
ci: let coordinated release merge its validated PR

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -23,7 +23,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
 permissions:
   actions: read
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   # Dev and beta for one train share a GitHub release container, so serialize
@@ -261,7 +261,7 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for the coordinator to merge the validated pull request
+      - name: Merge the validated pull request
         if: steps.existing.outputs.already_published != 'true'
         id: merge
         env:
@@ -270,18 +270,16 @@ jobs:
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
         run: |
           set -euo pipefail
-          for _ in {1..60}; do
-            pr_json=$(gh pr view "$PR_URL" --json state,headRefOid,mergeCommit)
-            [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
-            state=$(jq -r .state <<< "$pr_json")
-            if [[ "$state" == "MERGED" ]]; then break; fi
-            if [[ "$state" == "CLOSED" ]]; then
-              echo "Coordinator closed $PR_URL without merging it." >&2
-              exit 1
-            fi
-            sleep 10
-          done
-          [[ "$state" == "MERGED" ]]
+          pr_json=$(gh pr view "$PR_URL" --json state,headRefOid,mergeCommit)
+          [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
+          state=$(jq -r .state <<< "$pr_json")
+          if [[ "$state" == "OPEN" ]]; then
+            gh pr merge "$PR_URL" --merge --match-head-commit "$RELEASE_COMMIT"
+          elif [[ "$state" != "MERGED" ]]; then
+            echo "Coordinator PR $PR_URL was closed without merging." >&2
+            exit 1
+          fi
+
           merge_commit=$(gh pr view "$PR_URL" --json mergeCommit --jq .mergeCommit.oid)
           git fetch origin "$TARGET_BRANCH"
           git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$TARGET_BRANCH"


### PR DESCRIPTION
## Why

The coordinated Starter Kit workflow already owns exact-head validation, but it waited for the MentraOS coordinator to poll the same checks and merge the synchronization PR. That duplicated orchestration and forced one cross-repository GitHub App token to remain valid for up to 120 minutes, even though installation tokens expire after one hour.

## Change

- grant the Starter Kit coordinated workflow pull-request write permission;
- after the exact candidate validation run succeeds, merge that same head with --match-head-commit;
- preserve idempotent handling for a PR that was already merged;
- keep tag, result, and artifact publication unchanged.

MentraOS will still create the synchronization PR, then wait for the immutable public result and verify its provenance with a fresh read-only token.

## Verification

- actionlint .github/workflows/coordinated-example-release.yml
- node --test .github/scripts/coordinated-example-release.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The workflow now performs merges on the target branch after validation; incorrect head matching or race conditions could merge the wrong commit or fail releases, though `--match-head-commit` and existing head checks mitigate that.
> 
> **Overview**
> The coordinated example release workflow now **merges the synchronization PR itself** after exact-head validation succeeds, instead of polling until the MentraOS coordinator merges it.
> 
> Workflow permissions change from `pull-requests: read` to **`pull-requests: write`**. The merge step uses `gh pr merge` with `--match-head-commit` when the PR is still open, skips merge when already merged, and fails if the PR was closed without merging. Tag creation, result JSON, and artifact publication are unchanged.
> 
> MentraOS still opens the PR and waits on the immutable public result; this removes duplicate merge orchestration and avoids holding a cross-repo GitHub App token across long poll windows (installation tokens expire after one hour).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9670d24f39b0c1498e6a4a6446937d1606682d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->