### PR TITLE
Fail fast on example validation and label artifacts accurately

### DIFF
--- a/.github/scripts/wait-for-example-validation.sh
+++ b/.github/scripts/wait-for-example-validation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_id="${1:?Expected a workflow run ID}"
+for attempt in {1..540}; do
+  state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status,conclusion,jobs)
+  failures=$(jq -r '.jobs[] | select(.conclusion != null and .conclusion != "" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.name): \(.conclusion)"' <<< "$state")
+  if [[ -n "$failures" ]]; then
+    echo "Example validation failed in run $run_id:" >&2
+    echo "$failures" >&2
+    exit 1
+  fi
+  if [[ "$(jq -r .status <<< "$state")" == "completed" ]]; then
+    if [[ "$(jq -r .conclusion <<< "$state")" != "success" ]]; then
+      echo "Example validation run $run_id concluded $(jq -r .conclusion <<< "$state")." >&2
+      exit 1
+    fi
+    exit 0
+  fi
+  sleep 10
+done
+
+echo "Example validation run $run_id did not complete within 90 minutes." >&2
+exit 1

--- a/.github/scripts/wait-for-example-validation.sh
+++ b/.github/scripts/wait-for-example-validation.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 run_id="${1:?Expected a workflow run ID}"
-for attempt in {1..540}; do
+# The caller retains its existing 120-minute job limit for healthy builds.
+while true; do
   state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status,conclusion,jobs)
   failures=$(jq -r '.jobs[] | select(.conclusion != null and .conclusion != "" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.name): \(.conclusion)"' <<< "$state")
   if [[ -n "$failures" ]]; then
@@ -19,6 +20,3 @@ for attempt in {1..540}; do
   fi
   sleep 10
 done
-
-echo "Example validation run $run_id did not complete within 90 minutes." >&2
-exit 1

--- a/.github/scripts/wait-for-example-validation.test.mjs
+++ b/.github/scripts/wait-for-example-validation.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import {spawnSync} from 'node:child_process'
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import {fileURLToPath} from 'node:url'
+
+function check(t, states) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'example-validation-'))
+  t.after(() => rmSync(dir, {recursive: true, force: true}))
+  writeFileSync(path.join(dir, 'states.json'), JSON.stringify(states))
+  writeFileSync(path.join(dir, 'gh'), `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const dir = process.env.MOCK_DIR;
+const countPath = path.join(dir, 'count');
+const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, 'utf8')) : 0;
+fs.writeFileSync(countPath, String(count + 1));
+const states = JSON.parse(fs.readFileSync(path.join(dir, 'states.json'), 'utf8'));
+if (!states[count]) process.exit(9);
+console.log(JSON.stringify(states[count]));
+`, {mode: 0o755})
+  writeFileSync(path.join(dir, 'sleep'), '#!/bin/sh\nexit 0\n', {mode: 0o755})
+  const result = spawnSync('bash', [fileURLToPath(new URL('./wait-for-example-validation.sh', import.meta.url)), '123'], {
+    encoding: 'utf8',
+    env: {...process.env, PATH: `${dir}:${process.env.PATH}`, MOCK_DIR: dir, STARTER_KIT_REPOSITORY: 'example/repo'},
+  })
+  return {...result, calls: Number(readFileSync(path.join(dir, 'count'), 'utf8'))}
+}
+
+test('fails as soon as a job fails even while another job is running', t => {
+  const result = check(t, [{status: 'in_progress', conclusion: '', jobs: [
+    {name: 'React Native', conclusion: 'failure'}, {name: 'macOS', conclusion: ''},
+  ]}])
+  assert.equal(result.status, 1)
+  assert.equal(result.calls, 1)
+  assert.match(result.stderr, /React Native: failure/)
+})
+
+test('waits for running jobs and accepts successful validation with skipped jobs', t => {
+  const result = check(t, [
+    {status: 'in_progress', conclusion: '', jobs: [{name: 'build', conclusion: null}]},
+    {status: 'completed', conclusion: 'success', jobs: [{name: 'build', conclusion: 'success'}, {name: 'optional', conclusion: 'skipped'}]},
+  ])
+  assert.equal(result.status, 0)
+  assert.equal(result.calls, 2)
+})
+
+test('fails cancelled or timed-out jobs without waiting for the workflow', t => {
+  for (const conclusion of ['cancelled', 'timed_out']) {
+    const result = check(t, [{status: 'in_progress', conclusion: '', jobs: [{name: 'build', conclusion}]}])
+    assert.equal(result.status, 1)
+    assert.equal(result.calls, 1)
+  }
+})
+
+test('rejects a failed workflow even when no failed job is reported', t => {
+  const result = check(t, [{status: 'completed', conclusion: 'failure', jobs: []}])
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /concluded failure/)
+})

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -291,7 +291,7 @@ jobs:
             sleep 10
           done
           [[ -n "$run_id" ]]
