### PR TITLE
ci: fix coordinated release token scopes

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -21,6 +21,7 @@ run-name: Coordinated example ${{ inputs.channel || github.event.client_payload.
         type: string
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
@@ -214,6 +215,7 @@ jobs:
           repositories: Mentra-Bluetooth-SDK-Starter-Kit
           permission-contents: read
           permission-pull-requests: write
+          skip-token-revoke: true
 
       - name: Create or reuse the synchronization pull request
         if: steps.existing.outputs.already_published != 'true'
@@ -252,6 +254,12 @@ jobs:
           fi
           [[ "$(jq -r .headRefOid <<< "$pr_json")" == "$RELEASE_COMMIT" ]]
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Revoke pull request token
+        if: always() && steps.existing.outputs.already_published != 'true' && steps.pull-request-token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
+        run: gh api --method DELETE /installation/token
 
       - name: Wait for pull request validation of the candidate commit
         if: steps.existing.outputs.already_published != 'true'


### PR DESCRIPTION
Mirror the corrected Actions read scope and immediate PR-creation token revocation onto dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission and token-lifecycle changes with no application or data-path impact.
> 
> **Overview**
> Updates the **Coordinated Example Release** workflow so it can read Actions data and tightens how the GitHub App token used for sync PRs is revoked.
> 
> The workflow’s default **`permissions`** now include **`actions: read`**, which aligns with later steps that list and watch **`example-app-builds.yml`** runs on the candidate branch.
> 
> For the **pull request creation** app token, **`skip-token-revoke: true`** is set on **`actions/create-github-app-token`**, and a new **Revoke pull request token** step runs **`always()`** right after PR create/reuse (via **`DELETE /installation/token`**) so the narrow-scoped token is dropped before validation and merge steps that use other credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fab2877e68510e2e1d45d19bf3aea2f24c79c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->