### PR TITLE
fix: revert dev-only OTA additions from main

### DIFF
--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -17,7 +17,6 @@ const baseState: MentraLiveOtaState = {
   currentStep: null,
   error: null,
   firmwareRestarting: false,
-  glassesPackageName: null,
   hotspotArtifactPercent: null,
   hotspotPhase: 'idle',
   hotspotSupported: true,
@@ -311,40 +310,6 @@ describe('custom OTA presentation', () => {
       message: 'This mobile app is a development build, so automatic glasses updates are disabled.',
       title: 'Development Build',
     });
-  });
-
-  test('explains that a sideloaded glasses client blocks updates', () => {
-    const presentation = otaPresentation(otaState({screen: 'unofficial_client'}));
-
-    expect(presentation).toMatchObject({
-      message:
-        'Your glasses are running a sideloaded client, so updates are blocked. Restore the stock client to update them.',
-      primary: {action: 'finish', label: 'Continue'},
-      title: 'Updates Blocked',
-    });
-  });
-
-  test('asks the wearer to charge the glasses before updating', () => {
-    const presentation = otaPresentation(
-      otaState({batteryLevel: 12, canDismiss: true, screen: 'battery_required'}),
-    );
-
-    expect(presentation).toMatchObject({
-      message: 'Mentra Live is currently at 12%. Charge it before updating.',
-      primary: {action: 'install', disabled: true, label: 'Update Now'},
-      secondary: {action: 'finish', label: 'Later'},
-      title: 'Charge Mentra Live to Update',
-    });
-  });
-
-  test('names the sideloaded glasses client package when the controller reports one', () => {
-    const presentation = otaPresentation(
-      otaState({glassesPackageName: 'com.example.asg', screen: 'unofficial_client'}),
-    );
-
-    expect(presentation.message).toBe(
-      'Your glasses are running a sideloaded client (com.example.asg), so updates are blocked. Restore the stock client to update them.',
-    );
   });
 });
 

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -172,15 +172,6 @@ export function otaPresentation(
         title: 'Development Build',
         tone: 'neutral',
       };
-    case 'unofficial_client':
-      return {
-        message: state.glassesPackageName
-          ? `Your glasses are running a sideloaded client (${state.glassesPackageName}), so updates are blocked. Restore the stock client to update them.`
-          : 'Your glasses are running a sideloaded client, so updates are blocked. Restore the stock client to update them.',
-        primary: {action: 'finish', label: 'Continue'},
-        title: 'Updates Blocked',
-        tone: 'neutral',
-      };
     case 'check_failed':
       return {
         message: "Couldn't check for updates. Please check your connection and try again.",


### PR DESCRIPTION
## Summary
Remove the OTA additions from direct-to-main commit c84f1b359352398faa9e8591968bea82b4076b4a that were subsequently imported into staging by #190. Restore both OTA presentation files exactly to the pre-#190 staging versions. Preserve existing battery handling, Apache licensing, and all dependency pins.

The correct dev implementation already landed in #152 and remains untouched. The beta Engine packages do not expose unofficial_client or glassesPackageName.

## Validation
- Frozen-lockfile install with Engine 3.1.0-beta.186
- TypeScript: bun x tsc --noEmit passed
- All React Native unit tests: 37 passed
- git diff --check passed
- Both edited files match pre-#190 staging exactly

## Release ordering
Merge this PR into main first. Then merge the resulting actual main head into the dependent staging repair branch and merge that PR using a merge commit (not squash/rebase), so main remains an ancestor of staging for the production release gate. No auto-merge enabled; release branches remain frozen until explicit approval.