### PR TITLE
Retry transient GitHub validation and artifact reads

### DIFF
--- a/.github/scripts/download-example-artifacts.sh
+++ b/.github/scripts/download-example-artifacts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_id="${1:?Expected a workflow run ID}"
+for attempt in 1 2 3; do
+  # A failed archive extraction may leave partial files behind.
+  rm -rf validated-artifacts
+  if gh run download "$run_id" --repo "$STARTER_KIT_REPOSITORY" --dir validated-artifacts; then
+    exit 0
+  fi
+  echo "Could not download example artifacts from run $run_id ($attempt/3 attempts)." >&2
+  if (( attempt < 3 )); then
+    sleep 10
+  fi
+done
+exit 1

--- a/.github/scripts/download-example-artifacts.test.mjs
+++ b/.github/scripts/download-example-artifacts.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import {spawnSync} from 'node:child_process'
+import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import {fileURLToPath} from 'node:url'
+
+function check(t, failures) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'example-download-'))
+  t.after(() => rmSync(dir, {recursive: true, force: true}))
+  writeFileSync(path.join(dir, 'gh'), `#!/usr/bin/env node
+const fs = require('fs');
+const count = fs.existsSync('count') ? Number(fs.readFileSync('count', 'utf8')) : 0;
+fs.writeFileSync('count', String(count + 1));
+if (fs.existsSync('validated-artifacts/partial.zip')) process.exit(99);
+fs.mkdirSync('validated-artifacts', {recursive: true});
+if (count < Number(process.env.MOCK_FAILURES)) {
+  fs.writeFileSync('validated-artifacts/partial.zip', 'incomplete');
+  console.error('connection reset by peer');
+  process.exit(1);
+}
+fs.writeFileSync('validated-artifacts/example.apk', 'complete');
+`, {mode: 0o755})
+  writeFileSync(path.join(dir, 'sleep'), '#!/bin/sh\nexit 0\n', {mode: 0o755})
+  const result = spawnSync('bash', [fileURLToPath(new URL('./download-example-artifacts.sh', import.meta.url)), '123'], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: {...process.env, PATH: `${dir}:${process.env.PATH}`, MOCK_FAILURES: String(failures), STARTER_KIT_REPOSITORY: 'example/repo'},
+  })
+  return {
+    ...result,
+    calls: Number(readFileSync(path.join(dir, 'count'), 'utf8')),
+    complete: existsSync(path.join(dir, 'validated-artifacts/example.apk')),
+    partial: existsSync(path.join(dir, 'validated-artifacts/partial.zip')),
+  }
+}
+
+test('accepts a successful download without retrying', t => {
+  const result = check(t, 0)
+  assert.equal(result.status, 0)
+  assert.equal(result.calls, 1)
+  assert.equal(result.complete, true)
+})
+
+test('removes partial files before retrying a failed download', t => {
+  const result = check(t, 2)
+  assert.equal(result.status, 0)
+  assert.equal(result.calls, 3)
+  assert.equal(result.complete, true)
+  assert.equal(result.partial, false)
+})
+
+test('fails after three unsuccessful downloads', t => {
+  const result = check(t, 3)
+  assert.equal(result.status, 1)
+  assert.equal(result.calls, 3)
+  assert.equal(result.complete, false)
+  assert.match(result.stderr, /3\/3 attempts/)
+})

--- a/.github/scripts/wait-for-example-validation.sh
+++ b/.github/scripts/wait-for-example-validation.sh
@@ -2,9 +2,19 @@
 set -euo pipefail
 
 run_id="${1:?Expected a workflow run ID}"
+read_failures=0
 # The caller retains its existing 120-minute job limit for healthy builds.
 while true; do
-  state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status,conclusion,jobs)
+  if ! state=$(gh run view "$run_id" --repo "$STARTER_KIT_REPOSITORY" --json status,conclusion,jobs); then
+    read_failures=$((read_failures + 1))
+    echo "Could not read example validation run $run_id ($read_failures/3 consecutive attempts)." >&2
+    if (( read_failures >= 3 )); then
+      exit 1
+    fi
+    sleep 10
+    continue
+  fi
+  read_failures=0
   failures=$(jq -r '.jobs[] | select(.conclusion != null and .conclusion != "" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.name): \(.conclusion)"' <<< "$state")
   if [[ -n "$failures" ]]; then
     echo "Example validation failed in run $run_id:" >&2

