### PR TITLE
Merge staging changes into dev with dev.180 prerelease pins

### DIFF
--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "beta",
-  "correlationId": "mentraos-34295058548",
-  "expectedStarterKitHead": "8980ddd469a634b81b71f2bf9195f6af75d621e5",
+  "correlationId": "mentraos-34393628192",
+  "expectedStarterKitHead": "985e4a1a109f5654041e091efb4f42359311b051",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34295058548",
-    "sourceCommit": "ea4baf4f6b2372c5cf3e6984759ccf40a4a8d94c"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34393628192",
+    "sourceCommit": "1812404e233d04293ad1fdbf3c46e417474ead5b"
   },
   "ota": {
-    "manifestSha256": "b1a66cd2040a5c87b343cd94616398d8e2d37293786cc852dd4ff9049491e4a2",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.171.json"
+    "manifestSha256": "b32b9211891a2f29c5f232159ddba9393139f77f623a55f7e06805240f7f9b2f",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.178.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
-    "@mentra/engine": "3.1.0-beta.171"
+    "@mentra/bluetooth-sdk": "3.1.0-beta.178",
+    "@mentra/engine": "3.1.0-beta.178"
   },
-  "releaseIdentity": "3.1.0-beta.171",
-  "releaseSetId": "mentra-3.1.0-beta.171",
+  "releaseIdentity": "3.1.0-beta.178",
+  "releaseSetId": "mentra-3.1.0-beta.178",
   "schemaVersion": 1
 }

--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "beta",
-  "correlationId": "mentraos-34287491624",
-  "expectedStarterKitHead": "70d2c84509d3f10397ad05521a73a4292de32eaa",
+  "correlationId": "mentraos-34295058548",
+  "expectedStarterKitHead": "8980ddd469a634b81b71f2bf9195f6af75d621e5",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34287491624",
-    "sourceCommit": "4b429bc36e827f56658c1c51f5248209fb05886f"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34295058548",
+    "sourceCommit": "ea4baf4f6b2372c5cf3e6984759ccf40a4a8d94c"
   },
   "ota": {
-    "manifestSha256": "2f3a546e6e8c6339e464b7032274d42d09c48a06111af746ecf8c7af3f583508",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.170.json"
+    "manifestSha256": "b1a66cd2040a5c87b343cd94616398d8e2d37293786cc852dd4ff9049491e4a2",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.171.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
-    "@mentra/engine": "3.1.0-beta.170"
+    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
+    "@mentra/engine": "3.1.0-beta.171"
   },
-  "releaseIdentity": "3.1.0-beta.170",
-  "releaseSetId": "mentra-3.1.0-beta.170",
+  "releaseIdentity": "3.1.0-beta.171",
+  "releaseSetId": "mentra-3.1.0-beta.171",
   "schemaVersion": 1
 }

--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "beta",
-  "correlationId": "mentraos-34277484270",
-  "expectedStarterKitHead": "3644fd2a60f11fb5dad47045efad002fa5f96f70",
+  "correlationId": "mentraos-34287491624",
+  "expectedStarterKitHead": "70d2c84509d3f10397ad05521a73a4292de32eaa",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34277484270",
-    "sourceCommit": "c3ad979a600aa6a879e2d41e73b46f2faa0467de"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34287491624",
+    "sourceCommit": "4b429bc36e827f56658c1c51f5248209fb05886f"
   },
   "ota": {
-    "manifestSha256": "f1b503b8e740d4a5ee9a816ed402bae6cce9821b8895409bebe6a1c506027b7f",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.169.json"
+    "manifestSha256": "2f3a546e6e8c6339e464b7032274d42d09c48a06111af746ecf8c7af3f583508",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.170.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
-    "@mentra/engine": "3.1.0-beta.169"
+    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
+    "@mentra/engine": "3.1.0-beta.170"
   },
-  "releaseIdentity": "3.1.0-beta.169",
-  "releaseSetId": "mentra-3.1.0-beta.169",
+  "releaseIdentity": "3.1.0-beta.170",
+  "releaseSetId": "mentra-3.1.0-beta.170",
   "schemaVersion": 1
 }

--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "dev",
-  "correlationId": "mentraos-34303491114",
-  "expectedStarterKitHead": "d3f5fadfa44ae0c0100ebe80dd98156830323c17",
+  "correlationId": "mentraos-34401207582",
+  "expectedStarterKitHead": "34c13adc3f0292e28db7ae7f76062d35c6fc1dbb",
   "familyBaseVersion": "3.2.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34303491114",
-    "sourceCommit": "333e6c36f33855ce6db6c192d677c36bd6316c3f"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34401207582",
+    "sourceCommit": "1f24e462561fef37b7082204847a541db4a87c41"
   },
   "ota": {
-    "manifestSha256": "2bde3826947a1416081eeab114f207cb182d1a1e31f43c2a6212eb1865e5ba0c",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.2.0/mentra-live-ota-3.2.0-dev.177.json"
+    "manifestSha256": "cbf2a1b81430bd34942e2a1764138f6d79197767b4434a2d8c44311768f8b873",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.2.0/mentra-live-ota-3.2.0-dev.180.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.177",
-    "@mentra/engine": "3.2.0-dev.177"
+    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+    "@mentra/engine": "3.2.0-dev.180"
   },
-  "releaseIdentity": "3.2.0-dev.177",
-  "releaseSetId": "mentra-3.2.0-dev.177",
+  "releaseIdentity": "3.2.0-dev.180",
+  "releaseSetId": "mentra-3.2.0-dev.180",
   "schemaVersion": 1
 }

--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "beta",
-  "correlationId": "mentraos-34224625329",
-  "expectedStarterKitHead": "3a11ca39883e4d6dea6d77487b6f32d72c2ecdce",
+  "correlationId": "mentraos-34277484270",
+  "expectedStarterKitHead": "3644fd2a60f11fb5dad47045efad002fa5f96f70",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34224625329",
-    "sourceCommit": "cedbd0ae6a783a7d55e0526fd3a49dcd6f5b01cc"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34277484270",
+    "sourceCommit": "c3ad979a600aa6a879e2d41e73b46f2faa0467de"
   },
   "ota": {
-    "manifestSha256": "e125a20beb4c400ecad163d059da65b14390acf809b6f0d074fd874bfd7b59be",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.166.json"
+    "manifestSha256": "f1b503b8e740d4a5ee9a816ed402bae6cce9821b8895409bebe6a1c506027b7f",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.169.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
-    "@mentra/engine": "3.1.0-beta.166"
+    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
+    "@mentra/engine": "3.1.0-beta.169"
   },
-  "releaseIdentity": "3.1.0-beta.166",
-  "releaseSetId": "mentra-3.1.0-beta.166",
+  "releaseIdentity": "3.1.0-beta.169",
+  "releaseSetId": "mentra-3.1.0-beta.169",
   "schemaVersion": 1
 }

--- a/.github/coordinated-example-release.json
+++ b/.github/coordinated-example-release.json
@@ -1,21 +1,21 @@
 {
   "channel": "beta",
-  "correlationId": "mentraos-34215794395",
-  "expectedStarterKitHead": "da1f83322383c5c6b72bb9912b0ef7a686cc647d",
+  "correlationId": "mentraos-34224625329",
+  "expectedStarterKitHead": "3a11ca39883e4d6dea6d77487b6f32d72c2ecdce",
   "familyBaseVersion": "3.1.0",
   "mentraos": {
-    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34215794395",
-    "sourceCommit": "5b18e3344af3c4eca959f6056b3cdd841872ab04"
+    "coordinatorRunUrl": "https://github.com/Mentra-Community/MentraOS/actions/runs/34224625329",
+    "sourceCommit": "cedbd0ae6a783a7d55e0526fd3a49dcd6f5b01cc"
   },
   "ota": {
-    "manifestSha256": "f6a7089cde3090c1a08b7d45ba269ac6d6a104ace6f952dbef7c79db14b5d0b6",
-    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.164.json"
+    "manifestSha256": "e125a20beb4c400ecad163d059da65b14390acf809b6f0d074fd874bfd7b59be",
+    "manifestUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/mentra-builds-v3.1.0/mentra-live-ota-3.1.0-beta.166.json"
   },
   "packages": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.164",
-    "@mentra/engine": "3.1.0-beta.164"
+    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
+    "@mentra/engine": "3.1.0-beta.166"
   },
