### PR TITLE
docs: avoid stale example SDK versions

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -14,11 +14,8 @@ This example installs the SDK as `com.mentraglass:bluetooth-sdk` and is intended
 
 ## SDK Version
 
-The example reads the SDK version from `gradle.properties`:
-
-```properties
-mentraSdkVersion=3.1.0-dev.9
-```
+The example reads its exact SDK version from `mentraSdkVersion` in
+[`gradle.properties`](./gradle.properties).
 
 Use the latest SDK version published by Mentra. If a future release note lists an additional Maven repository, add it to `settings.gradle.kts` beside `google()` and `mavenCentral()`.
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -13,7 +13,8 @@ This example installs the SDK as the `MentraBluetoothSDK` Swift package. No path
 
 ## SDK Version
 
-The Xcode project pins the public Swift package to `3.1.0-dev.9`:
+The Xcode project pins an exact version of the public Swift package configured
+in [`project.yml`](./project.yml):
 
 ```text
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -21,12 +21,8 @@ cd examples/react-native
 bun install
 ```
 
-The example depends on the SDK version pinned in `package.json`, for example:
-
-```json
-"@mentra/bluetooth-sdk": "3.1.0-dev.27",
-"@mentra/engine": "3.1.0-dev.27"
-```
+The example depends on the exact SDK and Engine versions pinned in
+[`package.json`](./package.json). Those two package versions must match.
 
 Use compatible SDK and Engine versions published by Mentra. When validating
 unreleased SDK changes, use the local source override below so JavaScript,


### PR DESCRIPTION
## Summary

Remove hard-coded old dev package versions from the Android, iOS, and React Native example READMEs. Each README now points to the checked-in dependency file that the coordinated release synchronizer already keeps exact.

This avoids a second, drifting source of version truth without adding README rewriting to the release pipeline.

## Verification

- `git diff --check`
- Confirmed `gradle.properties`, `project.yml`, and `package.json` on `dev` carry the coordinated identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or dependency resolution impact.
> 
> **Overview**
> **Removes duplicate SDK version strings** from the Android, iOS, and React Native example READMEs so docs no longer drift from the real pins.
> 
> Each **SDK Version** / **Install** section now links to the single source of truth: `mentraSdkVersion` in [`gradle.properties`](./gradle.properties), the Swift package pin in [`project.yml`](./project.yml), and matching `@mentra/bluetooth-sdk` / `@mentra/engine` entries in [`package.json`](./package.json). The React Native README also states that those two package versions must stay aligned. Inline examples that showed old dev versions (e.g. `3.1.0-dev.9`, `3.1.0-dev.27`) are dropped in favor of “read the checked-in file.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec7b2655ec193e97e7b9ef990666c0f28e067c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->