### PR TITLE
Declare photo library usage for the React Native example

### DIFF
--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -21,7 +21,8 @@
         "NSBluetoothPeripheralUsageDescription": "This example app uses Bluetooth to connect to smart glasses.",
         "NSCameraUsageDescription": "This example app can trigger camera capture on connected smart glasses.",
         "NSLocalNetworkUsageDescription": "This example app can talk to local media upload and streaming preview servers.",
-        "NSMicrophoneUsageDescription": "This example app can stream microphone audio from connected smart glasses."
+        "NSMicrophoneUsageDescription": "This example app can stream microphone audio from connected smart glasses.",
+        "NSPhotoLibraryUsageDescription": "This example app can save photos from connected smart glasses to your photo library."
       }
     },
     "android": {


### PR DESCRIPTION
## Summary
- add the required iOS photo-library purpose string to the React Native example Expo config
- allow App Store Connect to process coordinated example TestFlight uploads

Apple accepted the `3.1.0-dev.80` upload but rejected processing with `90683` because `MentraSDKRN.app` lacked `NSPhotoLibraryUsageDescription`.

## Validation
- resolved Expo config contains the exact key and purpose string
- `jq` validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app Expo config only; no runtime or production SDK behavior changes.
> 
> **Overview**
> Adds **`NSPhotoLibraryUsageDescription`** to the React Native example’s Expo **`ios.infoPlist`** so the built **`MentraSDKRN.app`** declares why it may access the photo library (saving photos from connected smart glasses).
> 
> This addresses App Store Connect processing error **90683**, which blocked TestFlight handling of a prior upload that referenced photo-library access without the required purpose string. The change also fixes JSON formatting by adding a trailing comma on the existing microphone usage entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef5982abad774c85484b3705ce8049bb0cb5ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->