### PR TITLE
ci: let coordinated release merge its validated PR

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -23,7 +23,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
 permissions:
   actions: read
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   # Dev and beta for one train share a GitHub release container, so serialize
@@ -261,7 +261,7 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for the coordinator to merge the validated pull request
+      - name: Merge the validated pull request
         if: steps.existing.outputs.already_published != 'true'
         id: merge
         env:
@@ -270,18 +270,16 @@ jobs:
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
         run: |
           set -euo pipefail
-          for _ in {1..60}; do
-            pr_json=$(gh pr view "$PR_URL" --json state,headRefOid,mergeCommit)
-            [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
-            state=$(jq -r .state <<< "$pr_json")
-            if [[ "$state" == "MERGED" ]]; then break; fi
-            if [[ "$state" == "CLOSED" ]]; then
-              echo "Coordinator closed $PR_URL without merging it." >&2
-              exit 1
-            fi
-            sleep 10
-          done
-          [[ "$state" == "MERGED" ]]
+          pr_json=$(gh pr view "$PR_URL" --json state,headRefOid,mergeCommit)
+          [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
+          state=$(jq -r .state <<< "$pr_json")
+          if [[ "$state" == "OPEN" ]]; then
+            gh pr merge "$PR_URL" --merge --match-head-commit "$RELEASE_COMMIT"
+          elif [[ "$state" != "MERGED" ]]; then
+            echo "Coordinator PR $PR_URL was closed without merging." >&2
+            exit 1
+          fi
+
           merge_commit=$(gh pr view "$PR_URL" --json mergeCommit --jq .mergeCommit.oid)
           git fetch origin "$TARGET_BRANCH"
           git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$TARGET_BRANCH"


### PR DESCRIPTION
## Why

Repository-dispatch workflows run from the default branch. The coordinated workflow already owns exact-head validation, but it waited for MentraOS to poll the same checks and merge the PR. That duplicated orchestration and made a one-hour GitHub App token cover a workflow that permits longer waits.

## Change

- let the Starter Kit workflow merge its own exact validated synchronization PR;
- keep exact-head compare-and-swap protection;
- preserve idempotent handling when the PR was already merged;
- leave tag, result, and artifact publication unchanged.

The same change is proposed for the dev branch in #64 so generated candidates retain the controller contract in source.

## Verification

- actionlint .github/workflows/coordinated-example-release.yml
- node --test .github/scripts/coordinated-example-release.test.mjs
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The workflow now performs merges on the Starter Kit repo with exact-head CAS; mis-validation or token misuse could merge the wrong commit, though checks and `--match-head-commit` limit that risk.
> 
> **Overview**
> The coordinated example release workflow **merges its own validated sync PR** instead of polling until MentraOS merges it, so orchestration stays in one place and the job does not need to hold a token for long idle waits.
> 
> Workflow permissions change from **`pull-requests: read` to `pull-requests: write`**. The post-validation step is renamed and replaces a ~10-minute poll loop with a single check: confirm the PR head is **`RELEASE_COMMIT`**, **`gh pr merge --merge --match-head-commit`** when the PR is still open, or no-op when already merged; closed-without-merge still fails. Tag, artifact, and result publication steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83baf9ab067562d8813a861d7de3595137ded0f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->