### PR TITLE
Refresh Bun metadata when synchronizing release lockfiles

### DIFF
--- a/.github/workflows/coordinated-example-release.yml
+++ b/.github/workflows/coordinated-example-release.yml
@@ -182,7 +182,8 @@ jobs:
             update_lockfile() {
               local directory="$1"
               for attempt in {1..12}; do
-                if (cd "$directory" && bun install --lockfile-only); then
+                # Each retry must see newly published versions, not Bun's cached manifest.
+                if (cd "$directory" && bun install --lockfile-only --no-cache); then
                   return 0
                 fi
                 if (( attempt == 12 )); then


### PR DESCRIPTION
Release candidate creation failed for 3.2.0-dev.165 because Bun kept resolving against cached Engine metadata throughout all 12 retries, even though the version was already published. Run lockfile generation with `--no-cache` so each attempt can see newly published package versions. Existing exact pins and bounded retry counts remain unchanged.

Validation: reproduced the failure with the workflow's exact Bun 1.3.11 binary and a local registry with primed metadata. After exposing a new version, the normal retry made zero registry requests and still failed; `--no-cache` fetched the updated manifest and generated the correct lockfile. All 17 release/status-poll/artifact-download tests, actionlint, and diff checks passed. The failed release rerun has recovered candidate creation and is validating examples.

Shared fix targets staging first and will flow to dev through a real staging merge.