-          gh run watch "$run_id" --exit-status
+          bash .github/scripts/wait-for-example-validation.sh "$run_id"
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/$STARTER_KIT_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -255,9 +255,9 @@ jobs:
       - name: Read Bluetooth SDK version
         id: sdk-version
         run: |
-          version=$(jq -r '.dependencies["@mentra/bluetooth-sdk"]' examples/react-native/package.json | sed 's/^[^0-9]*//')
-          if [ -z "$version" ] || [ "$version" = "null" ]; then
-            echo "Could not read @mentra/bluetooth-sdk version from package.json" >&2
+          version=$(jq -er '.dependencies["@mentra/bluetooth-sdk"]' examples/react-native/package.json)
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "The example requires an exact @mentra/bluetooth-sdk version, got: $version" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -363,9 +363,9 @@ jobs:
       - name: Read Bluetooth SDK version
         id: sdk-version
         run: |
-          version=$(jq -r '.dependencies["@mentra/bluetooth-sdk"]' examples/react-native-elevenlabs-audio/package.json | sed 's/^[^0-9]*//')
-          if [ -z "$version" ] || [ "$version" = "null" ]; then
-            echo "Could not read @mentra/bluetooth-sdk version from package.json" >&2
+          version=$(jq -er '.dependencies["@mentra/bluetooth-sdk"]' examples/react-native-elevenlabs-audio/package.json)
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "The example requires an exact @mentra/bluetooth-sdk version, got: $version" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -137,12 +137,9 @@ jobs:
         if: steps.availability.outputs.available == 'true'
         id: collect
         env:
-          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix || steps.sdk-version.outputs.version }}
         run: |
           artifact_suffix="$ARTIFACT_SUFFIX"
-          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
-            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
-          fi
           suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-android${suffix}.apk"
           cp examples/android/app/build/outputs/apk/debug/app-debug.apk "$output"
@@ -224,7 +221,7 @@ jobs:
         id: collect
         working-directory: examples/ios
         env:
-          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix || steps.sdk-version.outputs.version }}
         run: |
           app_path=$(find build/Build/Products/Debug-iphoneos -maxdepth 1 -name '*.app' -print -quit)
           if [ -z "$app_path" ]; then
@@ -234,9 +231,6 @@ jobs:
           mkdir Payload
           cp -R "$app_path" Payload/
           artifact_suffix="$ARTIFACT_SUFFIX"
-          if [[ -z "$artifact_suffix" && -f ../../.github/coordinated-example-release.json ]]; then
-            artifact_suffix=$(jq -er .releaseIdentity ../../.github/coordinated-example-release.json)
-          fi
           suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-ios${suffix}-unsigned.ipa"
           zip -qry "$output" Payload
@@ -342,12 +336,9 @@ jobs:
       - name: Collect APK
         id: collect
         env:
-          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix || steps.sdk-version.outputs.version }}
         run: |
           artifact_suffix="$ARTIFACT_SUFFIX"
-          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
-            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
-          fi
           suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-react-native${suffix}.apk"
           cp examples/react-native/android/app/build/outputs/apk/release/app-release.apk "$output"
@@ -444,12 +435,9 @@ jobs:
       - name: Collect APK
         id: collect
         env:
-          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
+          ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix || steps.sdk-version.outputs.version }}
         run: |
           artifact_suffix="$ARTIFACT_SUFFIX"
-          if [[ -z "$artifact_suffix" && -f .github/coordinated-example-release.json ]]; then
-            artifact_suffix=$(jq -er .releaseIdentity .github/coordinated-example-release.json)
-          fi
           suffix="${artifact_suffix:+-$artifact_suffix}"
           output="mentra-example-rn-elevenlabs-audio${suffix}.apk"
           cp examples/react-native-elevenlabs-audio/android/app/build/outputs/apk/release/app-release.apk "$output"

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test coordinated release scripts
-        run: node --test .github/scripts/coordinated-example-release.test.mjs
+        run: node --test .github/scripts/coordinated-example-release.test.mjs .github/scripts/wait-for-example-validation.test.mjs
 
   android:
     name: Native Android example


### PR DESCRIPTION
Coordinated release validation currently waits for every example job even after one has already failed. Dev 3.2.0-dev.154 hit the React Native type error and continued waiting for the macOS build. Stop on the first failed, cancelled, or timed-out job, while still requiring the complete workflow to succeed before publication.

Also fix artifact filenames: PR/manual builds currently use the previous coordinated release's metadata even when an example has newer SDK pins. Default each filename to that job's detected SDK version; explicit coordinated-release suffixes still take precedence.

Validation: actionlint passes; all ten coordinated-release and validation-wait tests pass. Tests cover an early failure while another job runs, eventual success with skipped jobs, cancellation/timeouts, and a failed workflow without a reported failed job.

These shared workflow fixes start on staging and will merge from staging into dev before completing #152.
