### PR TITLE
ci: avoid duplicate coordinated example builds

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,7 +21,6 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -258,7 +257,6 @@ jobs:
         if: steps.existing.outputs.already_published != 'true'
         id: validation
         env:
-          RELEASE_IDENTITY: ${{ steps.release.outputs.releaseIdentity }}
           CANDIDATE_BRANCH: ${{ steps.release.outputs.candidateBranch }}
           RELEASE_COMMIT: ${{ steps.candidate.outputs.release_commit }}
         run: |
@@ -267,11 +265,6 @@ jobs:
             --limit 20 --json databaseId,headSha \
             --jq ".[] | select(.headSha == \"$RELEASE_COMMIT\") | .databaseId" \
             | head -1)
-          if [[ -z "$run_id" ]]; then
-            gh workflow run example-app-builds.yml \
-              --ref "$CANDIDATE_BRANCH" \
-              -f artifact_suffix="$RELEASE_IDENTITY"
-          fi
           for _ in {1..60}; do
             [[ -n "$run_id" ]] && break
             run_id=$(gh run list --workflow example-app-builds.yml --branch "$CANDIDATE_BRANCH" \


### PR DESCRIPTION
Mirror the single-trigger coordinated validation path onto dev: the App-created release PR triggers the exact-head example build, with no duplicate workflow_dispatch run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that reduces duplicate builds; failure mode is a longer wait if the PR-triggered build never starts.
> 
> **Overview**
> **Coordinated example release** no longer kicks off a second `example-app-builds` run when validation hasn’t started yet. The workflow only **waits** (polls) for an existing run whose `headSha` matches the release commit—typically the one already started by the sync PR—instead of calling `gh workflow run example-app-builds.yml` with `artifact_suffix`.
> 
> The workflow **`actions: write`** permission was dropped because manual workflow dispatch is no longer used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d26244a8f3bb0d87ed07adca367ea0c46e7ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->