### PR TITLE
Show empty-scan connection hints in mobile examples

### DIFF
--- a/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/MentraExampleController.kt
@@ -52,6 +52,8 @@ import com.mentra.bluetoothsdk.PhotoSize
 import com.mentra.bluetoothsdk.RgbLedAction
 import com.mentra.bluetoothsdk.RgbLedColor
 import com.mentra.bluetoothsdk.RgbLedRequest
+import com.mentra.bluetoothsdk.MentraBluetoothScanCallback
+import com.mentra.bluetoothsdk.ScanDiagnostic
 import com.mentra.bluetoothsdk.ScanSession
 import com.mentra.bluetoothsdk.SettingsAckEvent
 import com.mentra.bluetoothsdk.SpeakingStatusEvent
@@ -234,6 +236,7 @@ data class MentraExampleState(
     val bluetoothStatus: PhoneSdkRuntimeState? = null,
     val cameraStatus: String = "Camera: phone receiver will start before capture",
     val discoveredDevices: List<Device> = emptyList(),
+    val scanHint: String? = null,
     val selectedDiscoveredDevice: Device? = null,
     val selectedScanModel: DeviceModel = DeviceModel.MENTRA_LIVE,
     val events: List<ExampleEvent> = listOf(exampleEvent("LIVE", "SDK ready. Scan to discover glasses.")),
@@ -484,12 +487,20 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         val model = state.selectedScanModel
         runAction("Scan ${deviceModelLabel(model)}") {
             scanSession?.stop()
-            state = state.copy(discoveredDevices = emptyList(), selectedDiscoveredDevice = null)
-            scanSession = mentraBluetoothSdk.scan(model, 10_000L) { devices ->
-                state = state.copy(
-                    discoveredDevices = devices,
-                )
-            }
+            state = state.copy(discoveredDevices = emptyList(), selectedDiscoveredDevice = null, scanHint = null)
+            scanSession = mentraBluetoothSdk.scan(
+                model = model,
+                timeoutMs = 10_000L,
+                callback = object : MentraBluetoothScanCallback() {
+                    override fun onResults(devices: List<Device>) {
+                        state = state.copy(discoveredDevices = devices, scanHint = if (devices.isEmpty()) state.scanHint else null)
+                    }
+                    override fun onDiagnostic(diagnostic: ScanDiagnostic) {
+                        state = state.copy(scanHint = diagnostic.message)
+                        addEvent("BLE", diagnostic.message)
+                    }
+                },
+            )
         }
     }
 
@@ -503,11 +514,14 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
             discoveredDevices = emptyList(),
             selectedDiscoveredDevice = null,
             selectedScanModel = model,
