### PR TITLE
Align example OTA labels and reconnect presentation

### DIFF
--- a/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
+++ b/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import {
   ActivityIndicator,
   BackHandler,
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -24,6 +25,7 @@ import { Header } from "../components/Header";
 import { colors } from "../components/theme";
 import {
   otaPresentation,
+  otaRestartOverlayMessage,
   type CustomOtaAction,
   type CustomOtaButton,
   type CustomOtaChangelog,
@@ -68,6 +70,7 @@ export function CustomMentraLiveOtaFlow({
     () => otaPresentation(controller.state, deviceName),
     [controller.state, deviceName],
   );
+  const restartMessage = otaRestartOverlayMessage(controller.state, deviceName);
   const palette = toneColors[presentation.tone];
   const hasChangelogs = (presentation.changelogs?.length ?? 0) > 0;
 
@@ -93,6 +96,10 @@ export function CustomMentraLiveOtaFlow({
             {presentation.versionLabel}
           </Text>
         </View>
+      ) : null}
+
+      {presentation.progressLabel ? (
+        <Text style={styles.detail}>{presentation.progressLabel}</Text>
       ) : null}
 
       {presentation.progress !== undefined ? (
@@ -128,6 +135,21 @@ export function CustomMentraLiveOtaFlow({
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <Modal
+        animationType="fade"
+        transparent
+        visible={restartMessage !== null}
+        onRequestClose={() => {}}
+      >
+        <View style={styles.restartBackdrop}>
+          <View accessibilityViewIsModal style={styles.restartCard} testID="ota-restart-overlay">
+            <ActivityIndicator color={colors.greenPrimary} size="large" />
+            <Text accessibilityRole="header" style={styles.message}>
+              {restartMessage}
+            </Text>
+          </View>
+        </View>
+      </Modal>
       <Header title="Software Update" />
       <View style={styles.page} testID="custom-mentra-live-ota-flow">
         <ScrollView
@@ -399,6 +421,22 @@ function ActionButton({
 }
 
 const styles = StyleSheet.create({
+  restartBackdrop: {
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.4)",
+    flex: 1,
+    justifyContent: "center",
+    padding: 24,
+  },
+  restartCard: {
+    alignItems: "center",
+    backgroundColor: colors.bg,
+    borderRadius: 20,
+    gap: 20,
+    maxWidth: 420,
+    padding: 28,
+    width: "100%",
+  },
   safeArea: { backgroundColor: colors.bg, flex: 1 },
   page: { flex: 1, paddingBottom: 18, paddingHorizontal: 24 },
   contentScroll: { flex: 1 },

--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'bun:test';
 import type {MentraLiveOtaState} from '@mentra/engine/ota';
 
-import {otaPresentation} from './otaPresentation';
+import {otaPresentation, otaRestartOverlayMessage} from './otaPresentation';
 
 const baseState: MentraLiveOtaState = {
   batteryLevel: 80,
@@ -310,5 +310,105 @@ describe('custom OTA presentation', () => {
       message: 'This mobile app is a development build, so automatic glasses updates are disabled.',
       title: 'Development Build',
     });
+  });
+});
+
+
+describe('OTA transport labels and reconnect parity', () => {
+  test.each([
+    ['apk', 'Glasses software', 0],
+    ['mtk', 'System firmware', 1],
+    ['bes', 'Bluetooth firmware', 2],
+  ] as const)('labels the current %s download on the phone', (kind, label, index) => {
+    const p = otaPresentation(
+      otaState({
+        screen: 'preparing_hotspot',
+        hotspotPhase: 'downloading',
+        hotspotArtifact: {kind, index, totalCount: 3},
+        hotspotArtifactPercent: 42,
+      }),
+    );
+    expect(p.progressLabel).toBe(`File ${index + 1} of 3 · ${label}`);
+    expect(p.progress).toBe(42);
+    expect(p.detail).toBe('Each file downloads separately. Progress is for the current file.');
+  });
+
+  test('does not invent file metadata or a percentage while the phone prepares', () => {
+    const p = otaPresentation(otaState({screen: 'preparing_hotspot', hotspotPhase: 'downloading'}));
+    expect(p.progressLabel).toBeUndefined();
+    expect(p.progress).toBeUndefined();
+  });
+
+  test.each([
+    ['starting_hotspot', 'Starting glasses hotspot...'],
+    ['joining_hotspot', 'Connecting phone to glasses...'],
+    ['serving', 'Starting update...'],
+  ] as const)('clears the phone file label during %s', (hotspotPhase, title) => {
+    const p = otaPresentation(
+      otaState({
+        screen: 'preparing_hotspot',
+        hotspotPhase,
+        hotspotArtifact: {kind: 'apk', index: 0, totalCount: 3},
+        hotspotArtifactPercent: 100,
+      }),
+    );
+    expect(p.title).toBe(title);
+    expect(p.progressLabel).toBeUndefined();
+    expect(p.progress).toBeUndefined();
+  });
+
+  test.each(['download', 'install'] as const)(
+    'labels hotspot %s as work on the glasses',
+    (phase) => {
+      const p = otaPresentation(
+        otaState({
+          screen: 'updating',
+          phase,
+          transport: 'hotspot',
+          step: 'mtk',
+          currentStep: 2,
+          totalSteps: 3,
+          progress: 55,
+        }),
+      );
+      expect(p.title).toBe(
+        phase === 'download'
+          ? 'Transferring update to glasses...'
+          : 'Installing update on glasses...',
+      );
+      expect(p.progressLabel).toBe('Update 2 of 3 · System firmware');
+      expect(p.detail).toBe(
+        phase === 'download' ? 'Progress is for this file’s transfer from your phone.' : undefined,
+      );
+      expect(p.progress).toBe(55);
+    },
+  );
+
+  test('shows the component alone when the update count is unknown', () => {
+    expect(
+      otaPresentation(
+        otaState({screen: 'updating', transport: 'hotspot', phase: 'install', step: 'bes'}),
+      ).progressLabel,
+    ).toBe('Bluetooth firmware');
+  });
+
+  test('keeps a manual shutdown on the inline reconnecting page without a restart popup', () => {
+    const state = otaState({screen: 'disconnected', connected: false});
+    expect(otaRestartOverlayMessage(state)).toBeNull();
+    expect(otaPresentation(state)).toMatchObject({
+      title: 'Glasses disconnected',
+      message: 'Reconnecting...',
+      indeterminate: true,
+    });
+    expect(otaPresentation(state).primary).toBeUndefined();
+  });
+
+  test('shows the expected firmware restart popup and removes it when connected', () => {
+    const state = otaState({screen: 'restarting', connected: false, firmwareRestarting: true});
+    expect(otaRestartOverlayMessage(state)).toBe(
+      'Please wait while Mentra Live restarts and automatically reconnects...',
+    );
+    expect(otaRestartOverlayMessage({...state, connected: true})).toBeNull();
+    expect(otaRestartOverlayMessage({...state, firmwareRestarting: false})).toBeNull();
   });
 });

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -26,6 +26,7 @@ export type CustomOtaPresentation = {
   message?: string;
   primary?: CustomOtaButton;
   progress?: number;
+  progressLabel?: string;
   secondary?: CustomOtaButton;
   title: string;
   tone: 'active' | 'danger' | 'neutral' | 'success';
@@ -39,6 +40,21 @@ function updateVersionLabel(transition: MentraLiveOtaState['releaseTransition'])
 
 function completedVersionLabel(transition: MentraLiveOtaState['releaseTransition']): string | undefined {
   return transition ? `Updated to ${transition.toVersion}` : undefined;
+}
+
+const componentLabels = {
+  apk: 'Glasses software',
+  mtk: 'System firmware',
+  bes: 'Bluetooth firmware',
+} as const;
+
+export function otaRestartOverlayMessage(
+  state: MentraLiveOtaState,
+  deviceName = 'Mentra Live',
+): string | null {
+  return state.firmwareRestarting && !state.connected
+    ? `Please wait while ${deviceName} restarts and automatically reconnects...`
+    : null;
 }
 
 export function otaPresentation(
@@ -189,27 +205,59 @@ export function otaPresentation(
           title: 'Starting update...',
         },
       }[state.hotspotPhase];
+      const artifact = state.hotspotPhase === 'downloading' ? state.hotspotArtifact : null;
       return {
+        detail:
+          state.hotspotPhase === 'downloading'
+            ? 'Each file downloads separately. Progress is for the current file.'
+            : undefined,
         indeterminate: true,
         message: 'Do not disconnect your glasses',
-        progress: state.hotspotPhase === 'downloading'
-          ? (state.hotspotArtifactPercent ?? undefined)
+        progressLabel: artifact
+          ? `File ${artifact.index + 1} of ${artifact.totalCount} · ${componentLabels[artifact.kind]}`
           : undefined,
+        progress:
+          state.hotspotPhase === 'downloading'
+            ? (state.hotspotArtifactPercent ?? undefined)
+            : undefined,
         title: hotspotCopy.title,
         tone: 'active',
       };
     }
-    case 'updating':
+    case 'updating': {
+      const hotspot = state.transport === 'hotspot';
+      const component = state.step ? componentLabels[state.step] : undefined;
+      const hasStepCount =
+        state.currentStep !== null &&
+        state.totalSteps !== null &&
+        state.currentStep > 0 &&
+        state.currentStep <= state.totalSteps;
       return {
-        detail: state.versionChange && state.phase === 'install'
-          ? 'Your glasses will restart twice — this may take up to 2 minutes.'
-          : undefined,
+        detail:
+          state.versionChange && state.phase === 'install'
+            ? 'Your glasses will restart twice — this may take up to 2 minutes.'
+            : hotspot && state.phase === 'download'
+              ? 'Progress is for this file’s transfer from your phone.'
+              : undefined,
+        progressLabel:
+          hotspot && component
+            ? hasStepCount
+              ? `Update ${state.currentStep} of ${state.totalSteps} · ${component}`
+              : component
+            : undefined,
         indeterminate: state.installingApkOnly || state.progress === null,
         message: 'Do not disconnect your glasses',
         progress: state.installingApkOnly ? undefined : (state.progress ?? undefined),
-        title: state.phase === 'download' ? 'Downloading...' : 'Installing...',
+        title: hotspot
+          ? state.phase === 'download'
+            ? 'Transferring update to glasses...'
+            : 'Installing update on glasses...'
+          : state.phase === 'download'
+            ? 'Downloading...'
+            : 'Installing...',
         tone: 'active',
       };
+    }
     case 'restarting':
       return {
         detail: "We'll continue automatically when they're ready.",


### PR DESCRIPTION
## Change

Bring the custom React Native example OTA screens into parity with the Mentra App. Phone downloads now name the current file and component (for example, File 2 of 3 · System firmware), explain that percentages apply to each file, and distinguish phone download, phone-to-glasses transfer, and installation on the glasses.

Expected firmware restarts now display the same automatic-reconnect message in a modal without a dismiss action. Unexpected mid-download disconnects retain the inline Reconnecting spinner. The modal is driven only by Engine firmwareRestarting/connected state and disappears when connected; all reconnect arbitration and retries remain Engine-owned.

## Validation

- 37 Bun tests pass, including 12 new cases covering file/component labels, absent metadata, hotspot transitions, transfer/install labels, manual disconnects, and expected restart overlay visibility.
- TypeScript passes against the pinned 3.1.0-beta.170 packages.
- git diff --check passes.
- Native CI and the physical iPhone interruption retest remain pending. The prior device reproduction confirmed Reconnecting → Starting update → Update failed when an APK download was interrupted.

## Release order

Merge this example-app PR into staging first, then MentraOS PR https://github.com/Mentra-Community/MentraOS/pull/3967. The latter fixes Engine recovery when glasses report idle after reboot; its coordinated release will update the example app package pins. This PR does not duplicate that recovery logic or manually advance package versions. Validate the resulting staging/TestFlight builds together.
