### PR TITLE
Retry coordinated lockfile regeneration after npm publish

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -177,14 +177,21 @@ jobs:
             node .github/scripts/coordinated-example-release.mjs sync \
               --root . \
               --identity "$RELEASE_IDENTITY"
-            (
-              cd examples/react-native
-              bun install --lockfile-only
-            )
-            (
-              cd examples/react-native-elevenlabs-audio
-              bun install --lockfile-only
-            )
+            update_lockfile() {
+              local directory="$1"
+              for attempt in {1..12}; do
+                if (cd "$directory" && bun install --lockfile-only); then
+                  return 0
+                fi
+                if (( attempt == 12 )); then
+                  return 1
+                fi
+                echo "Package metadata has not propagated to Bun yet; retrying $directory ($attempt/12)."
+                sleep 10
+              done
+            }
+            update_lockfile examples/react-native
+            update_lockfile examples/react-native-elevenlabs-audio
             cp "$canonical_payload" .github/coordinated-example-release.json
             git config user.name "mentra-release-bot"
             git config user.email "actions@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- retry the actual Bun lockfile update after coordinated npm metadata appears
- cover the short registry propagation window observed for `@mentra/engine@3.1.0-dev.78`

## Why
The coordinated input check successfully found both exact npm versions, but Bun failed one second later because the Engine version had not propagated to the endpoint Bun resolved. Retrying the consumer operation keeps Starter Kit independent of MentraOS app publication while making the exact package dependency reliable.

## Validation
- `actionlint .github/workflows/coordinated-example-release.yml`
- `node --test .github/scripts/coordinated-example-release.test.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation only; adds retries around lockfile generation with no auth, data, or runtime product behavior changes.
> 
> **Overview**
> When creating a coordinated example release candidate, **lockfile regeneration for the React Native examples no longer runs `bun install --lockfile-only` once**. It now goes through a shared `update_lockfile` helper that retries up to **12 times** with **10s** pauses when Bun cannot resolve freshly published `@mentra/*` versions yet.
> 
> This targets the gap where the workflow’s npm input checks pass but Bun fails moments later because registry metadata has not reached Bun’s resolver—so candidate commits with updated `bun.lock` files are less likely to fail for transient propagation delays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c5bf89eff9d1ca78cd77b67f2d8c7449cf0a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->