### PR TITLE
Apply the native ACS plugin from the installed Engine

### DIFF
--- a/.github/scripts/react-native-acs-config.test.mjs
+++ b/.github/scripts/react-native-acs-config.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import {copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
+import {createRequire} from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+function fixture(t, dependencies) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'starter-acs-config-'))
+  t.after(() => rmSync(root, {recursive: true, force: true}))
+  const engine = path.join(root, 'node_modules/@mentra/engine')
+  mkdirSync(engine, {recursive: true})
+  writeFileSync(path.join(engine, 'package.json'), JSON.stringify({name: '@mentra/engine', dependencies}))
+  const configPath = path.join(root, 'app.config.js')
+  copyFileSync(new URL('../../examples/react-native/app.config.js', import.meta.url), configPath)
+  return {engine, configure: createRequire(configPath)(configPath)}
+}
+
+test('older Engine releases preserve the host configuration without requiring ACS', (t) => {
+  const {configure} = fixture(t, {})
+  const config = {name: 'Example', plugins: ['expo-audio'], extra: {releaseIdentity: '3.2.0-dev.116'}}
+  assert.equal(configure({config}), config)
+})
+
+test('ACS uses the exact Engine dependency even when it is not hoisted', (t) => {
+  const {engine, configure} = fixture(t, {'@mentra/acs-meeting': '3.2.0-dev.136'})
+  const acs = path.join(engine, 'node_modules/@mentra/acs-meeting')
+  mkdirSync(acs, {recursive: true})
+  const plugin = path.join(acs, 'app.plugin.js')
+  writeFileSync(plugin, 'module.exports = config => config\n')
+  const config = {name: 'Example', plugins: ['expo-audio'], extra: {releaseIdentity: '3.2.0-dev.136'}}
+  assert.deepEqual(configure({config}), {...config, plugins: ['expo-audio', realpathSync(plugin)]})
+  assert.deepEqual(config.plugins, ['expo-audio'])
+})
+
+test('an Engine release declaring ACS fails clearly if its plugin is missing', (t) => {
+  const {configure} = fixture(t, {'@mentra/acs-meeting': '3.2.0-dev.136'})
+  assert.throws(() => configure({config: {plugins: []}}), /@mentra\/acs-meeting\/app.plugin.js/)
+})

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test coordinated release scripts
-        run: node --test .github/scripts/coordinated-example-release.test.mjs
+        run: node --test .github/scripts/coordinated-example-release.test.mjs .github/scripts/react-native-acs-config.test.mjs
 
   android:
     name: Native Android example

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -9,7 +9,7 @@ Expo Go cannot load the SDK because the package contains native Android and iOS 
 ## Requirements
 
 - Node.js 20+.
-- Xcode 15+ for iOS builds.
+- Xcode 26.2+ for Expo SDK 55 iOS builds.
 - Android Studio / Android SDK and Java 17 for Android builds.
 - A physical phone for Bluetooth, camera, microphone, direct phone photo, and direct phone WebRTC testing.
 - Mentra smart glasses with Bluetooth enabled.
@@ -23,6 +23,10 @@ bun install
 
 The example depends on the exact SDK and Engine versions pinned in
 [`package.json`](./package.json). Those two package versions must match.
+
+`app.config.js` enables the ACS native build plugin when the installed Engine
+includes ACS. It uses Engine's exact dependency for Android desugaring and iOS
+framework setup; older Engine versions without ACS keep the existing config.
 
 Use compatible SDK and Engine versions published by Mentra. When validating
 unreleased SDK changes, use the local source override below so JavaScript,

--- a/examples/react-native/app.config.js
+++ b/examples/react-native/app.config.js
@@ -1,0 +1,16 @@
+const {createRequire} = require('node:module')
+
+module.exports = ({config}) => {
+  const engineManifest = require.resolve('@mentra/engine/package.json')
+  const engineRequire = createRequire(engineManifest)
+  const engine = engineRequire(engineManifest)
+
+  // Older release families do not include ACS. When Engine owns it, resolve
+  // its plugin from that same dependency tree, including non-hoisted installs.
+  if (!engine.dependencies?.['@mentra/acs-meeting']) return config
+
+  return {
+    ...config,
+    plugins: [...(config.plugins ?? []), engineRequire.resolve('@mentra/acs-meeting/app.plugin.js')],
+  }
+}


### PR DESCRIPTION
The dev.136 React Native example fails Android's checkDebugAarMetadata because Engine now includes ACS, but the host never applies the ACS config plugin. The same missing plugin also omits ACS's iOS framework configuration.

Load the plugin from the installed Engine dependency tree in app.config.js. This preserves Engine's exact package selection, works without npm hoisting, and leaves older Engine releases that do not include ACS unchanged. Missing plugins remain explicit errors. No SDK version pins or lockfiles change.

Merge this PR before [MentraOS #3940](https://github.com/Mentra-Community/MentraOS/pull/3940), which adds Android desugaring to the ACS plugin and fixes the Engine iOS consumer job. The next coordinated release will then select both changes.

Validation: all 9 release/configuration tests passed, including older Engine releases, a non-hoisted ACS dependency, and a declared-but-missing plugin. actionlint and git diff --check passed. Native builds for the new ACS version require the companion MentraOS package publication.

[Failing React Native job](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/runs/33939475557/job/101233929398).
