### PR TITLE
Retry public release asset checks during propagation

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -98,7 +98,9 @@ jobs:
             [[ "$(gh api "repos/$STARTER_KIT_REPOSITORY/git/ref/tags/sdk-$RELEASE_IDENTITY" --jq .object.sha)" == "$release_commit" ]]
             [[ "$(jq -er '.artifacts | length' "$result")" =~ ^(3|4)$ ]]
             while IFS= read -r url; do
-              curl --fail --silent --show-error --location --head "$url" >/dev/null
+              curl --fail --silent --show-error --location --head \
+                --retry 5 --retry-all-errors --retry-delay 10 --retry-max-time 180 --max-time 30 \
+                "$url" >/dev/null
             done < <(jq -r '.artifacts[].url' "$result")
             echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "result_url=https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$ARTIFACT_CONTAINER_TAG/$result_name" >> "$GITHUB_OUTPUT"
@@ -403,7 +405,10 @@ jobs:
           # Publish the result last. Its presence is the cross-repository completion signal.
           upload_immutable "$RESULT_NAME"
           result_url="https://github.com/$STARTER_KIT_REPOSITORY/releases/download/$ARTIFACT_CONTAINER_TAG/$RESULT_NAME"
-          curl --fail --silent --show-error --location --head "$result_url" >/dev/null
+          # GitHub can briefly return 404 on the public URL after a successful upload.
+          curl --fail --silent --show-error --location --head \
+            --retry 5 --retry-all-errors --retry-delay 10 --retry-max-time 180 --max-time 30 \
+            "$result_url" >/dev/null
           echo "result_url=$result_url" >> "$GITHUB_OUTPUT"
 
       - name: Summarize the coordinated example release


### PR DESCRIPTION
The dev.160 example release uploaded all immutable assets and its result successfully, then failed because GitHub briefly returned 404 for the public result URL. The same result was publicly available on the next check.

Retry public asset HEAD checks up to five times with a ten-second delay, a thirty-second request timeout, and a three-minute retry window. Apply the same policy when reconciling an existing release; immutable upload and provenance checks remain enforced.

Validation: all six coordinated-release tests and actionlint pass. A local HTTP server verified recovery after two 404 responses and failure after six requests for a persistent 404 (one-second delays for the check).
