### PR TITLE
ci: let Starter Kit open release PRs

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,7 +21,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -204,37 +204,41 @@ jobs:
 
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for the coordinator synchronization pull request
+      - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
         id: pull-request
         env:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
           MENTRAOS_RUN_URL: ${{ fromJSON(env.COORDINATED_PAYLOAD).mentraos.coordinatorRunUrl }}
         run: |
           set -euo pipefail
-          pr_url=""
-          for _ in {1..60}; do
-            pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
-              --limit 1 --json number,url,state,mergedAt)
-            if [[ "$(jq 'length' <<<"$pr_json")" != "0" ]]; then
-              pr_url=$(jq -r '.[0].url' <<<"$pr_json")
-              state=$(jq -r '.[0].state' <<<"$pr_json")
-              merged_at=$(jq -r '.[0].mergedAt // empty' <<<"$pr_json")
-              if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
-                echo "Coordinator PR $pr_url was closed without merging." >&2
-                exit 1
-              fi
-              break
-            fi
-            sleep 10
-          done
+          pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
+            --limit 1 --json url,state,mergedAt,headRefOid)
+          pr_url=$(jq -r '.[0].url // empty' <<< "$pr_json")
           if [[ -z "$pr_url" ]]; then
-            echo "MentraOS did not create the synchronization PR for $RELEASE_IDENTITY." >&2
-            echo "Coordinator: $MENTRAOS_RUN_URL" >&2
+            pr_body=$(printf '%s\n\n%s\n%s\n' \
+              "Automated dependency synchronization for coordinated release \`$RELEASE_IDENTITY\`." \
+              "Coordinator: $MENTRAOS_RUN_URL" \
+              "Starter Kit workflow: https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$GITHUB_RUN_ID")
+            pr_url=$(gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$CANDIDATE_BRANCH" \
+              --title "chore(release): synchronize examples to $RELEASE_IDENTITY" \
+              --body "$pr_body")
+            pr_json=$(gh pr view "$pr_url" --json url,state,mergedAt,headRefOid)
+          else
+            pr_json=$(jq '.[0]' <<< "$pr_json")
+          fi
+          state=$(jq -r .state <<< "$pr_json")
+          merged_at=$(jq -r '.mergedAt // empty' <<< "$pr_json")
+          if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+            echo "Synchronization PR $pr_url was closed without merging." >&2
             exit 1
           fi
+          [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Wait for pull request validation of the candidate commit

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -250,10 +250,19 @@ jobs:
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
         run: |
           set -euo pipefail
-          run_id=""
+          run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
+            --limit 20 --json databaseId,headSha \
+            --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
+            | head -1)
+          if [[ -z "$run_id" ]]; then
+            gh workflow run example-app-builds.yml \
+              --ref "$CANDIDATE_BRANCH" \
+              -f artifact_suffix="$RELEASE_IDENTITY"
+          fi
           for _ in {1..60}; do
+            [[ -n "$run_id" ]] && break
             run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
-              --event pull_request --limit 20 \
+              --limit 20 \
               --json databaseId,headSha \
               --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
               | head -1)


### PR DESCRIPTION
## What changed

- create or reuse the coordinated synchronization PR inside the Starter Kit controller
- verify the PR still points to the exact candidate commit before validation
- retain repository-local required-check waiting, exact-head merge, tagging, and publication

## Why

The Starter controller already owns candidate creation, validation, merge, and publication. Asking MentraOS to create one PR in the middle added a brittle cross-repository write/read boundary and duplicated reconciliation logic. Keeping the entire PR lifecycle in this repository removes that boundary and reduces the MentraOS coordinator to dispatch plus immutable-result verification.

## Validation

- `actionlint .github/workflows/coordinated-example-release.yml`
- `bun test --cwd .github/scripts coordinated-example-release.test.mjs` (6 pass)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation around PR creation, commit pinning, and CI dispatch; mistakes could block or mis-merge coordinated releases, but scope stays within the existing coordinated-example-release workflow.
> 
> **Overview**
> Moves the coordinated example **synchronization PR** lifecycle into the Starter Kit workflow instead of polling MentraOS to open it.
> 
> The workflow now **creates or reuses** a PR from the candidate branch (`gh pr create` with release/coordinator links in the body), fails if an existing PR was closed without merge, and **asserts the PR head matches** the candidate `release_commit` before validation. Workflow **`actions`** permission is bumped to **`write`** so the job can **`workflow_dispatch`** `example-app-builds.yml` when no run exists for that SHA (listing runs no longer filters to `pull_request` events only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eca634c9a4016c688f3f5400b290fa52a2f1b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->