+            scanHint = null,
             lastAction = "Selected scan model: ${deviceModelLabel(model)}",
         )
     }
 
     fun connect() = runAction("Connect") {
+        scanSession?.stop()
+        state = state.copy(scanHint = null)
         val target = state.selectedDiscoveredDevice
         when {
             target != null -> mentraBluetoothSdk.connect(target)
@@ -518,7 +532,8 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     fun connect(device: Device) = runAction("Connect ${device.name}") {
-        state = state.copy(selectedDiscoveredDevice = device)
+        scanSession?.stop()
+        state = state.copy(selectedDiscoveredDevice = device, scanHint = null)
         mentraBluetoothSdk.connect(device)
     }
 
@@ -2173,6 +2188,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
         }
         state = state.copy(
             glassesStatus = glasses,
+            scanHint = if (glasses.connected) null else state.scanHint,
             hotspotEnabled = enabledHotspotStatus(glasses) != null,
             mentraLiveVersions = resolveMentraLiveVersions(glasses, latestVersionInfo),
         )
@@ -2205,7 +2221,7 @@ class MentraExampleController(context: Context) : MentraBluetoothSdkCallback(), 
     }
 
     override fun onScanChanged(scan: BluetoothScanState) {
-        state = state.copy(discoveredDevices = scan.devices)
+        state = state.copy(discoveredDevices = scan.devices, scanHint = if (scan.devices.isEmpty()) state.scanHint else null)
     }
 
     override fun onDeviceDiscovered(device: Device) {

--- a/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
+++ b/examples/android/app/src/main/java/com/mentra/examples/android/screens/DeviceScreen.kt
@@ -522,6 +522,10 @@ private fun TargetPicker(controller: MentraExampleController, connected: Boolean
                 enabled = false,
                 onClick = {},
             )
+            state.discoveredDevices.isEmpty() && state.scanHint != null -> Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text("Glasses may be in use", color = AppColor.inkAlt, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                Text(state.scanHint, color = AppColor.muted, fontSize = 13.sp)
+            }
             state.discoveredDevices.isEmpty() && hasSavedConnectionTarget(state.bluetoothStatus) -> TargetDeviceRow(
                 name = savedConnectionTargetName(state.bluetoothStatus),
                 detail = savedConnectionTargetDetail(state.bluetoothStatus),

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.2.0-dev.180
+mentraSdkVersion=3.2.0-dev.181

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.2.0-dev.180;
+				version = 3.2.0-dev.181;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample/BluetoothViewModel.swift
+++ b/examples/ios/MentraExample/BluetoothViewModel.swift
@@ -346,6 +346,7 @@ enum ExampleStreamProtocol: String, CaseIterable {
 final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDelegate, AVAudioPlayerDelegate {
     @Published private(set) var glassesValues: GlassesRuntimeState?
     @Published private(set) var bluetoothValues: PhoneSdkRuntimeState?
+    @Published private(set) var scanHint: String?
     @Published private(set) var discoveredDevices: [Device] = []
     @Published private(set) var selectedDiscoveredDevice: Device?
     @Published private(set) var selectedScanModel: DeviceModel = .mentraLive
@@ -600,6 +601,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         let model = selectedScanModel
         runAction("Scan \(deviceModelLabel(model))") {
             scanSession?.stop()
+            scanHint = nil
             discoveredDevices.removeAll()
             selectedDiscoveredDevice = nil
             scanSession = try mentraBluetoothSdk.scan(
@@ -607,12 +609,19 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
                 timeout: 10,
                 onResults: { [weak self] devices in
                     self?.discoveredDevices = devices
+                    if !devices.isEmpty { self?.scanHint = nil }
+                },
+                onDiagnostic: { [weak self] diagnostic in
+                    self?.scanHint = diagnostic.message
+                    self?.append(tag: "BLE", text: diagnostic.message)
                 }
             )
         }
     }
 
     func connect() {
+        scanSession?.stop()
+        scanHint = nil
         runAction("Connect") {
             if let device = selectedDiscoveredDevice ?? discoveredDevices.first {
                 try mentraBluetoothSdk.connect(to: device)
@@ -636,10 +645,13 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
         discoveredDevices.removeAll()
         selectedDiscoveredDevice = nil
         selectedScanModel = model
+        scanHint = nil
         lastAction = "Selected scan model: \(deviceModelLabel(model))"
     }
 
     func connect(_ device: Device) {
+        scanSession?.stop()
+        scanHint = nil
         selectedDiscoveredDevice = device
         runAction("Connect \(device.name)") {
             try mentraBluetoothSdk.connect(to: device)
@@ -2182,6 +2194,7 @@ final class BluetoothViewModel: NSObject, ObservableObject, MentraBluetoothSDKDe
     }
 
     func mentraBluetoothSDK(_: MentraBluetoothSDK, didUpdateGlasses glasses: GlassesRuntimeState) {
+        if isGlassesConnected(glasses) { scanHint = nil }
         let wasConnected = glassesConnected
         if !glasses.connected || !wasConnected {
             latestVersionInfo = nil

--- a/examples/ios/MentraExample/DeviceScreen.swift
+++ b/examples/ios/MentraExample/DeviceScreen.swift
@@ -229,6 +229,11 @@ struct DeviceScreen: View {
                     enabled: false,
                     action: {}
                 )
+            } else if model.discoveredDevices.isEmpty, let hint = model.scanHint {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Glasses may be in use").font(.subheadline.weight(.semibold))
+                    Text(hint).font(.subheadline).foregroundStyle(AppColor.muted)
+                }
             } else if model.discoveredDevices.isEmpty, hasSavedConnectionTarget(model.bluetoothValues) {
                 TargetDeviceRow(
                     name: savedConnectionTargetName(model.bluetoothValues),

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.2.0-dev.180
+    exactVersion: 3.2.0-dev.181
 
 targets:
   MentraExample:

--- a/examples/macos/Package.swift
+++ b/examples/macos/Package.swift
@@ -2,7 +2,7 @@
 import Foundation
 import PackageDescription
 
-let sdkVersion = "3.2.0-dev.180"
+let sdkVersion = "3.2.0-dev.181"
 let sdk: Package.Dependency
 let sdkIdentity: String
 if let localPath = ProcessInfo.processInfo.environment["MENTRA_BLUETOOTH_SDK_PACKAGE_PATH"] {

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.181",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.181", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Z8fN2M5q34cQL98dVQdBpGGJXOnwHOsAvI4YZqzJ5TshhAvG5UYylqIGzRWYhqM5bRMQGS9bisZlmEZxcv/T7w=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.181",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-macos/bun.lock
+++ b/examples/react-native-macos/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-macos-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.181",
         "expo": "54.0.37",
         "react": "19.1.4",
         "react-native": "0.81.6",
@@ -297,7 +297,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.181", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Z8fN2M5q34cQL98dVQdBpGGJXOnwHOsAvI4YZqzJ5TshhAvG5UYylqIGzRWYhqM5bRMQGS9bisZlmEZxcv/T7w=="],
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 

--- a/examples/react-native-macos/package.json
+++ b/examples/react-native-macos/package.json
@@ -9,7 +9,7 @@
     "typecheck": "node typecheck.cjs"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.181",
     "expo": "54.0.37",
     "react": "19.1.4",
     "react-native": "0.81.6",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
-        "@mentra/engine": "3.2.0-dev.180",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.181",
+        "@mentra/engine": "3.2.0-dev.181",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -348,21 +348,21 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.180", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-3y2zveQNNixWxgTdvujVoxmGwxBETPn3sjM+XzLk9gpJiXjpAT79nB8HOfPoQbjSc3EqV0UUCMxoTBANW6Mt8Q=="],
+    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.181", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-hey9c/DSf6TIbHzrEDlMDBTGCX8e+1Jbq/opLw+OFAooFhWNwd70V4a5McdObDJK6l+OLSNcV/gXcPObjGLiqw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.181", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Z8fN2M5q34cQL98dVQdBpGGJXOnwHOsAvI4YZqzJ5TshhAvG5UYylqIGzRWYhqM5bRMQGS9bisZlmEZxcv/T7w=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.180", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.180", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-DW3LDdJSN4xBNriUn3Cvo3EXNRhh9wkHzr1HK01crVP6vxM8GwO5bNaHp4x1W5fTKQ+yt4J10we5HZ/cnGAUsQ=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.181", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.181", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-qmTOUEdClU/NNER5S2zdbMApjAO3UOcby014Rbva++ecB7TmjcUDTT/PLUSySvcVhhnSbncuyPYFX/p81lhLcw=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.180", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-lgHNH2GzTqXK+87BtwK2dDg/GDJUnHzzSnOZp33ffZRwql7VUB/QNnlmOVCsH/Dz9XuIhugnIWdX4x6RPYA97Q=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.181", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-EmMGLkTD7NhzW1c5Jjog6hVTE2hZuCUm7cnshrrtWJeu4RMadmVY1B3h7UGTVhVU3lR+We9demJuTeP8q+nYqQ=="],
 
-    "@mentra/crust": ["@mentra/crust@3.2.0-dev.180", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.180" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qAQv8hQ2LdhQWN87tR8VVt+jOirapQoMiAyX89TD/gUEzWInMp1oT1odA3yH7hVQgT534Gv7sDkN0QgnbIrPeg=="],
+    "@mentra/crust": ["@mentra/crust@3.2.0-dev.181", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.181" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-WVJ2xoxn87LEYth1WC/maSHcrXOEPrE2pLUfuyKEEIS6bb6eN4yCTrw60psbjzNyxPbDP7BJaDRYK++YinoQsw=="],
 
-    "@mentra/engine": ["@mentra/engine@3.2.0-dev.180", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.180", "@mentra/bluetooth-sdk": "3.2.0-dev.180", "@mentra/cloud-client": "3.2.0-dev.180", "@mentra/cloud-protocol": "3.2.0-dev.180", "@mentra/crust": "3.2.0-dev.180", "@mentra/miniapp": "3.2.0-dev.180", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-HeqWGzSXGBmD2Ep0zIG5MRGQ6lMXpNO3NGVD6A6eyVPkzFhHYeV+vn5+gcQy5NgrdsO7UyKKcRtq5J5FI/we0A=="],
+    "@mentra/engine": ["@mentra/engine@3.2.0-dev.181", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.181", "@mentra/bluetooth-sdk": "3.2.0-dev.181", "@mentra/cloud-client": "3.2.0-dev.181", "@mentra/cloud-protocol": "3.2.0-dev.181", "@mentra/crust": "3.2.0-dev.181", "@mentra/miniapp": "3.2.0-dev.181", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-ljCkWZSYQvjYLTBv1vVadnZd19bS369Qu9rjBzmEizXVWNoEG0Z8eP+k9jIF4Wa2W9Lfz106+DZjcRs/qikHOg=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.180", "", {}, "sha512-acVjQ8wIIkefa5Ky/wcAz7y1fmhJZZ96jeuIRLF+U/TMfo64dwxmMLtCDbzmLtGQA90OF9/7hXol6FmLG2iDsw=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.181", "", {}, "sha512-r+Z9ao7T06e28DQj28aysWXduppWgCe0SjUpynvDSW7QgQtO9Hz1jzpCW3EXQ/0mHOlCzlCZKHNrnCFjvLOhwg=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.180", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.180", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-FVRLfJL+DctHl7sX0CU/xz3ZD7ex4KweMEYZWFNT74VeYHRo1XRmOoDPq/m6jW2moKfneFvO3LjPV77JR0QmBQ=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.181", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.181", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-xGBm6vKD9yzIw/44u0d9ANJ3GfNcU4Fnu5AI46VPlR9yiBiZChKNAUU934QJUZuA8HHMZWf96YcxvlUKJvY7GA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
-    "@mentra/engine": "3.2.0-dev.180",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.181",
+    "@mentra/engine": "3.2.0-dev.181",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/screens/DeviceScreen.tsx
+++ b/examples/react-native/src/screens/DeviceScreen.tsx
@@ -375,6 +375,11 @@ function TargetPicker({ sdk, connected }: { sdk: BluetoothSdkExampleModel; conne
           selected={false}
           enabled={false}
         />
+      ) : sdk.discoveredDevices.length === 0 && sdk.scanHint ? (
+        <View accessibilityRole="alert">
+          <Text style={styles.targetName}>Glasses may be in use</Text>
+          <Text style={styles.targetDetail}>{sdk.scanHint}</Text>
+        </View>
       ) : sdk.discoveredDevices.length === 0 && savedName ? (
         <TargetDeviceRow
           name={savedName}

--- a/examples/react-native/src/useBluetoothSdkExample.ts
+++ b/examples/react-native/src/useBluetoothSdkExample.ts
@@ -392,6 +392,7 @@ export type BluetoothSdkExampleState = {
   cameraSettingsStatus: string;
   rawJsonExpanded: boolean;
   scanActive: boolean;
+  scanHint: string | null;
   selectedDiscoveredDevice: Device | null;
   selectedScanModel: ScanModel;
   directStreamReceiverRunning: boolean;
@@ -990,6 +991,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
 
   useEffect(() => {
     if (glassesConnected) {
+      if (bluetooth.scan.diagnostic) bluetooth.scan.clear();
       if (!wasConnectedRef.current && photoDestinationRef.current === 'glasses') {
         void prepareGlassesPhotoPreviewAction();
       }
@@ -1105,6 +1107,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       if (!(await ensureAndroidPermissions('connect'))) {
         throw new Error('Bluetooth permissions are required to connect.');
       }
+      await bluetooth.scan.stop();
       if (selectedDiscoveredDevice) {
         await bluetooth.connect(selectedDiscoveredDevice);
         return;
@@ -1126,6 +1129,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
       if (!(await ensureAndroidPermissions('connect'))) {
         throw new Error('Bluetooth permissions are required to connect.');
       }
+      await bluetooth.scan.stop();
       await bluetooth.connect(device);
     });
   }
@@ -3718,6 +3722,7 @@ export function useBluetoothSdkExample(options: BluetoothSdkExampleOptions = {})
     rawJsonExpanded,
     requestWifiScan,
     scanActive,
+    scanHint: bluetooth.scan.diagnostic?.message ?? null,
     selectDiscoveredDevice,
     selectLedColor,
     selectLedMode,


### PR DESCRIPTION
When an empty scan reports that matching glasses are already connected to the phone, show a “Glasses may be in use” hint in the native Android, native iOS, and React Native device pickers. Keep Scan available for retry and clear hints on retry, model changes, results, and connection actions.

The advisory identifies a matching phone connection; it does not identify another app or prove why the scan was empty. Normal empty scans remain successful and do not invoke an error callback.

Use SDK/engine `3.2.0-dev.181`, which contains MentraOS #3777. The npm packages, SwiftPM package, and both Maven artifacts are publicly available. The coordinated release pin update (#185) is merged.

Validation:
- React Native TypeScript check and 38 tests passed against the published npm packages.
- Native iOS unsigned iPhone example build passed against the published SwiftPM package.
- Native Android `:app:assembleDebug` passed against the public Maven artifacts, with local SDK overrides disabled.
- Remote example checks passed on `d32f85ddc629634bdc2ccd671f50b65414b4f92f`. The standalone Android CI compile was skipped while Maven propagated; the subsequent local public-Maven consumer build above passed.

Physical BLE validation and UI screenshots remain pending.
