### PR TITLE
ci: avoid duplicate coordinated example builds

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,7 +21,6 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -258,7 +257,6 @@ jobs:
         if: steps.existing.outputs.already_published != 'true'
         id: validation
         env:
-          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
         run: |
@@ -267,11 +265,6 @@ jobs:
             --limit 20 --json databaseId,headSha \
             --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
             | head -1)
-          if [[ -z "$run_id" ]]; then
-            gh workflow run example-app-builds.yml \
-              --ref "$CANDIDATE_BRANCH" \
-              -f artifact_suffix="$RELEASE_IDENTITY"
-          fi
           for _ in {1..60}; do
             [[ -n "$run_id" ]] && break
             run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \


### PR DESCRIPTION
The release-coordinator App-created synchronization PR reliably emits the ordinary pull_request build. Wait for that exact candidate SHA instead of also dispatching the same workflow manually, and drop the now-unused actions: write permission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that reduces duplicate builds and tightens permissions; release still fails if the PR-triggered build never appears for the candidate SHA.
> 
> **Overview**
> The coordinated example release workflow no longer **manually dispatches** `example-app-builds.yml` when it cannot find a run for the candidate commit. The validation step only **polls** for an existing workflow run whose `headSha` matches the release commit—relying on the synchronization PR’s normal **`pull_request`** build instead of starting a second run.
> 
> Workflow **`permissions`** drop **`actions: write`**, since triggering workflows via the API is no longer needed. The validation step env also omits the unused **`RELEASE_IDENTITY`** variable that only fed the removed dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4982ebfc37abcb95a83a6868e14ad0b05775e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->