### PR TITLE
fix: merge main OTA correction back into staging

### DIFF
--- a/examples/react-native/src/ota/otaPresentation.test.ts
+++ b/examples/react-native/src/ota/otaPresentation.test.ts
@@ -17,7 +17,6 @@ const baseState: MentraLiveOtaState = {
   currentStep: null,
   error: null,
   firmwareRestarting: false,
-  glassesPackageName: null,
   hotspotArtifactPercent: null,
   hotspotPhase: 'idle',
   hotspotSupported: true,
@@ -311,40 +310,6 @@ describe('custom OTA presentation', () => {
       message: 'This mobile app is a development build, so automatic glasses updates are disabled.',
       title: 'Development Build',
     });
-  });
-
-  test('explains that a sideloaded glasses client blocks updates', () => {
-    const presentation = otaPresentation(otaState({screen: 'unofficial_client'}));
-
-    expect(presentation).toMatchObject({
-      message:
-        'Your glasses are running a sideloaded client, so updates are blocked. Restore the stock client to update them.',
-      primary: {action: 'finish', label: 'Continue'},
-      title: 'Updates Blocked',
-    });
-  });
-
-  test('asks the wearer to charge the glasses before updating', () => {
-    const presentation = otaPresentation(
-      otaState({batteryLevel: 12, canDismiss: true, screen: 'battery_required'}),
-    );
-
-    expect(presentation).toMatchObject({
-      message: 'Mentra Live is currently at 12%. Charge it before updating.',
-      primary: {action: 'install', disabled: true, label: 'Update Now'},
-      secondary: {action: 'finish', label: 'Later'},
-      title: 'Charge Mentra Live to Update',
-    });
-  });
-
-  test('names the sideloaded glasses client package when the controller reports one', () => {
-    const presentation = otaPresentation(
-      otaState({glassesPackageName: 'com.example.asg', screen: 'unofficial_client'}),
-    );
-
-    expect(presentation.message).toBe(
-      'Your glasses are running a sideloaded client (com.example.asg), so updates are blocked. Restore the stock client to update them.',
-    );
   });
 });
 

--- a/examples/react-native/src/ota/otaPresentation.ts
+++ b/examples/react-native/src/ota/otaPresentation.ts
@@ -172,15 +172,6 @@ export function otaPresentation(
         title: 'Development Build',
         tone: 'neutral',
       };
-    case 'unofficial_client':
-      return {
-        message: state.glassesPackageName
-          ? `Your glasses are running a sideloaded client (${state.glassesPackageName}), so updates are blocked. Restore the stock client to update them.`
-          : 'Your glasses are running a sideloaded client, so updates are blocked. Restore the stock client to update them.',
-        primary: {action: 'finish', label: 'Continue'},
-        title: 'Updates Blocked',
-        tone: 'neutral',
-      };
     case 'check_failed':
       return {
         message: "Couldn't check for updates. Please check your connection and try again.",


### PR DESCRIPTION
## Summary
Merge the main repair from #193 into staging while preserving branch ancestry. Remove only the accidental OTA additions introduced by direct-to-main commit c84f1b359352398faa9e8591968bea82b4076b4a and imported by #190. Preserve the Apache license, existing battery handling, and beta.186 pins. The correct dev implementation in #152 stays untouched.

## Required merge order
1. Merge #193 into main.
2. Fetch origin and merge the resulting origin/main head into this PR branch, then push. The currently included repair commit is not a substitute for the final main PR merge commit.
3. Verify git merge-base --is-ancestor origin/main HEAD succeeds against the refreshed main ref and let CI pass.
4. Mark ready and merge this PR using a merge commit, not squash/rebase. Verify the latest main head is an ancestor of staging before the production release.

Draft intentionally blocks premature release use. No auto-merge enabled.

## Validation
- Repair tree is identical to the tested #193 tree
- Frozen-lockfile install with Engine 3.1.0-beta.186
- TypeScript passed; all 37 React Native unit tests passed on that identical tree
- OTA files exactly match pre-#190 staging
- Current main head is an ancestor of this branch; this must be checked again after #193 merges

This does not retry or rewrite the failed immutable beta.189 release plan, and does not prove store publishing access.