-  "releaseIdentity": "3.1.0-beta.164",
-  "releaseSetId": "mentra-3.1.0-beta.164",
+  "releaseIdentity": "3.1.0-beta.166",
+  "releaseSetId": "mentra-3.1.0-beta.166",
   "schemaVersion": 1
 }

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-beta.164
+mentraSdkVersion=3.1.0-beta.166

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-beta.169
+mentraSdkVersion=3.1.0-beta.170

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.2.0-dev.177
+mentraSdkVersion=3.2.0-dev.180

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-beta.166
+mentraSdkVersion=3.1.0-beta.169

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-beta.171
+mentraSdkVersion=3.1.0-beta.178

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-mentraSdkVersion=3.1.0-beta.170
+mentraSdkVersion=3.1.0-beta.171

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-beta.166;
+				version = 3.1.0-beta.169;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-beta.171;
+				version = 3.1.0-beta.178;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-beta.169;
+				version = 3.1.0-beta.170;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.2.0-dev.177;
+				version = 3.2.0-dev.180;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-beta.164;
+				version = 3.1.0-beta.166;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/MentraExample.xcodeproj/project.pbxproj
+++ b/examples/ios/MentraExample.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 			repositoryURL = "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.1.0-beta.170;
+				version = 3.1.0-beta.171;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.2.0-dev.177
+    exactVersion: 3.2.0-dev.180
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-beta.171
+    exactVersion: 3.1.0-beta.178
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-beta.166
+    exactVersion: 3.1.0-beta.169
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-beta.169
+    exactVersion: 3.1.0-beta.170
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-beta.164
+    exactVersion: 3.1.0-beta.166
 
 targets:
   MentraExample:

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -23,7 +23,7 @@ settings:
 packages:
   MentraBluetoothSDK:
     url: https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
-    exactVersion: 3.1.0-beta.170
+    exactVersion: 3.1.0-beta.171
 
 targets:
   MentraExample:

--- a/examples/macos/Package.swift
+++ b/examples/macos/Package.swift
@@ -2,7 +2,7 @@
 import Foundation
 import PackageDescription
 
