### PR TITLE
fix: keep OTA Wi-Fi setup open and block system back during updates

### DIFF
--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Keyboard, Platform, View, StyleSheet, StatusBar } from 'react-native';
+import { Keyboard, Platform, Pressable, Text, View, StyleSheet, StatusBar } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardVisibleContext } from './components/keyboardLayout';
 import { TabBar, TabKey } from './components/TabBar';
@@ -10,7 +10,7 @@ import { StreamScreen } from './screens/StreamScreen';
 import { SystemScreen } from './screens/SystemScreen';
 import { ConsoleScreen } from './screens/ConsoleScreen';
 import { otaFlowAdmission } from './otaFlowAdmission';
-import { isGlassesWifiConnected } from './sdkFormat';
+import { colors } from './components/theme';
 import { isMentraLiveRuntime, useBluetoothSdkExample } from './useBluetoothSdkExample';
 
 export default function App() {
@@ -30,7 +30,6 @@ export default function App() {
       completedConnectionGeneration: otaCompletedGenerationRef.current,
       connectionGeneration,
       waitingForWifi,
-      wifiConnected: isGlassesWifiConnected(sdk.glasses),
     });
 
     if (admission === 'idle') {
@@ -89,6 +88,17 @@ export default function App() {
           />
         ) : (
           <SafeAreaView style={styles.root} edges={['top']}>
+            {waitingForWifi && (
+              <View style={styles.otaResume}>
+                <Text style={styles.otaResumeText}>Finish Wi-Fi setup, then continue the update.</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={openOta}
+                  style={styles.otaResumeButton}>
+                  <Text style={styles.otaResumeLabel}>Continue update</Text>
+                </Pressable>
+              </View>
+            )}
             <View style={styles.screen}>
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
@@ -107,4 +117,8 @@ export default function App() {
 const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: '#fff' },
   screen: { flex: 1 },
+  otaResume: { padding: 16, gap: 12, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.hairline },
+  otaResumeText: { color: colors.ink, fontSize: 14 },
+  otaResumeButton: { backgroundColor: colors.greenInk, borderRadius: 14, minHeight: 48, alignItems: 'center', justifyContent: 'center' },
+  otaResumeLabel: { color: colors.bg, fontSize: 14, fontWeight: '700' },
 });

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -10,6 +10,7 @@ import { StreamScreen } from './screens/StreamScreen';
 import { SystemScreen } from './screens/SystemScreen';
 import { ConsoleScreen } from './screens/ConsoleScreen';
 import { otaFlowAdmission } from './otaFlowAdmission';
+import { connectedWifiStatus } from './sdkFormat';
 import { colors } from './components/theme';
 import { isMentraLiveRuntime, useBluetoothSdkExample } from './useBluetoothSdkExample';
 
@@ -18,8 +19,14 @@ export default function App() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [otaVisible, setOtaVisible] = useState(false);
   const [waitingForWifi, setWaitingForWifi] = useState(false);
+  const [otaWifiTargetSsid, setOtaWifiTargetSsid] = useState<string | null>(null);
   const otaCompletedGenerationRef = useRef<number | null>(null);
   const sdk = useBluetoothSdkExample({activeTab: tab});
+  const currentWifi = connectedWifiStatus(sdk.glasses);
+  const otaWifiSetupComplete = otaWifiTargetSsid !== null
+    && currentWifi?.ssid === otaWifiTargetSsid
+    && sdk.wifiConnectingSsid === null
+    && sdk.wifiConnectError === null;
   const mentraLiveConnected = isMentraLiveRuntime(sdk.glasses);
   const connectionGeneration = mentraLiveConnected && sdk.glasses.connected
     ? sdk.glassesConnectionGeneration
