### PR TITLE
Align OTA example restart presentation

### DIFF
--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -218,6 +218,25 @@ describe('custom OTA presentation', () => {
     expect(presentation.changelogs).toBeUndefined();
   });
 
+  test('matches the Mentra App reboot copy and exposes no completion action', () => {
+    const presentation = otaPresentation(otaState({
+      canFinish: false,
+      connected: false,
+      continueDisabled: false,
+      screen: 'restarting',
+    }));
+
+    expect(presentation).toMatchObject({
+      detail: "We'll continue automatically when they're ready.",
+      indeterminate: true,
+      message: 'The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.',
+      title: 'Restarting Mentra Live…',
+      tone: 'active',
+    });
+    expect(presentation.primary).toBeUndefined();
+    expect(presentation.secondary).toBeUndefined();
+  });
+
   test('blocks installation until the glasses battery reaches the OTA minimum', () => {
     const presentation = otaPresentation(otaState({
       batteryLevel: 18,

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -212,13 +212,11 @@ export function otaPresentation(
       };
     case 'restarting':
       return {
-        primary: {
-          action: 'finish',
-          disabled: state.continueDisabled,
-          label: 'Continue',
-        },
-        title: 'Update Installed',
-        tone: 'success',
+        detail: "We'll continue automatically when they're ready.",
+        indeterminate: true,
+        message: 'The update is installed. Keep your glasses nearby and leave this screen open while they finish starting.',
+        title: `Restarting ${deviceName}…`,
+        tone: 'active',
       };
     case 'verifying':
       return {


### PR DESCRIPTION
## Summary
- mirror the Mentra App restart copy in the custom React Native OTA example
- render restarting as active work with a spinner
- remove the premature finish action while retaining example-specific styling

## Tests
- `bun test src/ota/otaPresentation.test.ts` (19 passed)
- `bun x tsc --noEmit`
- `git diff --check`

## Dependency
The engine owns restart protection and ready-state gating in [MentraOS #3868](https://github.com/Mentra-Community/MentraOS/pull/3868). This example consumes that behavior through the next coordinated `@mentra/engine` release; this PR keeps the app-owned presentation aligned while retaining its custom styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app presentation and test-only changes; removing the early finish button aligns with engine-owned restart gating and reduces mistaken user dismissal.
> 
> **Overview**
> Updates the React Native OTA **example** so the `restarting` screen matches Mentra App reboot messaging instead of treating restart as a finished update.
> 
> The `restarting` branch in `otaPresentation` no longer shows a **Continue** / `finish` primary action or success styling. It now uses an **active** tone with indeterminate progress, copy that the update is installed and the user should keep glasses nearby and leave the screen open, plus detail that the flow will continue automatically when the device is ready. The title becomes **`Restarting ${deviceName}…`** (e.g. “Restarting Mentra Live…”).
> 
> A unit test asserts this copy and that neither primary nor secondary actions are exposed during restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede4a74de7c4e570f9d19a6244f7a6604c598489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->