### PR TITLE
Skip unsigned iOS artifact uploads for ordinary PRs

### DIFF
--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -14,7 +14,7 @@ const releaseWorkflow = readFileSync(new URL("../workflows/coordinated-example-r
 test("keeps iOS validation mandatory and packages artifacts only for release or manual runs", () => {
   const workflow = readFileSync(new URL("../workflows/example-app-builds.yml", import.meta.url), "utf8")
   const ios = workflow.split("\n  ios:\n")[1].split("\n  macos:\n")[0]
-  const artifactCondition = "if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')"
+  const artifactCondition = "if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'coordinated/'))"
   for (const name of ["Package unsigned IPA", "Upload IPA artifact"]) {
     const step = ios.split(`- name: ${name}\n`)[1].split("\n      - name:")[0]
     assert.ok(step.includes(artifactCondition), `${name} must preserve coordinated-release artifacts`)

--- a/.github/scripts/coordinated-example-release.test.mjs
+++ b/.github/scripts/coordinated-example-release.test.mjs
@@ -11,6 +11,21 @@ const manifestSha = "b".repeat(64)
 
 const releaseWorkflow = readFileSync(new URL("../workflows/coordinated-example-release.yml", import.meta.url), "utf8")
 
+test("keeps iOS validation mandatory and packages artifacts only for release or manual runs", () => {
+  const workflow = readFileSync(new URL("../workflows/example-app-builds.yml", import.meta.url), "utf8")
+  const ios = workflow.split("\n  ios:\n")[1].split("\n  macos:\n")[0]
+  const artifactCondition = "if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')"
+  for (const name of ["Package unsigned IPA", "Upload IPA artifact"]) {
+    const step = ios.split(`- name: ${name}\n`)[1].split("\n      - name:")[0]
+    assert.ok(step.includes(artifactCondition), `${name} must preserve coordinated-release artifacts`)
+  }
+  for (const name of ["Type check Swift", "Build"]) {
+    const step = ios.split(`- name: ${name}\n`)[1].split("\n      - name:")[0]
+    assert.doesNotMatch(step, /\n\s+if:/, `${name} must run for ordinary PRs`)
+    assert.match(step, /xcodebuild/)
+  }
+})
+
 function payload(identity = "3.1.0-beta.57") {
   const [base, prerelease] = identity.split("-")
   const channel = prerelease?.startsWith("dev.") ? "dev" : prerelease?.startsWith("beta.") ? "beta" : "production"

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -218,6 +218,9 @@ jobs:
             build
 
       - name: Package unsigned IPA
+        # Coordinated releases consume this artifact from their validation PR.
+        # Ordinary PRs only need the mandatory analysis and build above.
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')
         id: collect
         working-directory: examples/ios
         env:
@@ -237,6 +240,7 @@ jobs:
           echo "path=examples/ios/$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload IPA artifact
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-ios

--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Package unsigned IPA
         # Coordinated releases consume this artifact from their validation PR.
         # Ordinary PRs only need the mandatory analysis and build above.
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')
+        if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'coordinated/'))
         id: collect
         working-directory: examples/ios
         env:
@@ -240,7 +240,7 @@ jobs:
           echo "path=examples/ios/$output" >> "$GITHUB_OUTPUT"
 
       - name: Upload IPA artifact
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'coordinated/')
+        if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'coordinated/'))
         uses: actions/upload-artifact@v4
         with:
           name: mentra-example-ios

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ download the files carrying the same full version:
 - `mentra-example-rn-elevenlabs-audio-<version>.apk` — React Native ElevenLabs audio example
 - `mentra-example-ios-<version>-unsigned.ipa` — native iOS example
 
-Android APKs install directly from the phone browser (enable installs from unknown sources when prompted). The iOS IPA is unsigned; install it with a sideloading tool such as [Sideloadly](https://sideloadly.io/) or [AltStore](https://altstore.io/), which re-signs it with your own Apple ID. Pull-request builds are also available for 90 days as run artifacts on each [workflow run](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/workflows/example-app-builds.yml).
+Android APKs install directly from the phone browser (enable installs from unknown sources when prompted). The iOS IPA is unsigned; install it with a sideloading tool such as [Sideloadly](https://sideloadly.io/) or [AltStore](https://altstore.io/), which re-signs it with your own Apple ID. Android pull-request builds are also available for 90 days as run artifacts on each [workflow run](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/actions/workflows/example-app-builds.yml). Ordinary pull requests analyze and compile the native iOS example without packaging or uploading it; unsigned IPA artifacts are retained for coordinated-release pull requests and manual workflow runs.
 
 ## What The Examples Demonstrate
 


### PR DESCRIPTION
## Summary

- Keep native iOS analysis and compilation mandatory for all PRs.
- Skip unsigned IPA packaging/upload for ordinary PRs.
- Preserve artifacts for coordinated/* release PRs and manual workflow runs: the coordinated release publisher consumes this IPA, unlike the unused MentraOS PR artifact.
- Leave Android artifacts and signed release/TestFlight workflows unchanged; update the README to match.

## Validation

- actionlint passes.
- All 23 release-script tests pass, including a regression for the artifact conditions and unconditional iOS build steps.
- git diff --check passes.
- All remote checks pass on 4ad18e9, including native iOS/Android/macOS and all React Native examples; no merge or release claimed.
