### PR TITLE
ci: use coordinator app for release PRs

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -204,10 +204,23 @@ jobs:
 
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
 
+      - name: Create pull request token
+        if: steps.existing.outputs.already_published != 'true'
+        id: pull-request-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: read
+          permission-pull-requests: write
+
       - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
         id: pull-request
         env:
+          GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
@@ -274,10 +287,23 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 
+      - name: Create pull request merge token
+        if: steps.existing.outputs.already_published != 'true'
+        id: pull-request-merge-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Merge the validated pull request
         if: steps.existing.outputs.already_published != 'true'
         id: merge
         env:
+          GH_TOKEN: ${{ steps.pull-request-merge-token.outputs.token }}
           PR_URL: ${{ steps.pull-request.outputs.url }}
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}


### PR DESCRIPTION
Use narrowly scoped, freshly minted release-coordinator App tokens to create and merge automated coordinated-release PRs. The repository GITHUB_TOKEN continues to own candidate pushes and validation dispatches, while the App token bypasses the organization-level restriction on Actions-created pull requests without remaining live across the validation wait.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI authentication for automated PR create/merge; release logic is unchanged and merge credentials are scoped and ephemeral.
> 
> **Overview**
> The coordinated example release workflow now mints **short-lived GitHub App tokens** from the starter-kit coordinator app instead of relying on the job’s default `GITHUB_TOKEN` when it **opens or merges** the synchronization PR.
> 
> A **PR-create** step grants `pull-requests: write` and `contents: read` on `Mentra-Bluetooth-SDK-Starter-Kit` and feeds that token into the existing “create or reuse pull request” `gh` commands. A separate **merge** step mints a token with `contents: write` and `pull-requests: write` only for the merge step, so elevated permissions are not held across the validation wait.
> 
> **Candidate branch pushes**, validation dispatch/watch, tagging, and release uploads continue to use `github.token` via the workflow’s global `GH_TOKEN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9bd35efd19e5eabb0305ff497a60542e9c807f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->