### PR TITLE
ci: let Starter Kit open release PRs

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,7 +21,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -204,37 +204,41 @@ jobs:
 
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for the coordinator synchronization pull request
+      - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
         id: pull-request
         env:
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
+          RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
           MENTRAOS_RUN_URL: ${{ fromJSON(env.COORDINATED_PAYLOAD).mentraos.coordinatorRunUrl }}
         run: |
           set -euo pipefail
-          pr_url=""
-          for _ in {1..60}; do
-            pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
-              --limit 1 --json number,url,state,mergedAt)
-            if [[ "$(jq 'length' <<<"$pr_json")" != "0" ]]; then
-              pr_url=$(jq -r '.[0].url' <<<"$pr_json")
-              state=$(jq -r '.[0].state' <<<"$pr_json")
-              merged_at=$(jq -r '.[0].mergedAt // empty' <<<"$pr_json")
-              if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
-                echo "Coordinator PR $pr_url was closed without merging." >&2
-                exit 1
-              fi
-              break
-            fi
-            sleep 10
-          done
+          pr_json=$(gh pr list --state all --base "$TARGET_BRANCH" --head "$CANDIDATE_BRANCH" \
+            --limit 1 --json url,state,mergedAt,headRefOid)
+          pr_url=$(jq -r '.[0].url // empty' <<< "$pr_json")
           if [[ -z "$pr_url" ]]; then
-            echo "MentraOS did not create the synchronization PR for $RELEASE_IDENTITY." >&2
-            echo "Coordinator: $MENTRAOS_RUN_URL" >&2
+            pr_body=$(printf '%s\n\n%s\n%s\n' \
+              "Automated dependency synchronization for coordinated release \`$RELEASE_IDENTITY\`." \
+              "Coordinator: $MENTRAOS_RUN_URL" \
+              "Starter Kit workflow: https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$GITHUB_RUN_ID")
+            pr_url=$(gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$CANDIDATE_BRANCH" \
+              --title "chore(release): synchronize examples to $RELEASE_IDENTITY" \
+              --body "$pr_body")
+            pr_json=$(gh pr view "$pr_url" --json url,state,mergedAt,headRefOid)
+          else
+            pr_json=$(jq '.[0]' <<< "$pr_json")
+          fi
+          state=$(jq -r .state <<< "$pr_json")
+          merged_at=$(jq -r '.mergedAt // empty' <<< "$pr_json")
+          if [[ "$state" == "CLOSED" && -z "$merged_at" ]]; then
+            echo "Synchronization PR $pr_url was closed without merging." >&2
             exit 1
           fi
+          [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Wait for pull request validation of the candidate commit

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -250,10 +250,19 @@ jobs:
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
         run: |
           set -euo pipefail
-          run_id=""
+          run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
+            --limit 20 --json databaseId,headSha \
+            --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
+            | head -1)
+          if [[ -z "$run_id" ]]; then
+            gh workflow run example-app-builds.yml \
+              --ref "$CANDIDATE_BRANCH" \
+              -f artifact_suffix="$RELEASE_IDENTITY"
+          fi
           for _ in {1..60}; do
+            [[ -n "$run_id" ]] && break
             run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \
-              --event pull_request --limit 20 \
+              --limit 20 \
               --json databaseId,headSha \
               --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
               | head -1)


### PR DESCRIPTION
Keeps the `dev` channel source aligned with the default-branch coordinated controller in #72.

The Starter Kit now owns candidate creation, synchronization PR creation, validation, exact-head merge, and immutable publication with its repository-local token. MentraOS only dispatches and verifies the result.

Validation:
- `actionlint .github/workflows/coordinated-example-release.yml`
- `bun test --cwd .github/scripts coordinated-example-release.test.mjs` (6 pass)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation (PR creation, merge gates, and CI triggering); mistakes could block or mis-merge coordinated releases, but scope is confined to this workflow and uses existing commit/head checks.
> 
> **Overview**
> Moves coordinated example release orchestration into the Starter Kit workflow instead of waiting on MentraOS to open PRs or start CI.
> 
> **Workflow permissions** now include `actions: write` so the job can dispatch `example-app-builds.yml`.
> 
> The sync step **creates the synchronization PR** with `gh pr create` when none exists (reusing an existing PR otherwise), checks it wasn’t closed unmerged, and **requires the PR head to match** the candidate `release_commit`. The old poll loop for an external coordinator PR is removed.
> 
> **Validation** no longer assumes a `pull_request`-event run: it looks for an `example-app-builds` run on the candidate SHA, **manually triggers** the workflow with `artifact_suffix` if missing, then polls and watches that run to completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc17ea2f284d7dd953f5a9fe04b989fc1eb162c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->