### PR TITLE
ci: fix coordinated release token scopes

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,6 +21,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
@@ -214,6 +215,7 @@ jobs:
           repositories: Mentra-Bluetooth-SDK-Starter-Kit
           permission-contents: read
           permission-pull-requests: write
+          skip-token-revoke: true
 
       - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
@@ -252,6 +254,12 @@ jobs:
           fi
           [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Revoke pull request token
+        if: always() && steps.existing.outputs.already_published != 'true' && steps.pull-request-token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
+        run: gh api --method DELETE /installation/token
 
       - name: Wait for pull request validation of the candidate commit
         if: steps.existing.outputs.already_published != 'true'


### PR DESCRIPTION
Restore the Actions read scope required to find, watch, and download the exact validation run. Mark the short-lived PR-creation App token for explicit lifecycle management and revoke it immediately after PR reconciliation, before the long validation wait.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow permission and token hygiene changes; no application runtime or release artifact logic is modified.
> 
> **Overview**
> Fixes **GitHub Actions permissions and App token lifecycle** in the coordinated example release workflow so validation can run reliably and PR-scoped credentials are not held through the long build wait.
> 
> Workflow-level permissions now include **`actions: read`**, restoring the scope needed for `gh run list` / `gh run watch` on `example-app-builds.yml` when locating and monitoring the candidate commit’s validation run.
> 
> The Starter Kit coordinator **PR-creation App token** is created with **`skip-token-revoke: true`**, then a dedicated **`Revoke pull request token`** step (runs `always()` after PR create/reconcile) explicitly deletes the installation token **before** the validation wait. Merge still uses a separate merge token with contents write as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0533149a6872f745fc35809daf30696c476d77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->