@@ -65,6 +72,7 @@ export default function App() {
   };
 
   const openWifiSetup = () => {
+    setOtaWifiTargetSsid(null);
     setWaitingForWifi(true);
     setOtaVisible(false);
     setTab('system');
@@ -88,22 +96,34 @@ export default function App() {
           />
         ) : (
           <SafeAreaView style={styles.root} edges={['top']}>
-            {waitingForWifi && (
+            {waitingForWifi && tab === 'system' && (
               <View style={styles.otaResume}>
-                <Text style={styles.otaResumeText}>Finish Wi-Fi setup, then continue the update.</Text>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={openOta}
-                  style={styles.otaResumeButton}>
-                  <Text style={styles.otaResumeLabel}>Continue update</Text>
-                </Pressable>
+                <Text style={styles.otaResumeText}>
+                  {otaWifiSetupComplete
+                    ? `Connected to ${currentWifi?.ssid}`
+                    : 'Connect to a Wi-Fi network to continue the update.'}
+                </Text>
+                {otaWifiSetupComplete && (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={openOta}
+                    style={styles.otaResumeButton}>
+                    <Text style={styles.otaResumeLabel}>Continue update</Text>
+                  </Pressable>
+                )}
               </View>
             )}
             <View style={styles.screen}>
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
               {tab === 'stream' && <StreamScreen sdk={sdk} />}
-              {tab === 'system' && <SystemScreen sdk={sdk} />}
+              {tab === 'system' && <SystemScreen sdk={{
+                ...sdk,
+                sendWifiCredentials: async (ssid, password, requiresPassword) => {
+                  if (waitingForWifi) setOtaWifiTargetSsid(ssid);
+                  await sdk.sendWifiCredentials(ssid, password, requiresPassword);
+                },
+              }} />}
               {tab === 'console' && <ConsoleScreen sdk={sdk} />}
             </View>
             {!keyboardVisible && <TabBar active={tab} onChange={setTab} />}

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -19,14 +19,11 @@ export default function App() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [otaVisible, setOtaVisible] = useState(false);
   const [waitingForWifi, setWaitingForWifi] = useState(false);
-  const [otaWifiTargetSsid, setOtaWifiTargetSsid] = useState<string | null>(null);
   const otaCompletedGenerationRef = useRef<number | null>(null);
   const sdk = useBluetoothSdkExample({activeTab: tab});
   const currentWifi = connectedWifiStatus(sdk.glasses);
-  const otaWifiSetupComplete = otaWifiTargetSsid !== null
-    && currentWifi?.ssid === otaWifiTargetSsid
-    && sdk.wifiConnectingSsid === null
-    && sdk.wifiConnectError === null;
+  // A failed attempt to join another network must not block the current one.
+  const otaWifiSetupComplete = currentWifi !== null && sdk.wifiConnectingSsid === null;
   const mentraLiveConnected = isMentraLiveRuntime(sdk.glasses);
   const connectionGeneration = mentraLiveConnected && sdk.glasses.connected
     ? sdk.glassesConnectionGeneration
@@ -72,7 +69,6 @@ export default function App() {
   };
 
   const openWifiSetup = () => {
-    setOtaWifiTargetSsid(null);
     setWaitingForWifi(true);
     setOtaVisible(false);
     setTab('system');
@@ -117,13 +113,7 @@ export default function App() {
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
               {tab === 'stream' && <StreamScreen sdk={sdk} />}
-              {tab === 'system' && <SystemScreen sdk={{
-                ...sdk,
-                sendWifiCredentials: async (ssid, password, requiresPassword) => {
-                  if (waitingForWifi) setOtaWifiTargetSsid(ssid);
-                  await sdk.sendWifiCredentials(ssid, password, requiresPassword);
-                },
-              }} />}
+              {tab === 'system' && <SystemScreen sdk={sdk} />}
               {tab === 'console' && <ConsoleScreen sdk={sdk} />}
             </View>
             {!keyboardVisible && <TabBar active={tab} onChange={setTab} />}

--- a/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
+++ b/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import {
   ActivityIndicator,
+  BackHandler,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -50,6 +51,13 @@ export function CustomMentraLiveOtaFlow({
   onFinished,
   onOpenWifiSetup,
 }: CustomMentraLiveOtaFlowProps) {
+  useEffect(() => {
+    // Only the flow's buttons may leave OTA. This app has no navigation stack;
+    // without a handler, Android Back invokes the system's default exit action.
+    const subscription = BackHandler.addEventListener("hardwareBackPress", () => true);
+    return () => subscription.remove();
+  }, []);
+
   const controller = useMentraLiveOta({
     initialPage,
     initializeRuntime,

--- a/examples/react-native/src/otaFlowAdmission.test.ts
+++ b/examples/react-native/src/otaFlowAdmission.test.ts
@@ -8,7 +8,6 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: null,
       connectionGeneration: 0,
       waitingForWifi: false,
-      wifiConnected: false,
     })).toBe('open');
   });
 
@@ -17,7 +16,6 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: 4,
       connectionGeneration: 4,
       waitingForWifi: false,
-      wifiConnected: true,
     })).toBe('done');
   });
 
