### PR TITLE
fix(react-native): set the required iOS deployment target

### DIFF
--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -52,6 +52,9 @@
       [
         "expo-build-properties",
         {
+          "ios": {
+            "deploymentTarget": "15.5"
+          },
           "android": {
             "minSdkVersion": 33,
             "usesCleartextTraffic": true,


### PR DESCRIPTION
Set the React Native example deployment target to iOS 15.5, matching the minimum required by the pinned react-native-zip-archive pod so Expo prebuild can complete CocoaPods installation and produce an Xcode workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app Expo config only; no runtime or production app logic changes.
> 
> **Overview**
> Sets **`ios.deploymentTarget` to `15.5`** on the React Native example’s `expo-build-properties` plugin so prebuild/Xcode align with the minimum iOS version required by native dependencies (e.g. **`react-native-zip-archive`**), allowing CocoaPods install and workspace generation to succeed.
> 
> Android and other `expo-build-properties` settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af4e1086dac41cda1b3c8739dbe981644bc56e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->