-let sdkVersion = "3.2.0-dev.177"
+let sdkVersion = "3.2.0-dev.180"
 let sdk: Package.Dependency
 let sdkIdentity: String
 if let localPath = ProcessInfo.processInfo.environment["MENTRA_BLUETOOTH_SDK_PACKAGE_PATH"] {

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.169",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.170",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.169", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-gNLEvtrRi90/lJjnXk1Kq3ykW8RRriVbXzzcjJUAjo7lu6rJ6xycyxu6ZobuHy22Y0ZGeKR6HI5V6j5aB27OZQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.170", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-CHNG5s/AvpJo0qBmPLMmYGNChrw5YCsLhczw6gVYwClQRtNRdvaHbX1/UnDCg0dYH+R2yFiVvkU+0lTWoZefAA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.166",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.169",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.166", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-W+cNUmsBwJ1NBMPTxAFrL81amgdfl9wY07WfrV+FXdrolw6+TgB/dCwAt9FallvMFQ54Azmp5qcbO+KhaTDS8g=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.169", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-gNLEvtrRi90/lJjnXk1Kq3ykW8RRriVbXzzcjJUAjo7lu6rJ6xycyxu6ZobuHy22Y0ZGeKR6HI5V6j5aB27OZQ=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.177",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.177", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Ap5bn4/fpOffDu6rkA0QOUH6eMIqHfAD1YFd0ygDyXSGuuUa1Rd0qsQhRJgTV+KvRY1qskcIUvWGI3RVbg/WzA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.164",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.166",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.164", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-i+XOKGqpfjMeAghEhsvaoFHMQ2/i5M6L/ZFNDO7kwmzBzrVehmc7FjF9SM46gE8rzccK3jb2GCFq8EdR0UDZaQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.166", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-W+cNUmsBwJ1NBMPTxAFrL81amgdfl9wY07WfrV+FXdrolw6+TgB/dCwAt9FallvMFQ54Azmp5qcbO+KhaTDS8g=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.170",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.171",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.170", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-CHNG5s/AvpJo0qBmPLMmYGNChrw5YCsLhczw6gVYwClQRtNRdvaHbX1/UnDCg0dYH+R2yFiVvkU+0lTWoZefAA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.171", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-OO5u7pN0QF0JeOX0UnTLk0BWOSdpygGAlneLnLVOUQgc9yLaxn9+8qDaK2hPKbsY6+DY8qPsMPNynNIb46tDXA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/bun.lock
+++ b/examples/react-native-elevenlabs-audio/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-elevenlabs-audio-repro",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.171",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.178",
         "expo": "~55.0.24",
         "expo-build-properties": "~55.0.14",
         "expo-dev-client": "~55.0.34",
@@ -290,7 +290,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.171", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-OO5u7pN0QF0JeOX0UnTLk0BWOSdpygGAlneLnLVOUQgc9yLaxn9+8qDaK2hPKbsY6+DY8qPsMPNynNIb46tDXA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.178", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-K592KPtwMD24PEaObp00HJsnlKBaJcctVNcxZHvw5wvmRoFRHVaf2ycsjoOYvGOF6CaK3k8Dq0idm4NA45+FWA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.83.6", "", {}, "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg=="],
 

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.177",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.178",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.164",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-elevenlabs-audio/package.json
+++ b/examples/react-native-elevenlabs-audio/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
     "expo": "~55.0.24",
     "expo-build-properties": "~55.0.14",
     "expo-dev-client": "~55.0.34",

--- a/examples/react-native-macos/bun.lock
+++ b/examples/react-native-macos/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mentra-bluetooth-sdk-macos-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.177",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
         "expo": "54.0.37",
         "react": "19.1.4",
         "react-native": "0.81.6",
@@ -297,7 +297,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.177", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Ap5bn4/fpOffDu6rkA0QOUH6eMIqHfAD1YFd0ygDyXSGuuUa1Rd0qsQhRJgTV+KvRY1qskcIUvWGI3RVbg/WzA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 

--- a/examples/react-native-macos/package.json
+++ b/examples/react-native-macos/package.json
@@ -9,7 +9,7 @@
     "typecheck": "node typecheck.cjs"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.177",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
     "expo": "54.0.37",
     "react": "19.1.4",
     "react-native": "0.81.6",

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.169",
-        "@mentra/engine": "3.1.0-beta.169",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.170",
+        "@mentra/engine": "3.1.0-beta.170",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -346,19 +346,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.169", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-gNLEvtrRi90/lJjnXk1Kq3ykW8RRriVbXzzcjJUAjo7lu6rJ6xycyxu6ZobuHy22Y0ZGeKR6HI5V6j5aB27OZQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.170", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-CHNG5s/AvpJo0qBmPLMmYGNChrw5YCsLhczw6gVYwClQRtNRdvaHbX1/UnDCg0dYH+R2yFiVvkU+0lTWoZefAA=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.169", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.169", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-Roe6mQS/MWm8hPw+15GbrzHSmVEFCN4BX0Ses/wGjNL/zGRXBRqFh713yUhz430YWMU7znU5rw6oYFBkLpZtXw=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.170", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.170", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-CIsloRFRvPjcS8xfls07N5kGCUulvLJvwr2kmmlyYvVWDLI2ySWEiZFC8EK0Eslx5WBqSPKKkxHFRcW9zICOQA=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.169", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-DzO48qM2U/qajy+6JpIp1bXPjl+2C7qGFP/GNFMrZNbHMLevu9HPQFfbR59ZH77FjF9R+mqPmPn0GvdVyTQW1w=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.170", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-QE8IPVGumX/+p+qVf5gMqUnJKVVVr1lyBEPuXOd+P+IKWr1Wte4fddsksPcURa4GXoqj71YLeKbCCPZaY+/4BA=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-beta.169", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.169" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-+TN4eVjgihZs6OM/1D12oIm66hidnobNNJF0OYpsPgVQiCBKL5JP1YseacFH7/ab5Z5R0VPjU/y5kODByZG39w=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-beta.170", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.170" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-cONGEVKupQwUu28Qmp2yGLkOJVOXlPuKOcr54ek9QwBL4wvoS5tQDu9um2vdNWuJUu8ChtrduriS6nc5j/uiQQ=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-beta.169", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.169", "@mentra/cloud-client": "3.1.0-beta.169", "@mentra/cloud-protocol": "3.1.0-beta.169", "@mentra/crust": "3.1.0-beta.169", "@mentra/miniapp": "3.1.0-beta.169", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-sRfS4tn45vkld1gVMfjavUCObe5U/Tc6D7PtRazNWFZMqIXErDEu2tFSvTzjSKDWbjn/x5gOzxijIpXkWjbtPw=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-beta.170", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.170", "@mentra/cloud-client": "3.1.0-beta.170", "@mentra/cloud-protocol": "3.1.0-beta.170", "@mentra/crust": "3.1.0-beta.170", "@mentra/miniapp": "3.1.0-beta.170", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-3i4YmJrYEFR7kfnLPvrq+pJVFO3De2XMm8fimrlgSx1zx5pc1kXSW4FBT2+7m1bt1XSSyZ0prHh5fzdx4qz8eA=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.169", "", {}, "sha512-khqFc2/egBziX9C9DrRQv21cLUjhDnlBV3gpVCjSarmBDiDJebStjnnRjwjV/q+tiiieoSVAJw7pwPXBUtERIg=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.170", "", {}, "sha512-AqlLgFHdbMNxFk/7FIzKx77vpmkjVealXOlX6yHXJkKp+pPahdt6TUMmQ4BjfI6pZX+ZfWcuXJSS/TPa4rC3vQ=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.169", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.169", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-RueIzUW0WJZK34XNQIO3xPFNUNaziBXg74ix+lzFoKWzu/Xuqyat33V9XuffpJL5eWPYg1nh0gwscD6VqkPnjg=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.170", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.170", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-v7PJeUhnEXXOOuGerQIix/lAnIDJ6MaamZwzSI27XFl5hCOYk5UH0Vc9cSA+lN8fOvsBlE6NNcjFnFg2WvT1qA=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.164",
-        "@mentra/engine": "3.1.0-beta.164",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.166",
+        "@mentra/engine": "3.1.0-beta.166",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -346,19 +346,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.164", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-i+XOKGqpfjMeAghEhsvaoFHMQ2/i5M6L/ZFNDO7kwmzBzrVehmc7FjF9SM46gE8rzccK3jb2GCFq8EdR0UDZaQ=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.166", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-W+cNUmsBwJ1NBMPTxAFrL81amgdfl9wY07WfrV+FXdrolw6+TgB/dCwAt9FallvMFQ54Azmp5qcbO+KhaTDS8g=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.164", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.164", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-BhkrcXwGpXQGaSzs2Mgnl6F2J7vTnV9qd+9xffGNVqbwBdqZqglhCjWLAIj2xbtQWPsdUO/Dvdqcu7/HnMiXvw=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.166", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.166", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-6ncysVigaX5ztVGAfmXWG6VpfKrPu7cMi/OkdQud++a7iUi2Dmrjeg1ESzOJMgyUobU0+qPeT40qtyE3nAWhkg=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.164", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-JuPj2gtZPNvwyhiNeOkPFwZ9q/Ne1pswykEx4aSy+gzN37uYJzzoN+9wZswg/bzmXTkHvkBEPD6nZxpBSLLdiw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.166", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-cqZBhRgciayV3P/IXJUwJm2z4nsrb/iKV4SAJ55xzWZd7rEr248WYDJDSiXERalehWaULzY5XBftNgSfXy1Hxw=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-beta.164", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.164" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-wfITR6ZEwrYIIjvwC6ui6PcBO60XEGuNBqLSQBLs24pCrIBYeFcRtWZEPfJg/dp8Nm6DiF9yhNRNe6vOFS+Ekw=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-beta.166", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.166" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-cfZQb4FnMQft0czxG1UEHW7xq/2y/1BUS+IxBz/eFIp64KKQbMRfTGWRWlbI4YX0kggzM07D+z7CzPxndOS8Vw=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-beta.164", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.164", "@mentra/cloud-client": "3.1.0-beta.164", "@mentra/cloud-protocol": "3.1.0-beta.164", "@mentra/crust": "3.1.0-beta.164", "@mentra/miniapp": "3.1.0-beta.164", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-xdolc0ZflZZ3KLkPVA05qMuoRnPIpF9I1/UCKN0QDLpwdHTgeq2G30MR6jWyrD/MhPN9uTd6jVT773HSGhVJ5Q=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-beta.166", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.166", "@mentra/cloud-client": "3.1.0-beta.166", "@mentra/cloud-protocol": "3.1.0-beta.166", "@mentra/crust": "3.1.0-beta.166", "@mentra/miniapp": "3.1.0-beta.166", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-QLkOc0mDPNC6wanQ6zRu0vebg5xMUK1xsE9WiRK/cYK7gtxXC8lJOqrYIcKXWJiJJYMlGawATKuPfVexbWbWTQ=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.164", "", {}, "sha512-xAXkcr5uM7Y42x43cHZ72ECe6RtJuV/h7HAH6qYEqxwW9njRN4IzYz1+lOUlDCGgrNf8AAQUFD9LBDav58fo0g=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.166", "", {}, "sha512-vQI2MN125oIVpng5xngZoTweVIqM2YaHX/KAFq8men07w3QzBlpaikHZEENvJZyGzcNAY9wyKh5F0jnfheOupg=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.164", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.164", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-o+JQeKJzWD5E4vJInyvev+61sMUSEyp7Cyt4QcZPweI2mtavqlT+6gkafot6Z64JkOlJlmbpjPfdoOjzkBBv2Q=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.166", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.166", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Hk0bz63SDM8WTjFIwUn4Kgr9gV9ltF6bL8jZtn6dKZ5XSLbiDuSe2WNQz8EKkMja6Jyt6fbz+Iy4SKZW3TFxRg=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.166",
-        "@mentra/engine": "3.1.0-beta.166",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.169",
+        "@mentra/engine": "3.1.0-beta.169",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -346,19 +346,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.166", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-W+cNUmsBwJ1NBMPTxAFrL81amgdfl9wY07WfrV+FXdrolw6+TgB/dCwAt9FallvMFQ54Azmp5qcbO+KhaTDS8g=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.169", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-gNLEvtrRi90/lJjnXk1Kq3ykW8RRriVbXzzcjJUAjo7lu6rJ6xycyxu6ZobuHy22Y0ZGeKR6HI5V6j5aB27OZQ=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.166", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.166", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-6ncysVigaX5ztVGAfmXWG6VpfKrPu7cMi/OkdQud++a7iUi2Dmrjeg1ESzOJMgyUobU0+qPeT40qtyE3nAWhkg=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.169", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.169", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-Roe6mQS/MWm8hPw+15GbrzHSmVEFCN4BX0Ses/wGjNL/zGRXBRqFh713yUhz430YWMU7znU5rw6oYFBkLpZtXw=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.166", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-cqZBhRgciayV3P/IXJUwJm2z4nsrb/iKV4SAJ55xzWZd7rEr248WYDJDSiXERalehWaULzY5XBftNgSfXy1Hxw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.169", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-DzO48qM2U/qajy+6JpIp1bXPjl+2C7qGFP/GNFMrZNbHMLevu9HPQFfbR59ZH77FjF9R+mqPmPn0GvdVyTQW1w=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-beta.166", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.166" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-cfZQb4FnMQft0czxG1UEHW7xq/2y/1BUS+IxBz/eFIp64KKQbMRfTGWRWlbI4YX0kggzM07D+z7CzPxndOS8Vw=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-beta.169", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.169" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-+TN4eVjgihZs6OM/1D12oIm66hidnobNNJF0OYpsPgVQiCBKL5JP1YseacFH7/ab5Z5R0VPjU/y5kODByZG39w=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-beta.166", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.166", "@mentra/cloud-client": "3.1.0-beta.166", "@mentra/cloud-protocol": "3.1.0-beta.166", "@mentra/crust": "3.1.0-beta.166", "@mentra/miniapp": "3.1.0-beta.166", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-QLkOc0mDPNC6wanQ6zRu0vebg5xMUK1xsE9WiRK/cYK7gtxXC8lJOqrYIcKXWJiJJYMlGawATKuPfVexbWbWTQ=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-beta.169", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.169", "@mentra/cloud-client": "3.1.0-beta.169", "@mentra/cloud-protocol": "3.1.0-beta.169", "@mentra/crust": "3.1.0-beta.169", "@mentra/miniapp": "3.1.0-beta.169", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-sRfS4tn45vkld1gVMfjavUCObe5U/Tc6D7PtRazNWFZMqIXErDEu2tFSvTzjSKDWbjn/x5gOzxijIpXkWjbtPw=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.166", "", {}, "sha512-vQI2MN125oIVpng5xngZoTweVIqM2YaHX/KAFq8men07w3QzBlpaikHZEENvJZyGzcNAY9wyKh5F0jnfheOupg=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.169", "", {}, "sha512-khqFc2/egBziX9C9DrRQv21cLUjhDnlBV3gpVCjSarmBDiDJebStjnnRjwjV/q+tiiieoSVAJw7pwPXBUtERIg=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.166", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.166", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-Hk0bz63SDM8WTjFIwUn4Kgr9gV9ltF6bL8jZtn6dKZ5XSLbiDuSe2WNQz8EKkMja6Jyt6fbz+Iy4SKZW3TFxRg=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.169", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.169", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-RueIzUW0WJZK34XNQIO3xPFNUNaziBXg74ix+lzFoKWzu/Xuqyat33V9XuffpJL5eWPYg1nh0gwscD6VqkPnjg=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.177",
-        "@mentra/engine": "3.2.0-dev.177",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+        "@mentra/engine": "3.2.0-dev.180",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -348,21 +348,21 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.177", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-J7JqPo3fcrnk8R1DE3HOP2AjNaPSKgZBuawNTcuDAkSeZXCWUmIIAcmsLqZwxl17RjH31YppU5mJQmEKorKMJg=="],
+    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.180", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-3y2zveQNNixWxgTdvujVoxmGwxBETPn3sjM+XzLk9gpJiXjpAT79nB8HOfPoQbjSc3EqV0UUCMxoTBANW6Mt8Q=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.177", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-Ap5bn4/fpOffDu6rkA0QOUH6eMIqHfAD1YFd0ygDyXSGuuUa1Rd0qsQhRJgTV+KvRY1qskcIUvWGI3RVbg/WzA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.180", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-7MOXVoR72pbJcs9dQJSFULFR4vNt34Uxtf0rB+efIOXNQJa+S37g+aBZJ22zWR+Btm2iCS8XaVw8yMIJewBzaw=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.177", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.177", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-nBtMD6XioXWeebZxV+bNdSsqJDLnrNc33Q3pOMzgiN2xrCVaiTmGn9PLUSDW33vsX0wAKi9XmK6TWk0qXDVqiA=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.180", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.180", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-DW3LDdJSN4xBNriUn3Cvo3EXNRhh9wkHzr1HK01crVP6vxM8GwO5bNaHp4x1W5fTKQ+yt4J10we5HZ/cnGAUsQ=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.177", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-kE5Ot7ZlA7NNPJf23ylV6kaX6fTFLxb6QqJ1UZUvYcL2b/WK4z0SNp8tkTYw1SnFwiRCSLYASpStqdWFA7cLVw=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.180", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-lgHNH2GzTqXK+87BtwK2dDg/GDJUnHzzSnOZp33ffZRwql7VUB/QNnlmOVCsH/Dz9XuIhugnIWdX4x6RPYA97Q=="],
 
