### PR TITLE
fix(react-native): set the required iOS deployment target

### DIFF
--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -52,6 +52,9 @@
       [
         "expo-build-properties",
         {
+          "ios": {
+            "deploymentTarget": "15.5"
+          },
           "android": {
             "minSdkVersion": 33,
             "usesCleartextTraffic": true,


### PR DESCRIPTION
Mirror the iOS 15.5 React Native example deployment target onto dev so coordinated TestFlight builds can install RNZipArchive through CocoaPods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app Expo config only; no runtime, auth, or library API changes.
> 
> **Overview**
> Sets the React Native **Expo example**’s iOS minimum via `expo-build-properties`, adding **`ios.deploymentTarget`: `"15.5"`** in `examples/react-native/app.json` alongside the existing Android build settings.
> 
> This aligns the example app with the iOS 15.5 target needed for coordinated TestFlight builds and **RNZipArchive** installation through CocoaPods on the dev branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2c2b7484ff4d13c6de390082810f4990999c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->