### PR TITLE
ci: use coordinator app for release PRs

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -204,10 +204,23 @@ jobs:
 
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
 
+      - name: Create pull request token
+        if: steps.existing.outputs.already_published != 'true'
+        id: pull-request-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: read
+          permission-pull-requests: write
+
       - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
         id: pull-request
         env:
+          GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
           RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
@@ -274,10 +287,23 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 
+      - name: Create pull request merge token
+        if: steps.existing.outputs.already_published != 'true'
+        id: pull-request-merge-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.STARTER_KIT_COORDINATOR_APP_ID }}
+          private-key: ${{ secrets.STARTER_KIT_COORDINATOR_APP_PRIVATE_KEY }}
+          owner: Mentra-Community
+          repositories: Mentra-Bluetooth-SDK-Starter-Kit
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Merge the validated pull request
         if: steps.existing.outputs.already_published != 'true'
         id: merge
         env:
+          GH_TOKEN: ${{ steps.pull-request-merge-token.outputs.token }}
           PR_URL: ${{ steps.pull-request.outputs.url }}
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
           TARGET_BRANCH: ${{ steps.release.outputs.targetBranch }}


### PR DESCRIPTION
Mirror the coordinated-release GitHub App token boundary onto dev. Fresh scoped tokens create and merge the automated synchronization PR; the ordinary workflow token still owns candidate pushes and validation dispatches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can create and merge release PRs and tightens token scope; misconfigured app permissions or secrets could break the release path without affecting unrelated steps.
> 
> **Overview**
> The coordinated example release workflow now uses **scoped GitHub App tokens** for automated synchronization PRs instead of the default `GITHUB_TOKEN` for those steps.
> 
> Before create/reuse PR, a **pull-request token** is minted (`permission-contents: read`, `permission-pull-requests: write`) and passed as `GH_TOKEN` for that step. Before merge, a separate **merge token** is minted with **`permission-contents: write`** so `gh pr merge` can land the validated candidate. Candidate branch pushes, validation dispatch, tagging, and release publishing still rely on the workflow’s ordinary token (`env.GH_TOKEN: ${{ github.token }}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d5cb869634761c9a223ecde5eb306a72b445c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->