-    "@mentra/crust": ["@mentra/crust@3.2.0-dev.177", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.177" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-LP40U/R0v0rT5W/ykOjUbj2uDdCUAHE9Q13vcZ4T+P0wR38UsPlMroM2Q1BuP0ipwm9Q8cXHmVcfVN/nWZa7Fw=="],
+    "@mentra/crust": ["@mentra/crust@3.2.0-dev.180", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.180" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qAQv8hQ2LdhQWN87tR8VVt+jOirapQoMiAyX89TD/gUEzWInMp1oT1odA3yH7hVQgT534Gv7sDkN0QgnbIrPeg=="],
 
-    "@mentra/engine": ["@mentra/engine@3.2.0-dev.177", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.177", "@mentra/bluetooth-sdk": "3.2.0-dev.177", "@mentra/cloud-client": "3.2.0-dev.177", "@mentra/cloud-protocol": "3.2.0-dev.177", "@mentra/crust": "3.2.0-dev.177", "@mentra/miniapp": "3.2.0-dev.177", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-QauhDVBIuTRuDTU4WF9t6rveBwCB3OJA8lYx02YOlLR4bnMNBcRRdzFnV2/QMqfBaywqUira8zWkKTlgOLN+GA=="],
+    "@mentra/engine": ["@mentra/engine@3.2.0-dev.180", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.180", "@mentra/bluetooth-sdk": "3.2.0-dev.180", "@mentra/cloud-client": "3.2.0-dev.180", "@mentra/cloud-protocol": "3.2.0-dev.180", "@mentra/crust": "3.2.0-dev.180", "@mentra/miniapp": "3.2.0-dev.180", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-HeqWGzSXGBmD2Ep0zIG5MRGQ6lMXpNO3NGVD6A6eyVPkzFhHYeV+vn5+gcQy5NgrdsO7UyKKcRtq5J5FI/we0A=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.177", "", {}, "sha512-VWXgEoA9ha1EBa1dkEyRIfp8mo/U5NyCe1oUiQuvrawJT/rsu9iBvriU1Xu3n3hbqX33OnprWK2BLGuLLC4aMA=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.180", "", {}, "sha512-acVjQ8wIIkefa5Ky/wcAz7y1fmhJZZ96jeuIRLF+U/TMfo64dwxmMLtCDbzmLtGQA90OF9/7hXol6FmLG2iDsw=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.177", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.177", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-SUfwmUc4wLV+8/5QsPdnJ/HrkrbwrUR+SLP1+jrbuuAF4Zgteyyo7URw/5f9aAoGG5SK/FHNryxhsinJVJas1Q=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.180", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.180", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-FVRLfJL+DctHl7sX0CU/xz3ZD7ex4KweMEYZWFNT74VeYHRo1XRmOoDPq/m6jW2moKfneFvO3LjPV77JR0QmBQ=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.170",
-        "@mentra/engine": "3.1.0-beta.170",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.171",
+        "@mentra/engine": "3.1.0-beta.171",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -346,19 +346,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.170", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-CHNG5s/AvpJo0qBmPLMmYGNChrw5YCsLhczw6gVYwClQRtNRdvaHbX1/UnDCg0dYH+R2yFiVvkU+0lTWoZefAA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.171", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-OO5u7pN0QF0JeOX0UnTLk0BWOSdpygGAlneLnLVOUQgc9yLaxn9+8qDaK2hPKbsY6+DY8qPsMPNynNIb46tDXA=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.170", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.170", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-CIsloRFRvPjcS8xfls07N5kGCUulvLJvwr2kmmlyYvVWDLI2ySWEiZFC8EK0Eslx5WBqSPKKkxHFRcW9zICOQA=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.171", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.171", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-HUIXDoKM/j1EyDqQ2A6OuvlRwVhyg53jiIIgt/5hqzlQIc7BrtV78JZ5VTe5pPUAGX3JdXUjC1yTa4qK3U/VkA=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.170", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-QE8IPVGumX/+p+qVf5gMqUnJKVVVr1lyBEPuXOd+P+IKWr1Wte4fddsksPcURa4GXoqj71YLeKbCCPZaY+/4BA=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.171", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-TWwHCGNt1qRqvLGOgjYGLCJsq84gBRcRX2w4qlsDOiVRsXITehsbVgql7yLH1Fj4S5A0eEaXyNK+jRN8Ea5iTg=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-beta.170", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.170" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-cONGEVKupQwUu28Qmp2yGLkOJVOXlPuKOcr54ek9QwBL4wvoS5tQDu9um2vdNWuJUu8ChtrduriS6nc5j/uiQQ=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-beta.171", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.171" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-42PTALBREF7j4bmnzVW8hqBIBrCjbU3PQ6tR2uWNwx38jYz3d6ph9q0oWacX0rexyPX3D/8rMh0t8tILa0EAWw=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-beta.170", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.170", "@mentra/cloud-client": "3.1.0-beta.170", "@mentra/cloud-protocol": "3.1.0-beta.170", "@mentra/crust": "3.1.0-beta.170", "@mentra/miniapp": "3.1.0-beta.170", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-3i4YmJrYEFR7kfnLPvrq+pJVFO3De2XMm8fimrlgSx1zx5pc1kXSW4FBT2+7m1bt1XSSyZ0prHh5fzdx4qz8eA=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-beta.171", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.171", "@mentra/cloud-client": "3.1.0-beta.171", "@mentra/cloud-protocol": "3.1.0-beta.171", "@mentra/crust": "3.1.0-beta.171", "@mentra/miniapp": "3.1.0-beta.171", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-PBmVXCRuzmqQQjUAw3hPQGlw5zSpOh02flDHbFUqo0tgY6wMxdcJo70z0OdS+IXWjCCVcVmRy2FBKMIEG52eUw=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.170", "", {}, "sha512-AqlLgFHdbMNxFk/7FIzKx77vpmkjVealXOlX6yHXJkKp+pPahdt6TUMmQ4BjfI6pZX+ZfWcuXJSS/TPa4rC3vQ=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.171", "", {}, "sha512-UUH6lhRPYM+E6/JxHawiB1RqtWKQ14kQYNhhE1W0+xvY+NLFbpewXB1C3u2HHcWwwru9CtcBRf7pRmKcyl+xeA=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.170", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.170", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-v7PJeUhnEXXOOuGerQIix/lAnIDJ6MaamZwzSI27XFl5hCOYk5UH0Vc9cSA+lN8fOvsBlE6NNcjFnFg2WvT1qA=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.171", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.171", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-EFoD5JVdjTR4xuX5neWDAWmpZHSbuNYDRXD9IP9TmDLVab6SQnmu0Bm6rhVIXXKtm9W4JQGrPFQkRHgzh4OHmQ=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.1.0-beta.171",
-        "@mentra/engine": "3.1.0-beta.171",
+        "@mentra/bluetooth-sdk": "3.1.0-beta.178",
+        "@mentra/engine": "3.1.0-beta.178",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -346,19 +346,19 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.171", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-OO5u7pN0QF0JeOX0UnTLk0BWOSdpygGAlneLnLVOUQgc9yLaxn9+8qDaK2hPKbsY6+DY8qPsMPNynNIb46tDXA=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.1.0-beta.178", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-K592KPtwMD24PEaObp00HJsnlKBaJcctVNcxZHvw5wvmRoFRHVaf2ycsjoOYvGOF6CaK3k8Dq0idm4NA45+FWA=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.171", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.171", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-HUIXDoKM/j1EyDqQ2A6OuvlRwVhyg53jiIIgt/5hqzlQIc7BrtV78JZ5VTe5pPUAGX3JdXUjC1yTa4qK3U/VkA=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.1.0-beta.178", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.178", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-40isDhfQjIWwEf1ZybPm/wXNZ4NvxwC/rp2eRHLXnzh1uF312B/VO/Llf2XpSL7eFR2p0h/cS25qa0AkCWqsWA=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.171", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-TWwHCGNt1qRqvLGOgjYGLCJsq84gBRcRX2w4qlsDOiVRsXITehsbVgql7yLH1Fj4S5A0eEaXyNK+jRN8Ea5iTg=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.1.0-beta.178", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-pp15De77ejycL18rpqhAvDIVsecnAUX8LAIDyWAYs3y4jKzD8P6Idf2mFOZsEI7rvdoJT7ybP3jMo8ai+Q4c1A=="],
 
-    "@mentra/crust": ["@mentra/crust@3.1.0-beta.171", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.171" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-42PTALBREF7j4bmnzVW8hqBIBrCjbU3PQ6tR2uWNwx38jYz3d6ph9q0oWacX0rexyPX3D/8rMh0t8tILa0EAWw=="],
+    "@mentra/crust": ["@mentra/crust@3.1.0-beta.178", "", { "dependencies": { "@mentra/jspolyfill": "3.1.0-beta.178" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qe57oOTl9S8ksHiW5oNNhdbGTQY9BoAkX/Gp5Cs8Oh7hajmnbXnDjka0hpBO7jijWqXQh9TIAjJY5mnIx1sk1A=="],
 
-    "@mentra/engine": ["@mentra/engine@3.1.0-beta.171", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.171", "@mentra/cloud-client": "3.1.0-beta.171", "@mentra/cloud-protocol": "3.1.0-beta.171", "@mentra/crust": "3.1.0-beta.171", "@mentra/miniapp": "3.1.0-beta.171", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-PBmVXCRuzmqQQjUAw3hPQGlw5zSpOh02flDHbFUqo0tgY6wMxdcJo70z0OdS+IXWjCCVcVmRy2FBKMIEG52eUw=="],
+    "@mentra/engine": ["@mentra/engine@3.1.0-beta.178", "", { "dependencies": { "@mentra/bluetooth-sdk": "3.1.0-beta.178", "@mentra/cloud-client": "3.1.0-beta.178", "@mentra/cloud-protocol": "3.1.0-beta.178", "@mentra/crust": "3.1.0-beta.178", "@mentra/miniapp": "3.1.0-beta.178", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-hGDg6Yutlg4w+AGAYrQ7dkDM39208fdoBk1KGWazKeVdQy/PnAPf9maqPqIY/tFIxk16Fhsu+Us972FOwUVSJg=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.171", "", {}, "sha512-UUH6lhRPYM+E6/JxHawiB1RqtWKQ14kQYNhhE1W0+xvY+NLFbpewXB1C3u2HHcWwwru9CtcBRf7pRmKcyl+xeA=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.1.0-beta.178", "", {}, "sha512-znNqk/2yyskgiGYvVYv93pTTbDX9bOxtVait0revpDiv5cQGVBvex6UfVMd/q0PxKYMtKMNAKxnSBDaTIxJJ0A=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.171", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.171", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-EFoD5JVdjTR4xuX5neWDAWmpZHSbuNYDRXD9IP9TmDLVab6SQnmu0Bm6rhVIXXKtm9W4JQGrPFQkRHgzh4OHmQ=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.1.0-beta.178", "", { "dependencies": { "@mentra/cloud-protocol": "3.1.0-beta.178", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-B3k6VsGzjUNQP8Wy1zxOQtTug7qzeJ4ubHQuwEbTbaHnHVRems3cPxSGFQjBXuH4osbhIS52x+5nGfWi2ci9Uw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
-    "@mentra/engine": "3.1.0-beta.169",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
+    "@mentra/engine": "3.1.0-beta.170",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.164",
-    "@mentra/engine": "3.1.0-beta.164",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
+    "@mentra/engine": "3.1.0-beta.166",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.166",
-    "@mentra/engine": "3.1.0-beta.166",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.169",
+    "@mentra/engine": "3.1.0-beta.169",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.170",
-    "@mentra/engine": "3.1.0-beta.170",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
+    "@mentra/engine": "3.1.0-beta.171",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.1.0-beta.171",
-    "@mentra/engine": "3.1.0-beta.171",
+    "@mentra/bluetooth-sdk": "3.1.0-beta.178",
+    "@mentra/engine": "3.1.0-beta.178",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.177",
-    "@mentra/engine": "3.2.0-dev.177",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.180",
+    "@mentra/engine": "3.2.0-dev.180",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Keyboard, Platform, View, StyleSheet, StatusBar } from 'react-native';
+import { Keyboard, Platform, Pressable, Text, View, StyleSheet, StatusBar } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardVisibleContext } from './components/keyboardLayout';
 import { TabBar, TabKey } from './components/TabBar';
@@ -10,7 +10,7 @@ import { StreamScreen } from './screens/StreamScreen';
 import { SystemScreen } from './screens/SystemScreen';
 import { ConsoleScreen } from './screens/ConsoleScreen';
 import { otaFlowAdmission } from './otaFlowAdmission';
-import { isGlassesWifiConnected } from './sdkFormat';
+import { colors } from './components/theme';
 import { isMentraLiveRuntime, useBluetoothSdkExample } from './useBluetoothSdkExample';
 
 export default function App() {
@@ -30,7 +30,6 @@ export default function App() {
       completedConnectionGeneration: otaCompletedGenerationRef.current,
       connectionGeneration,
       waitingForWifi,
-      wifiConnected: isGlassesWifiConnected(sdk.glasses),
     });
 
     if (admission === 'idle') {
@@ -89,6 +88,17 @@ export default function App() {
           />
         ) : (
           <SafeAreaView style={styles.root} edges={['top']}>
+            {waitingForWifi && (
+              <View style={styles.otaResume}>
+                <Text style={styles.otaResumeText}>Finish Wi-Fi setup, then continue the update.</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={openOta}
+                  style={styles.otaResumeButton}>
+                  <Text style={styles.otaResumeLabel}>Continue update</Text>
+                </Pressable>
+              </View>
+            )}
             <View style={styles.screen}>
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
@@ -107,4 +117,8 @@ export default function App() {
 const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: '#fff' },
   screen: { flex: 1 },
+  otaResume: { padding: 16, gap: 12, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.hairline },
+  otaResumeText: { color: colors.ink, fontSize: 14 },
+  otaResumeButton: { backgroundColor: colors.greenInk, borderRadius: 14, minHeight: 48, alignItems: 'center', justifyContent: 'center' },
+  otaResumeLabel: { color: colors.bg, fontSize: 14, fontWeight: '700' },
 });

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -10,6 +10,7 @@ import { StreamScreen } from './screens/StreamScreen';
 import { SystemScreen } from './screens/SystemScreen';
 import { ConsoleScreen } from './screens/ConsoleScreen';
 import { otaFlowAdmission } from './otaFlowAdmission';
+import { connectedWifiStatus } from './sdkFormat';
 import { colors } from './components/theme';
 import { isMentraLiveRuntime, useBluetoothSdkExample } from './useBluetoothSdkExample';
 
@@ -18,8 +19,14 @@ export default function App() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [otaVisible, setOtaVisible] = useState(false);
   const [waitingForWifi, setWaitingForWifi] = useState(false);
+  const [otaWifiTargetSsid, setOtaWifiTargetSsid] = useState<string | null>(null);
   const otaCompletedGenerationRef = useRef<number | null>(null);
   const sdk = useBluetoothSdkExample({activeTab: tab});
+  const currentWifi = connectedWifiStatus(sdk.glasses);
+  const otaWifiSetupComplete = otaWifiTargetSsid !== null
+    && currentWifi?.ssid === otaWifiTargetSsid
+    && sdk.wifiConnectingSsid === null
+    && sdk.wifiConnectError === null;
   const mentraLiveConnected = isMentraLiveRuntime(sdk.glasses);
   const connectionGeneration = mentraLiveConnected && sdk.glasses.connected
     ? sdk.glassesConnectionGeneration
@@ -65,6 +72,7 @@ export default function App() {
   };
 
   const openWifiSetup = () => {
+    setOtaWifiTargetSsid(null);
     setWaitingForWifi(true);
     setOtaVisible(false);
     setTab('system');
@@ -88,22 +96,34 @@ export default function App() {
           />
         ) : (
           <SafeAreaView style={styles.root} edges={['top']}>
-            {waitingForWifi && (
+            {waitingForWifi && tab === 'system' && (
               <View style={styles.otaResume}>
-                <Text style={styles.otaResumeText}>Finish Wi-Fi setup, then continue the update.</Text>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={openOta}
-                  style={styles.otaResumeButton}>
-                  <Text style={styles.otaResumeLabel}>Continue update</Text>
-                </Pressable>
+                <Text style={styles.otaResumeText}>
+                  {otaWifiSetupComplete
+                    ? `Connected to ${currentWifi?.ssid}`
+                    : 'Connect to a Wi-Fi network to continue the update.'}
+                </Text>
+                {otaWifiSetupComplete && (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={openOta}
+                    style={styles.otaResumeButton}>
+                    <Text style={styles.otaResumeLabel}>Continue update</Text>
+                  </Pressable>
+                )}
               </View>
             )}
             <View style={styles.screen}>
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
               {tab === 'stream' && <StreamScreen sdk={sdk} />}
-              {tab === 'system' && <SystemScreen sdk={sdk} />}
+              {tab === 'system' && <SystemScreen sdk={{
+                ...sdk,
+                sendWifiCredentials: async (ssid, password, requiresPassword) => {
+                  if (waitingForWifi) setOtaWifiTargetSsid(ssid);
+                  await sdk.sendWifiCredentials(ssid, password, requiresPassword);
+                },
+              }} />}
               {tab === 'console' && <ConsoleScreen sdk={sdk} />}
             </View>
             {!keyboardVisible && <TabBar active={tab} onChange={setTab} />}

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -19,14 +19,11 @@ export default function App() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [otaVisible, setOtaVisible] = useState(false);
   const [waitingForWifi, setWaitingForWifi] = useState(false);
-  const [otaWifiTargetSsid, setOtaWifiTargetSsid] = useState<string | null>(null);
   const otaCompletedGenerationRef = useRef<number | null>(null);
   const sdk = useBluetoothSdkExample({activeTab: tab});
   const currentWifi = connectedWifiStatus(sdk.glasses);
-  const otaWifiSetupComplete = otaWifiTargetSsid !== null
-    && currentWifi?.ssid === otaWifiTargetSsid
-    && sdk.wifiConnectingSsid === null
-    && sdk.wifiConnectError === null;
+  // A failed attempt to join another network must not block the current one.
+  const otaWifiSetupComplete = currentWifi !== null && sdk.wifiConnectingSsid === null;
   const mentraLiveConnected = isMentraLiveRuntime(sdk.glasses);
   const connectionGeneration = mentraLiveConnected && sdk.glasses.connected
     ? sdk.glassesConnectionGeneration
@@ -72,7 +69,6 @@ export default function App() {
   };
 
   const openWifiSetup = () => {
-    setOtaWifiTargetSsid(null);
     setWaitingForWifi(true);
     setOtaVisible(false);
     setTab('system');
@@ -117,13 +113,7 @@ export default function App() {
               {tab === 'device' && <DeviceScreen sdk={sdk} onOpenOta={openOta} />}
               {tab === 'camera' && <CameraScreen sdk={sdk} />}
               {tab === 'stream' && <StreamScreen sdk={sdk} />}
-              {tab === 'system' && <SystemScreen sdk={{
-                ...sdk,
-                sendWifiCredentials: async (ssid, password, requiresPassword) => {
-                  if (waitingForWifi) setOtaWifiTargetSsid(ssid);
-                  await sdk.sendWifiCredentials(ssid, password, requiresPassword);
-                },
-              }} />}
+              {tab === 'system' && <SystemScreen sdk={sdk} />}
               {tab === 'console' && <ConsoleScreen sdk={sdk} />}
             </View>
             {!keyboardVisible && <TabBar active={tab} onChange={setTab} />}

--- a/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
+++ b/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import {
   ActivityIndicator,
+  BackHandler,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -50,6 +51,13 @@ export function CustomMentraLiveOtaFlow({
   onFinished,
   onOpenWifiSetup,
 }: CustomMentraLiveOtaFlowProps) {
+  useEffect(() => {
+    // Only the flow's buttons may leave OTA. This app has no navigation stack;
+    // without a handler, Android Back invokes the system's default exit action.
+    const subscription = BackHandler.addEventListener("hardwareBackPress", () => true);
+    return () => subscription.remove();
+  }, []);
+
   const controller = useMentraLiveOta({
     initialPage,
     initializeRuntime,

--- a/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
+++ b/examples/react-native/src/ota/CustomMentraLiveOtaFlow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import {
   ActivityIndicator,
   BackHandler,
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -24,6 +25,7 @@ import { Header } from "../components/Header";
 import { colors } from "../components/theme";
 import {
   otaPresentation,
+  otaRestartOverlayMessage,
   type CustomOtaAction,
   type CustomOtaButton,
   type CustomOtaChangelog,
@@ -68,6 +70,7 @@ export function CustomMentraLiveOtaFlow({
     () => otaPresentation(controller.state, deviceName),
     [controller.state, deviceName],
   );
+  const restartMessage = otaRestartOverlayMessage(controller.state, deviceName);
   const palette = toneColors[presentation.tone];
   const hasChangelogs = (presentation.changelogs?.length ?? 0) > 0;
 
@@ -93,6 +96,10 @@ export function CustomMentraLiveOtaFlow({
             {presentation.versionLabel}
           </Text>
         </View>
+      ) : null}
+
+      {presentation.progressLabel ? (
+        <Text style={styles.detail}>{presentation.progressLabel}</Text>
       ) : null}
 
       {presentation.progress !== undefined ? (
@@ -128,6 +135,21 @@ export function CustomMentraLiveOtaFlow({
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <Modal
+        animationType="fade"
+        transparent
+        visible={restartMessage !== null}
+        onRequestClose={() => {}}
+      >
+        <View style={styles.restartBackdrop}>
+          <View accessibilityViewIsModal style={styles.restartCard} testID="ota-restart-overlay">
+            <ActivityIndicator color={colors.greenPrimary} size="large" />
+            <Text accessibilityRole="header" style={styles.message}>
+              {restartMessage}
+            </Text>
+          </View>
+        </View>
+      </Modal>
       <Header title="Software Update" />
       <View style={styles.page} testID="custom-mentra-live-ota-flow">
         <ScrollView
@@ -399,6 +421,22 @@ function ActionButton({
 }
 
 const styles = StyleSheet.create({
+  restartBackdrop: {
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.4)",
+    flex: 1,
+    justifyContent: "center",
+    padding: 24,
+  },
+  restartCard: {
+    alignItems: "center",
+    backgroundColor: colors.bg,
+    borderRadius: 20,
+    gap: 20,
+    maxWidth: 420,
+    padding: 28,
+    width: "100%",
+  },
   safeArea: { backgroundColor: colors.bg, flex: 1 },
   page: { flex: 1, paddingBottom: 18, paddingHorizontal: 24 },
   contentScroll: { flex: 1 },

--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'bun:test';
 import type {MentraLiveOtaState} from '@mentra/engine/ota';
 
-import {otaPresentation} from './otaPresentation';
+import {otaPresentation, otaRestartOverlayMessage} from './otaPresentation';
 
 const baseState: MentraLiveOtaState = {
   batteryLevel: 80,
@@ -310,5 +310,105 @@ describe('custom OTA presentation', () => {
       message: 'This mobile app is a development build, so automatic glasses updates are disabled.',
       title: 'Development Build',
     });
+  });
+});
+
+
+describe('OTA transport labels and reconnect parity', () => {
+  test.each([
+    ['apk', 'Glasses software', 0],
+    ['mtk', 'System firmware', 1],
+    ['bes', 'Bluetooth firmware', 2],
+  ] as const)('labels the current %s download on the phone', (kind, label, index) => {
+    const p = otaPresentation(
+      otaState({
+        screen: 'preparing_hotspot',
+        hotspotPhase: 'downloading',
+        hotspotArtifact: {kind, index, totalCount: 3},
+        hotspotArtifactPercent: 42,
+      }),
+    );
+    expect(p.progressLabel).toBe(`File ${index + 1} of 3 · ${label}`);
+    expect(p.progress).toBe(42);
+    expect(p.detail).toBe('Each file downloads separately. Progress is for the current file.');
+  });
+
+  test('does not invent file metadata or a percentage while the phone prepares', () => {
+    const p = otaPresentation(otaState({screen: 'preparing_hotspot', hotspotPhase: 'downloading'}));
+    expect(p.progressLabel).toBeUndefined();
+    expect(p.progress).toBeUndefined();
+  });
+
+  test.each([
+    ['starting_hotspot', 'Starting glasses hotspot...'],
+    ['joining_hotspot', 'Connecting phone to glasses...'],
+    ['serving', 'Starting update...'],
+  ] as const)('clears the phone file label during %s', (hotspotPhase, title) => {
+    const p = otaPresentation(
+      otaState({
+        screen: 'preparing_hotspot',
+        hotspotPhase,
+        hotspotArtifact: {kind: 'apk', index: 0, totalCount: 3},
+        hotspotArtifactPercent: 100,
+      }),
+    );
+    expect(p.title).toBe(title);
+    expect(p.progressLabel).toBeUndefined();
+    expect(p.progress).toBeUndefined();
+  });
+
+  test.each(['download', 'install'] as const)(
+    'labels hotspot %s as work on the glasses',
+    (phase) => {
+      const p = otaPresentation(
+        otaState({
+          screen: 'updating',
+          phase,
+          transport: 'hotspot',
+          step: 'mtk',
+          currentStep: 2,
+          totalSteps: 3,
+          progress: 55,
+        }),
+      );
+      expect(p.title).toBe(
+        phase === 'download'
+          ? 'Transferring update to glasses...'
+          : 'Installing update on glasses...',
+      );
+      expect(p.progressLabel).toBe('Update 2 of 3 · System firmware');
+      expect(p.detail).toBe(
+        phase === 'download' ? 'Progress is for this file’s transfer from your phone.' : undefined,
+      );
+      expect(p.progress).toBe(55);
+    },
+  );
+
+  test('shows the component alone when the update count is unknown', () => {
+    expect(
+      otaPresentation(
+        otaState({screen: 'updating', transport: 'hotspot', phase: 'install', step: 'bes'}),
+      ).progressLabel,
+    ).toBe('Bluetooth firmware');
+  });
+
+  test('keeps a manual shutdown on the inline reconnecting page without a restart popup', () => {
+    const state = otaState({screen: 'disconnected', connected: false});
+    expect(otaRestartOverlayMessage(state)).toBeNull();
+    expect(otaPresentation(state)).toMatchObject({
+      title: 'Glasses disconnected',
+      message: 'Reconnecting...',
+      indeterminate: true,
+    });
+    expect(otaPresentation(state).primary).toBeUndefined();
+  });
+
+  test('shows the expected firmware restart popup and removes it when connected', () => {
+    const state = otaState({screen: 'restarting', connected: false, firmwareRestarting: true});
+    expect(otaRestartOverlayMessage(state)).toBe(
+      'Please wait while Mentra Live restarts and automatically reconnects...',
+    );
+    expect(otaRestartOverlayMessage({...state, connected: true})).toBeNull();
+    expect(otaRestartOverlayMessage({...state, firmwareRestarting: false})).toBeNull();
   });
 });

--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -1,9 +1,9 @@
 import {describe, expect, test} from 'bun:test';
-import type {OtaPresentationState} from './otaPresentation';
+import type {MentraLiveOtaState} from '@mentra/engine/ota';
 
 import {otaPresentation, otaRestartOverlayMessage} from './otaPresentation';
 
-const baseState: OtaPresentationState = {
+const baseState: MentraLiveOtaState = {
   batteryLevel: 80,
   canDiscard: false,
   canDismiss: false,
@@ -38,7 +38,7 @@ const baseState: OtaPresentationState = {
   wifiStatusKnown: true,
 };
 
-function otaState(overrides: Partial<OtaPresentationState>): OtaPresentationState {
+function otaState(overrides: Partial<MentraLiveOtaState>): MentraLiveOtaState {
   return {...baseState, ...overrides};
 }
 

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -3,15 +3,6 @@ import type {
   MentraLiveOtaState,
 } from '@mentra/engine/ota';
 
-// Older coordinated Engine releases omit per-file hotspot metadata.
-export type OtaPresentationState = MentraLiveOtaState & {
-  hotspotArtifact?: {
-    kind: 'apk' | 'mtk' | 'bes';
-    index: number;
-    totalCount: number;
-  } | null;
-};
-
 export type CustomOtaAction = Exclude<
   keyof MentraLiveOtaController,
   'state'
@@ -67,7 +58,7 @@ export function otaRestartOverlayMessage(
 }
 
 export function otaPresentation(
-  state: OtaPresentationState,
+  state: MentraLiveOtaState,
   deviceName = 'Mentra Live',
 ): CustomOtaPresentation {
   const {changelogs, releaseTransition} = state;

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -26,6 +26,7 @@ export type CustomOtaPresentation = {
   message?: string;
   primary?: CustomOtaButton;
   progress?: number;
+  progressLabel?: string;
   secondary?: CustomOtaButton;
   title: string;
   tone: 'active' | 'danger' | 'neutral' | 'success';
@@ -39,6 +40,21 @@ function updateVersionLabel(transition: MentraLiveOtaState['releaseTransition'])
 
 function completedVersionLabel(transition: MentraLiveOtaState['releaseTransition']): string | undefined {
   return transition ? `Updated to ${transition.toVersion}` : undefined;
+}
+
+const componentLabels = {
+  apk: 'Glasses software',
+  mtk: 'System firmware',
+  bes: 'Bluetooth firmware',
+} as const;
+
+export function otaRestartOverlayMessage(
+  state: MentraLiveOtaState,
+  deviceName = 'Mentra Live',
+): string | null {
+  return state.firmwareRestarting && !state.connected
+    ? `Please wait while ${deviceName} restarts and automatically reconnects...`
+    : null;
 }
 
 export function otaPresentation(
@@ -189,27 +205,59 @@ export function otaPresentation(
           title: 'Starting update...',
         },
       }[state.hotspotPhase];
+      const artifact = state.hotspotPhase === 'downloading' ? state.hotspotArtifact : null;
       return {
+        detail:
+          state.hotspotPhase === 'downloading'
+            ? 'Each file downloads separately. Progress is for the current file.'
+            : undefined,
         indeterminate: true,
         message: 'Do not disconnect your glasses',
-        progress: state.hotspotPhase === 'downloading'
-          ? (state.hotspotArtifactPercent ?? undefined)
+        progressLabel: artifact
+          ? `File ${artifact.index + 1} of ${artifact.totalCount} · ${componentLabels[artifact.kind]}`
           : undefined,
+        progress:
+          state.hotspotPhase === 'downloading'
+            ? (state.hotspotArtifactPercent ?? undefined)
+            : undefined,
         title: hotspotCopy.title,
         tone: 'active',
       };
     }
-    case 'updating':
+    case 'updating': {
+      const hotspot = state.transport === 'hotspot';
+      const component = state.step ? componentLabels[state.step] : undefined;
+      const hasStepCount =
+        state.currentStep !== null &&
+        state.totalSteps !== null &&
+        state.currentStep > 0 &&
+        state.currentStep <= state.totalSteps;
       return {
-        detail: state.versionChange && state.phase === 'install'
-          ? 'Your glasses will restart twice — this may take up to 2 minutes.'
-          : undefined,
+        detail:
+          state.versionChange && state.phase === 'install'
+            ? 'Your glasses will restart twice — this may take up to 2 minutes.'
+            : hotspot && state.phase === 'download'
+              ? 'Progress is for this file’s transfer from your phone.'
+              : undefined,
+        progressLabel:
+          hotspot && component
+            ? hasStepCount
+              ? `Update ${state.currentStep} of ${state.totalSteps} · ${component}`
+              : component
+            : undefined,
         indeterminate: state.installingApkOnly || state.progress === null,
         message: 'Do not disconnect your glasses',
         progress: state.installingApkOnly ? undefined : (state.progress ?? undefined),
-        title: state.phase === 'download' ? 'Downloading...' : 'Installing...',
+        title: hotspot
+          ? state.phase === 'download'
+            ? 'Transferring update to glasses...'
+            : 'Installing update on glasses...'
+          : state.phase === 'download'
+            ? 'Downloading...'
+            : 'Installing...',
         tone: 'active',
       };
+    }
     case 'restarting':
       return {
         detail: "We'll continue automatically when they're ready.",

--- a/examples/react-native/src/otaFlowAdmission.test.ts
+++ b/examples/react-native/src/otaFlowAdmission.test.ts
@@ -8,7 +8,6 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: null,
       connectionGeneration: 0,
       waitingForWifi: false,
-      wifiConnected: false,
     })).toBe('open');
   });
 
@@ -17,7 +16,6 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: 4,
       connectionGeneration: 4,
       waitingForWifi: false,
-      wifiConnected: true,
     })).toBe('done');
   });
 
@@ -26,22 +24,32 @@ describe('OTA flow admission', () => {
       completedConnectionGeneration: 4,
       connectionGeneration: 5,
       waitingForWifi: false,
-      wifiConnected: true,
     })).toBe('open');
   });
 
-  test('waits in System until legacy Wi-Fi setup completes', () => {
+  test('keeps Wi-Fi setup open across status refreshes and BLE reconnects', () => {
+    for (const connectionGeneration of [0, 0, null, 1]) {
+      expect(otaFlowAdmission({
+        completedConnectionGeneration: null,
+        connectionGeneration,
+        waitingForWifi: true,
+      })).toBe('wait_for_wifi');
+    }
+  });
+
+  test('reopens OTA when the user continues from Wi-Fi setup', () => {
     expect(otaFlowAdmission({
       completedConnectionGeneration: null,
       connectionGeneration: 0,
-      waitingForWifi: true,
-      wifiConnected: false,
-    })).toBe('wait_for_wifi');
-    expect(otaFlowAdmission({
-      completedConnectionGeneration: null,
-      connectionGeneration: 0,
-      waitingForWifi: true,
-      wifiConnected: true,
+      waitingForWifi: false,
     })).toBe('open');
+  });
+
+  test('stays idle when disconnected outside Wi-Fi setup', () => {
+    expect(otaFlowAdmission({
+      completedConnectionGeneration: null,
+      connectionGeneration: null,
+      waitingForWifi: false,
+    })).toBe('idle');
   });
 });

--- a/examples/react-native/src/otaFlowAdmission.ts
+++ b/examples/react-native/src/otaFlowAdmission.ts
@@ -4,14 +4,14 @@ export function otaFlowAdmission({
   completedConnectionGeneration,
   connectionGeneration,
   waitingForWifi,
-  wifiConnected,
 }: {
   completedConnectionGeneration: number | null;
   connectionGeneration: number | null;
   waitingForWifi: boolean;
-  wifiConnected: boolean;
 }): OtaFlowAdmission {
+  // Setup is a user-controlled detour: an existing connection (or a reconnect)
+  // must not dismiss it before the user has finished changing networks.
+  if (waitingForWifi) return 'wait_for_wifi';
   if (connectionGeneration === null) return 'idle';
-  if (waitingForWifi) return wifiConnected ? 'open' : 'wait_for_wifi';
   return completedConnectionGeneration === connectionGeneration ? 'done' : 'open';
 }


### PR DESCRIPTION
Merge staging into dev to bring over the OTA navigation, progress labels, and reconnect presentation changes. Preserve the existing dev behavior and use the matching 3.2.0-dev.180 prerelease across maintained examples, lockfiles, and coordinated release metadata.

Release-coordinate conflicts retain the dev channel. The merged product logic is unchanged; the newer published Engine provides the hotspot artifact metadata used by staging.

Validation: all 22 release-tooling tests and 38 OTA tests pass. TypeScript checks pass for React Native, React Native macOS, and the ElevenLabs example against the published dev.180 packages. Remote native builds are pending.
