### PR TITLE
fix(ota): keep release notes scrollable on small windows

### DIFF
--- a/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
+++ b/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -122,21 +122,17 @@ export function CustomMentraLiveOtaFlow({
     <SafeAreaView style={styles.safeArea}>
       <Header title="Software Update" />
       <View style={styles.page} testID="custom-mentra-live-ota-flow">
-        {hasChangelogs ? (
-          <View
-            style={[styles.contentScroll, styles.centerContent, styles.topContent]}
-          >
-            {content}
-          </View>
-        ) : (
-          <ScrollView
-            contentContainerStyle={styles.centerContent}
-            showsVerticalScrollIndicator={false}
-            style={styles.contentScroll}
-          >
-            {content}
-          </ScrollView>
-        )}
+        <ScrollView
+          contentContainerStyle={[
+            styles.centerContent,
+            hasChangelogs && styles.topContent,
+          ]}
+          nestedScrollEnabled
+          style={styles.contentScroll}
+          testID="custom-ota-page-scroll"
+        >
+          {content}
+        </ScrollView>
 
         {presentation.primary || presentation.secondary ? (
           <View style={styles.actions}>
@@ -287,14 +283,7 @@ function ChangelogMarkdown({ markdown }: { markdown: string }) {
 }
 
 function ChangelogList({ changelogs }: { changelogs?: CustomOtaChangelog[] }) {
-  const [contentHeight, setContentHeight] = useState(0);
-  const [viewportHeight, setViewportHeight] = useState(0);
-  const [isAtEnd, setIsAtEnd] = useState(false);
-
   if (!changelogs?.length) return null;
-
-  const showScrollHint =
-    viewportHeight > 0 && contentHeight > viewportHeight + 1 && !isAtEnd;
 
   return (
     <View style={styles.changelogCard} testID="custom-ota-changelog-card">
@@ -302,21 +291,7 @@ function ChangelogList({ changelogs }: { changelogs?: CustomOtaChangelog[] }) {
       <ScrollView
         contentContainerStyle={styles.changelogContent}
         nestedScrollEnabled
-        onContentSizeChange={(_width, height) => {
-          setContentHeight(height);
-          setIsAtEnd(false);
-        }}
-        onLayout={({ nativeEvent }) =>
-          setViewportHeight(nativeEvent.layout.height)
-        }
-        onScroll={({ nativeEvent }) => {
-          const distanceFromEnd =
-            nativeEvent.contentSize.height -
-            (nativeEvent.contentOffset.y +
-              nativeEvent.layoutMeasurement.height);
-          setIsAtEnd(distanceFromEnd <= 8);
-        }}
-        scrollEventThrottle={16}
+        persistentScrollbar
         showsVerticalScrollIndicator
         style={styles.changelogList}
         testID="custom-ota-changelog-scroll"
@@ -336,16 +311,6 @@ function ChangelogList({ changelogs }: { changelogs?: CustomOtaChangelog[] }) {
           </View>
         ))}
       </ScrollView>
-      <View style={styles.changelogScrollHintSlot}>
-        {showScrollHint ? (
-          <Text
-            style={styles.changelogScrollHint}
-            testID="custom-ota-changelog-scroll-hint"
-          >
-            Scroll for more ↓
-          </Text>
-        ) : null}
-      </View>
     </View>
   );
 }
@@ -508,14 +473,16 @@ const styles = StyleSheet.create({
     borderColor: colors.hairline,
     borderRadius: 16,
     borderWidth: 1,
-    flex: 1,
+    flexGrow: 1,
     gap: 12,
     maxWidth: 420,
+    minHeight: 200,
     padding: 16,
     width: "100%",
   },
   changelogTitle: { color: colors.ink, fontSize: 16, fontWeight: "700" },
-  changelogList: { flex: 1, width: "100%" },
+  // Bound the notes themselves so the card can grow for its title, but not for all of the Markdown.
+  changelogList: { flexGrow: 1, height: 120, width: "100%" },
   changelogContent: { gap: 20, paddingBottom: 4 },
   changelogEntry: { gap: 8 },
   changelogEntryDivider: {
@@ -529,17 +496,6 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   changelogMarkdownContent: { gap: 10 },
-  changelogScrollHintSlot: {
-    alignItems: "center",
-    height: 18,
-    justifyContent: "center",
-  },
-  changelogScrollHint: {
-    color: colors.muted,
-    fontSize: 12,
-    fontWeight: "500",
-    lineHeight: 16,
-  },
   actions: { gap: 10 },
   actionSpacer: { height: 48 },
   button: {


### PR DESCRIPTION
## Problem
The changelog screen replaced the page ScrollView with a fixed-height View. On short windows or large accessibility text, fixed status content could squeeze the notes viewport to zero height. This addresses the remaining review on #139 without replacing the tested expanding changelog card.

## Change
Use one page ScrollView above the pinned action buttons. The notes ScrollView starts at height 120 and grows into spare space; the card has a 200 minimum height and can grow for its heading. This preserves independent notes scrolling on normal screens and lets the surrounding page scroll only when it no longer fits. No resize callbacks, breakpoints, layout mode switching, or OTA state-machine changes.

Per Philippe, remove the Scroll for more label and reserved row, together with its three state variables and scroll/layout handlers. Keep the vertical scrollbar, including persistentScrollbar on Android. Apple platforms retain their system indicator behavior.

This matches the Engine/MentraOS staging change. Land fixes on staging, then merge staging into dev in each repo.

## Verification
- React Native TypeScript: passed.
- OTA presentation/admission tests: 23 passed.
- Engine companion: mobile TypeScript and all 80 OTA presentation/progress tests passed.
- Reproduced the old failure at 390x600 with 2x text using source-component browser rendering: notes collapsed to zero height here and 7px in Engine.
- 22 browser cases with real source components, mocked OTA state and plain-text Markdown rendering: complete/up_to_date/empty notes; normal phone, short window, desktop, and 1x/2x/3x text. Scrolled page and notes to the end and clicked Done. Screenshots inspected.
- 12 Yoga calculations from the actual style objects confirm minimum notes height, bounded inner scroll and growth into spare room.
- No native app rebuild or physical firmware update performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI/layout only in the React Native OTA flow; no auth, data, or OTA state-machine changes.
> 
> **Overview**
> Fixes OTA changelog layout so release notes stay usable on short viewports and large text without swapping between a fixed `View` and a page `ScrollView`.
> 
> **Page layout:** The screen always wraps status + changelog in one outer `ScrollView` (`nestedScrollEnabled`, `custom-ota-page-scroll`), with top alignment when changelogs are present. Action buttons stay pinned below, so the whole page can scroll only when content no longer fits.
> 
> **Changelog card:** Drops the “Scroll for more ↓” hint and all resize/scroll tracking (`useState`, `onLayout`, `onContentSizeChange`, `onScroll`). The inner notes list keeps its own scroll with a visible indicator (`persistentScrollbar` on Android) and style bounds: card `minHeight: 200` and `flexGrow`, notes area `height: 120` with `flexGrow` so markdown scrolls inside the card instead of collapsing to zero height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed0a856e43cd32ad64f34c5b2d45976fa71d95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->