@@ -26,22 +24,32 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: 4,
       connectionGeneration: 5,
       waitingForWifi: false,
-      wifiConnected: true,
     })).toBe('open');
   });
 
-  test('waits in System until legacy Wi-Fi setup completes', () => {
+  test('keeps Wi-Fi setup open across status refreshes and BLE reconnects', () => {
+    for (const connectionGeneration of [0, 0, null, 1]) {
+      expect(otaFlowAdmission({
+        completedConnectionGeneration: null,
+        connectionGeneration,
+        waitingForWifi: true,
+      })).toBe('wait_for_wifi');
+    }
+  });
+
+  test('reopens OTA when the user continues from Wi-Fi setup', () => {
     expect(otaFlowAdmission({
       completedConnectionGeneration: null,
       connectionGeneration: 0,
-      waitingForWifi: true,
-      wifiConnected: false,
-    })).toBe('wait_for_wifi');
-    expect(otaFlowAdmission({
-      completedConnectionGeneration: null,
-      connectionGeneration: 0,
-      waitingForWifi: true,
-      wifiConnected: true,
+      waitingForWifi: false,
     })).toBe('open');
+  });
+
+  test('stays idle when disconnected outside Wi-Fi setup', () => {
+    expect(otaFlowAdmission({
+      completedConnectionGeneration: null,
+      connectionGeneration: null,
+      waitingForWifi: false,
+    })).toBe('idle');
   });
 });

--- a/examples/react-native/src/otaFlowAdmission.ts
+++ b/examples/react-native/src/otaFlowAdmission.ts
@@ -4,14 +4,14 @@ export function otaFlowAdmission({
   completedConnectionGeneration,
   connectionGeneration,
   waitingForWifi,
-  wifiConnected,
 }: {
   completedConnectionGeneration: number | null;
   connectionGeneration: number | null;
   waitingForWifi: boolean;
-  wifiConnected: boolean;
 }): OtaFlowAdmission {
+  // Setup is a user-controlled detour: an existing connection (or a reconnect)
+  // must not dismiss it before the user has finished changing networks.
+  if (waitingForWifi) return 'wait_for_wifi';
   if (connectionGeneration === null) return 'idle';
-  if (waitingForWifi) return wifiConnected ? 'open' : 'wait_for_wifi';
   return completedConnectionGeneration === connectionGeneration ? 'done' : 'open';
 }


### PR DESCRIPTION
Opening OTA Wi-Fi setup while the glasses already reported connected immediately reopened “Checking for updates.” Android system Back also fell through to the default exit action while the OTA screen was open.

Keep Wi-Fi setup open until the user taps **Continue update**. The System tab shows an inline **Connected to [network]** message and Continue whenever the glasses are connected and no Wi-Fi connection attempt is pending. This supports an existing connection or returning to the original network after a failed join; connection errors remain visible separately. Disconnecting or starting a join hides Continue. Wi-Fi status refreshes and BLE reconnects never automatically dismiss setup.

For parity with Mentra-Community/MentraOS#3965, consume Android Back throughout the custom OTA screen's lifetime. Unmounting the screen removes the handler, so the flow's own exit and Wi-Fi setup buttons still work and normal Back behavior resumes outside OTA. The example has no navigation stack, so the MentraOS-specific iOS stack gesture and navigation-interceptor fixes do not apply.

Validation: all 25 existing React Native Bun tests pass, `bunx tsc --noEmit` passes, and `git diff --check` passes. Admission coverage includes setup across BLE reconnects, explicit continuation, and disconnected admission. Physical-device validation of the Wi-Fi confirmation and Android Back handling remains pending.