--- a/.github/scripts/wait-for-example-validation.test.mjs
+++ b/.github/scripts/wait-for-example-validation.test.mjs
@@ -19,6 +19,10 @@ const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, 'utf8
 fs.writeFileSync(countPath, String(count + 1));
 const states = JSON.parse(fs.readFileSync(path.join(dir, 'states.json'), 'utf8'));
 if (!states[count]) process.exit(9);
+if (states[count].readError) {
+  console.error(states[count].readError);
+  process.exit(1);
+}
 console.log(JSON.stringify(states[count]));
 `, {mode: 0o755})
   writeFileSync(path.join(dir, 'sleep'), '#!/bin/sh\nexit 0\n', {mode: 0o755})
@@ -59,4 +63,49 @@ test('rejects a failed workflow even when no failed job is reported', t => {
   const result = check(t, [{status: 'completed', conclusion: 'failure', jobs: []}])
   assert.equal(result.status, 1)
   assert.match(result.stderr, /concluded failure/)
+})
+
+test('recovers from two transient status read failures', t => {
+  const result = check(t, [
+    {readError: 'i/o timeout'},
+    {readError: 'HTTP 502'},
+    {status: 'completed', conclusion: 'success', jobs: []},
+  ])
+  assert.equal(result.status, 0)
+  assert.equal(result.calls, 3)
+})
+
+test('stops after three consecutive status read failures', t => {
+  const result = check(t, [
+    {readError: 'i/o timeout'},
+    {readError: 'i/o timeout'},
+    {readError: 'i/o timeout'},
+    {status: 'completed', conclusion: 'success', jobs: []},
+  ])
+  assert.equal(result.status, 1)
+  assert.equal(result.calls, 3)
+  assert.match(result.stderr, /3\/3 consecutive attempts/)
+})
+
+test('resets the read failure count after a successful running-state read', t => {
+  const result = check(t, [
+    {readError: 'i/o timeout'},
+    {readError: 'i/o timeout'},
+    {status: 'in_progress', conclusion: '', jobs: []},
+    {readError: 'i/o timeout'},
+    {readError: 'i/o timeout'},
+    {status: 'completed', conclusion: 'success', jobs: []},
+  ])
+  assert.equal(result.status, 0)
+  assert.equal(result.calls, 6)
+})
+
+test('still fails immediately on a failed job after recovering a status read', t => {
+  const result = check(t, [
+    {readError: 'i/o timeout'},
+    {status: 'in_progress', conclusion: '', jobs: [{name: 'build', conclusion: 'failure'}]},
+  ])
+  assert.equal(result.status, 1)
+  assert.equal(result.calls, 2)
+  assert.match(result.stderr, /build: failure/)
 })

--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Download validated artifacts
         if: steps.existing.outputs.already_published != 'true'
-        run: gh run download "${{ steps.validation.outputs.run_id }}" --dir validated-artifacts
+        run: bash .github/scripts/download-example-artifacts.sh "${{ steps.validation.outputs.run_id }}"
 
       - name: Create source tag and deterministic result
         if: steps.existing.outputs.already_published != 'true'

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test coordinated release scripts
-        run: node --test .github/scripts/coordinated-example-release.test.mjs .github/scripts/wait-for-example-validation.test.mjs
+        run: node --test .github/scripts/coordinated-example-release.test.mjs .github/scripts/wait-for-example-validation.test.mjs .github/scripts/download-example-artifacts.test.mjs
 
   android:
     name: Native Android example


### PR DESCRIPTION
The dev.163 companion exited while its example builds were healthy because a GitHub API status request timed out. The beta.162 companion later failed when an artifact download connection reset after its builds passed.

Retry failed status reads at the existing ten-second polling interval, stopping after three consecutive failures and resetting the counter after a successful read. Retry validated artifact downloads up to three times, clearing the job-owned download directory before each attempt so partial archives cannot survive into publication.

A reported failed, cancelled, or timed-out build still fails immediately. The caller's existing 120-minute job limit continues to bound the release job.

Validation: all 17 polling, download, and coordinated-release tests pass. Coverage includes transient recovery, persistent failure, counter reset, immediate build-failure detection after a read error, and removal of partial download files. Both workflows pass actionlint; Bash syntax and diff checks pass. The CI contract job includes the new download tests.
