### PR TITLE
Handle the new OTA custom software state in the example

### DIFF
--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -1,9 +1,9 @@
 import {describe, expect, test} from 'bun:test';
 import type {MentraLiveOtaState} from '@mentra/engine/ota';
 
-import {otaPresentation} from './otaPresentation';
+import {otaPresentation, type CustomOtaState} from './otaPresentation';
 
-const baseState: MentraLiveOtaState = {
+const baseState: MentraLiveOtaState & {glassesPackageName: string | null} = {
   batteryLevel: 80,
   canDiscard: false,
   canDismiss: false,
@@ -17,6 +17,7 @@ const baseState: MentraLiveOtaState = {
   currentStep: null,
   error: null,
   firmwareRestarting: false,
+  glassesPackageName: null,
   hotspotArtifactPercent: null,
   hotspotPhase: 'idle',
   hotspotSupported: true,
@@ -37,11 +38,20 @@ const baseState: MentraLiveOtaState = {
   wifiStatusKnown: true,
 };
 
-function otaState(overrides: Partial<MentraLiveOtaState>): MentraLiveOtaState {
+function otaState(overrides: Partial<CustomOtaState>): CustomOtaState {
   return {...baseState, ...overrides};
 }
 
 describe('custom OTA presentation', () => {
+  test('explains custom software and allows continuing without an update', () => {
+    const presentation = otaPresentation(otaState({screen: 'unofficial_client'}));
+
+    expect(presentation.title).toBe('Custom Glasses Software');
+    expect(presentation.message).toContain('Automatic updates are disabled');
+    expect(presentation.primary).toEqual({action: 'finish', label: 'Continue'});
+    expect(presentation.secondary).toBeUndefined();
+  });
+
   test('matches the Mentra App checking page copy', () => {
     const presentation = otaPresentation(otaState({screen: 'checking'}));
 

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -3,6 +3,12 @@ import type {
   MentraLiveOtaState,
 } from '@mentra/engine/ota';
 
+// Staging SDKs predate this screen; keep the example compatible with both
+// release channels while retaining exhaustive checks for future SDK screens.
+export type CustomOtaState = Omit<MentraLiveOtaState, 'screen'> & {
+  screen: MentraLiveOtaState['screen'] | 'unofficial_client';
+};
+
 export type CustomOtaAction = Exclude<
   keyof MentraLiveOtaController,
   'state'
@@ -42,7 +48,7 @@ function completedVersionLabel(transition: MentraLiveOtaState['releaseTransition
 }
 
 export function otaPresentation(
-  state: MentraLiveOtaState,
+  state: CustomOtaState,
   deviceName = 'Mentra Live',
 ): CustomOtaPresentation {
   const {changelogs, releaseTransition} = state;
@@ -154,6 +160,13 @@ export function otaPresentation(
         message: 'This mobile app is a development build, so automatic glasses updates are disabled.',
         primary: {action: 'finish', label: 'Continue'},
         title: 'Development Build',
+        tone: 'neutral',
+      };
+    case 'unofficial_client':
+      return {
+        message: 'Your glasses are running custom software. Automatic updates are disabled to preserve it.',
+        primary: {action: 'finish', label: 'Continue'},
+        title: 'Custom Glasses Software',
         tone: 'neutral',
       };
     case 'check_failed':


### PR DESCRIPTION
The coordinated dev SDK added the unofficial_client OTA screen and glassesPackageName state field, causing the React Native example typecheck to fail. Show a custom-software explanation with Continue and update the test fixture. Retain compatibility with the staging SDK, which predates the screen, while keeping exhaustive handling of other SDK screens.

Validation: TypeScript passes and all 24 tests pass against staging SDK 3.1.0-beta.138 and the exact failing dev SDK 3.2.0-dev.153. The custom-software presentation is covered by a regression test. Native CI builds are pending; device UI behavior has not been tested.

Shared hotfix starts on staging and will flow to dev by merging staging into dev. SDK version pins remain channel-specific.
