### PR TITLE
Limit example Android foreground services to connected devices

### DIFF
--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -111,6 +111,31 @@ Local on-device STT/TTS via Sherpa-ONNX is **not** bundled in the public Android
 
 Day-to-day iteration: prefer `bun run android:dev` after the first successful install.
 
+## Android Foreground Services
+
+This Bluetooth-only host declares `connectedDevice` for the SDK foreground
+service. Its microphone demo receives PCM from the glasses over BLE; it does
+not select Android's phone microphone. It does not run location tasks or play
+media in the background. `withConnectedDeviceForegroundService` overrides the
+SDK service type and removes Expo's unused location task service. Expo audio
+background playback and recording are disabled, and the four unused typed FGS
+permissions are blocked in `app.json`. Ordinary Bluetooth, Wi-Fi, location and
+audio permissions are separate and are not removed by this configuration.
+The existing iOS `audio` background mode is preserved explicitly in `infoPlist`.
+
+This requires an SDK whose Android `ForegroundService` honors the merged host
+manifest for both startup and subsequent type selection. The dependency pin
+must be advanced to that SDK release before this configuration is shipped;
+until then, use the local SDK override below for validation. An older SDK tries
+to start undeclared service types. Rebuild the native app after changing these
+settings; a JavaScript update cannot change the manifest.
+
+Before release, verify connection/reconnection and permissions on a physical
+Android phone, including app background/resume, glasses microphone recording,
+media playback pause on background, photo transfers, and both OTA transports.
+The retained connected-device service still needs a Google Play declaration
+and demonstration video.
+
 ## SDK Plugin Configuration
 
 The example's `app.json` already includes the Mentra SDK plugin:

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -123,11 +123,10 @@ permissions are blocked in `app.json`. Ordinary Bluetooth, Wi-Fi, location and
 audio permissions are separate and are not removed by this configuration.
 The existing iOS `audio` background mode is preserved explicitly in `infoPlist`.
 
-This requires an SDK whose Android `ForegroundService` honors the merged host
-manifest for both startup and subsequent type selection. The dependency pin
-must be advanced to that SDK release before this configuration is shipped;
-until then, use the local SDK override below for validation. An older SDK tries
-to start undeclared service types. Rebuild the native app after changing these
+The pinned SDK includes Android `ForegroundService` support for the merged
+host manifest at both startup and subsequent type selection. Do not downgrade
+the SDK below `3.2.0-dev.200` while using this configuration: older SDKs try to
+start undeclared service types. Rebuild the native app after changing these
 settings; a JavaScript update cannot change the manifest.
 
 Before release, verify connection/reconnection and permissions on a physical

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -18,6 +18,9 @@
         "com.apple.developer.networking.wifi-info": true
       },
       "infoPlist": {
+        "UIBackgroundModes": [
+          "audio"
+        ],
         "NSBluetoothAlwaysUsageDescription": "This example app uses Bluetooth to connect to smart glasses.",
         "NSBluetoothPeripheralUsageDescription": "This example app uses Bluetooth to connect to smart glasses.",
         "NSCameraUsageDescription": "This example app can trigger camera capture on connected smart glasses.",
@@ -29,6 +32,12 @@
     "android": {
       "package": "com.mentra.bluetoothsdk.example.reactnative",
       "softwareKeyboardLayoutMode": "pan",
+      "blockedPermissions": [
+        "android.permission.FOREGROUND_SERVICE_DATA_SYNC",
+        "android.permission.FOREGROUND_SERVICE_LOCATION",
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
+        "android.permission.FOREGROUND_SERVICE_MICROPHONE"
+      ],
       "permissions": [
         "android.permission.BLUETOOTH",
         "android.permission.BLUETOOTH_ADMIN",
@@ -73,7 +82,13 @@
           }
         }
       ],
-      "expo-audio",
+      [
+        "expo-audio",
+        {
+          "enableBackgroundPlayback": false,
+          "enableBackgroundRecording": false
+        }
+      ],
       [
         "expo-splash-screen",
         {
@@ -83,7 +98,8 @@
         }
       ],
       "expo-video",
-      "react-native-wifi-reborn"
+      "react-native-wifi-reborn",
+      "./plugins/withConnectedDeviceForegroundService"
     ]
   }
 }

--- a/examples/react-native/bun.lock
+++ b/examples/react-native/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "mentra-bluetooth-sdk-rn-example",
       "dependencies": {
-        "@mentra/bluetooth-sdk": "3.2.0-dev.195",
-        "@mentra/engine": "3.2.0-dev.195",
+        "@mentra/bluetooth-sdk": "3.2.0-dev.200",
+        "@mentra/engine": "3.2.0-dev.200",
         "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
         "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
         "expo": "~55.0.24",
@@ -348,21 +348,21 @@
 
     "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
 
-    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.195", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-pez9CjwX0W+HZoGFWxS/td8cizuMMJOpCkHXCjhWgaEWNh0KmZdvxTLr+h3HWpLolGSF3BmA1TDRel6VFUAP/g=="],
+    "@mentra/acs-meeting": ["@mentra/acs-meeting@3.2.0-dev.200", "", { "dependencies": { "@expo/config-plugins": "~55.0.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-utCbQy/Hn2l3gk61niyw/w03psJtVQX3RPZX9X/kFjYNxxH+BEBkQIrx0E8mUzPn1ottUvV/OFnzVRV/Kf8UJQ=="],
 
-    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.195", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-oq1oxWIyYkM+YR8fuHbd6/3T/6brPPwuZibK3cfVUJI2tSskVrQiKY93DpIjN3T2yaga7CWvojekn6qcbdHi1A=="],
+    "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@3.2.0-dev.200", "", { "peerDependencies": { "@expo/config-plugins": ">=8.0.0", "@types/react": ">=18.0.0", "expo": ">=49.0.0", "react": ">=18.0.0", "react-native": ">=0.72.0" } }, "sha512-dWl+zm11KESddvdJ8JwGCEX1ZxUtVNT7nTqvx/aYvQmyQ/Fx+PlNhHGrOCt7SwlbUPVORc+zhInAH/NWSKO/eA=="],
 
-    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.195", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.195", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-bbEJZSs7MPOdcCTnIrVVAj8VVB38RsFFgOXaf5Vm96axc08ZH7gysZuS/6R73q8i5Jnh1QHs9YBY9K8cS1joRA=="],
+    "@mentra/cloud-client": ["@mentra/cloud-client@3.2.0-dev.200", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.200", "tweetnacl": "^1.0.3" }, "peerDependencies": { "ws": "^8.18.0" }, "optionalPeers": ["ws"] }, "sha512-H/BnAfyS2e01WJu6JOk/G0BAa0fAfVXW0Gy3ema2fi7EFeniTI79k5NSnUX3aYH33DyfPQR4XzfezkjSRyIZAg=="],
 
-    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.195", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-Qw0kAghKc5YNfCq05W3bTfZKncpRe9XIPW7XVCckQjSIMxTIe2GAXQREVGF2C0msQ0IC9upqZEp5DJiKf6qlhQ=="],
+    "@mentra/cloud-protocol": ["@mentra/cloud-protocol@3.2.0-dev.200", "", { "dependencies": { "zod": "^3.24.1" } }, "sha512-YFwBEW64Vh513N4F02LxPBuY2HkiSj+2B3XTzdq1kWtS7tz91wW1ldhpIdTj238baudziYBF1FSXdzwvJ8d3nA=="],
 
-    "@mentra/crust": ["@mentra/crust@3.2.0-dev.195", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.195" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-ZOKMQCejkx2mUgbERIgkRgVU/N2YTtQG4AzH1VTa2Yw9Jwe8uAfheGhk65arQcjEvVvd1VmqKsonmVXHd9GQiw=="],
+    "@mentra/crust": ["@mentra/crust@3.2.0-dev.200", "", { "dependencies": { "@mentra/jspolyfill": "3.2.0-dev.200" }, "peerDependencies": { "@types/react": "*", "expo": "*", "react": "*", "react-native": "*" } }, "sha512-BHnSi/z0jHnPRHOD16DFmnkrPoIsJqkOoNUVDjWCYrfw6y9LFxNxuoy+CxJpNJCZXqVUaJB+xSJCVMF4U3JoaA=="],
 
-    "@mentra/engine": ["@mentra/engine@3.2.0-dev.195", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.195", "@mentra/bluetooth-sdk": "3.2.0-dev.195", "@mentra/cloud-client": "3.2.0-dev.195", "@mentra/cloud-protocol": "3.2.0-dev.195", "@mentra/crust": "3.2.0-dev.195", "@mentra/miniapp": "3.2.0-dev.195", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-N6EoneiDMmbiDVQEnWDBYU4StUVCRAyREMYthke7n3TwCOPGatKjXyOV1AX8HIkMZzfvfj3WUFFkroFY7jPEOQ=="],
+    "@mentra/engine": ["@mentra/engine@3.2.0-dev.200", "", { "dependencies": { "@mentra/acs-meeting": "3.2.0-dev.200", "@mentra/bluetooth-sdk": "3.2.0-dev.200", "@mentra/cloud-client": "3.2.0-dev.200", "@mentra/cloud-protocol": "3.2.0-dev.200", "@mentra/crust": "3.2.0-dev.200", "@mentra/miniapp": "3.2.0-dev.200", "buffer": "^6.0.3", "events": "^3.3.0", "react-native-marked": "8.1.1", "semver": "^7.7.4", "typesafe-ts": "^1.7.1" }, "peerDependencies": { "@craftzdog/react-native-buffer": "*", "@dr.pogodin/react-native-fs": "*", "@react-native-community/netinfo": "*", "@types/react": "*", "axios": "*", "expo": "~55.0.24", "expo-audio": "~55.0.14", "expo-battery": "^55.0.13", "expo-calendar": "~55.0.14", "expo-clipboard": "~55.0.13", "expo-constants": "~55.0.16", "expo-device": "~55.0.17", "expo-file-system": "~55.0.20", "expo-location": "~55.1.10", "expo-modules-core": "~55.0.25", "expo-notifications": "~55.0.23", "expo-task-manager": "~55.0.16", "react": "*", "react-native": "*", "react-native-ble-manager": "*", "react-native-localize": "*", "react-native-mmkv": "*", "react-native-nitro-bg-timer": "*", "react-native-nitro-modules": "*", "react-native-permissions": "*", "react-native-reanimated": "4.2.1", "react-native-safe-area-context": "*", "react-native-share": "*", "react-native-svg": "*", "react-native-udp": "*", "react-native-wifi-reborn": "*", "react-native-worklets": "0.7.4", "react-native-zip-archive": "7.1.1", "zustand": "*" } }, "sha512-RYz5PS2Zsa1s0fZViHsEYjbeP995OWIxbRxIyoStuv1JvZkSdNiiWVTgRK1D2OecD30A04NISpSVP4FvalYQCQ=="],
 
-    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.195", "", {}, "sha512-i9gCYFejOSfhEeyqSJfTq3Cu0ZK1jpipUsSoVTEdtvzJOfE1r4mZA85hNX8Kbblqz9Cn87ZflizCZnOuKdVUFA=="],
+    "@mentra/jspolyfill": ["@mentra/jspolyfill@3.2.0-dev.200", "", {}, "sha512-TYRDSCLdAcKvF1KyC4JiCb73CjaGwJSC5vNZOaCKPQWF9Ccp87sE/KFNbGc6wg258nxhJompO/OMNElgUi16Wg=="],
 
-    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.195", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.195", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-nG0dAWHVY891pp/JqbxvEvzcQbm/NsUMnSaobFKcNGuF5eVspr93VIzc2O51msAmvZVLm5Jnwp2pS4ZARU5gRw=="],
+    "@mentra/miniapp": ["@mentra/miniapp@3.2.0-dev.200", "", { "dependencies": { "@mentra/cloud-protocol": "3.2.0-dev.200", "eventemitter3": "^5.0.1" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-mmCfixp9K1RDcTSNJkSRvWr8xjKey3fCYwaMdhClwakbLlu43vUi3CBWwVEjddG4A/PDai/9FCCncworzdByaw=="],
 
     "@mentra/react-native-barcode-scanner": ["@mentra/react-native-barcode-scanner@file:modules/mentra-barcode-scanner", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }],
 

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,8 +21,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@mentra/bluetooth-sdk": "3.2.0-dev.195",
-    "@mentra/engine": "3.2.0-dev.195",
+    "@mentra/bluetooth-sdk": "3.2.0-dev.200",
+    "@mentra/engine": "3.2.0-dev.200",
     "@mentra/react-native-barcode-scanner": "file:modules/mentra-barcode-scanner",
     "@mentra/react-native-video-stream-receiver": "file:modules/mentra-video-stream-receiver",
     "expo": "~55.0.24",

--- a/examples/react-native/plugins/withConnectedDeviceForegroundService.js
+++ b/examples/react-native/plugins/withConnectedDeviceForegroundService.js
@@ -1,0 +1,36 @@
+const {AndroidConfig, withAndroidManifest} = require('expo/config-plugins');
+
+const SDK_SERVICE = 'com.mentra.bluetoothsdk.services.ForegroundService';
+const LOCATION_SERVICE = 'expo.modules.location.services.LocationTaskService';
+
+function applyConnectedDeviceForegroundService(manifest) {
+  manifest.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
+  const application = AndroidConfig.Manifest.getMainApplicationOrThrow(manifest);
+  application.service ??= [];
+
+  let service = application.service.find(item => item.$['android:name'] === SDK_SERVICE);
+  if (!service) {
+    service = {$: {'android:name': SDK_SERVICE}};
+    application.service.push(service);
+  }
+  service.$['android:exported'] = 'false';
+  service.$['android:foregroundServiceType'] = 'connectedDevice';
+  const replace = new Set((service.$['tools:replace'] || '').split(',').filter(Boolean));
+  replace.add('android:foregroundServiceType');
+  service.$['tools:replace'] = [...replace].join(',');
+
+  // Engine has an expo-location peer, but this Bluetooth-only host never starts
+  // location tasks. Remove its autolinked service without breaking that peer.
+  application.service = application.service.filter(item => item.$['android:name'] !== LOCATION_SERVICE);
+  application.service.push({$: {'android:name': LOCATION_SERVICE, 'tools:node': 'remove'}});
+  return manifest;
+}
+
+module.exports = function withConnectedDeviceForegroundService(config) {
+  return withAndroidManifest(config, mod => {
+    mod.modResults = applyConnectedDeviceForegroundService(mod.modResults);
+    return mod;
+  });
+};
+
+module.exports.applyConnectedDeviceForegroundService = applyConnectedDeviceForegroundService;

--- a/examples/react-native/plugins/withConnectedDeviceForegroundService.test.ts
+++ b/examples/react-native/plugins/withConnectedDeviceForegroundService.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, test} from 'bun:test';
+import appConfig from '../app.json';
+
+const {applyConnectedDeviceForegroundService} = require('./withConnectedDeviceForegroundService');
+const SDK_SERVICE = 'com.mentra.bluetoothsdk.services.ForegroundService';
+const LOCATION_SERVICE = 'expo.modules.location.services.LocationTaskService';
+
+describe('Bluetooth-only Android foreground services', () => {
+  test('overrides the SDK type and removes only the unused location service', () => {
+    const manifest = {
+      manifest: {
+        $: {},
+        application: [{
+          $: {'android:name': '.MainApplication'},
+          service: [
+            {$: {'android:name': SDK_SERVICE, 'android:foregroundServiceType': 'dataSync|location', 'tools:replace': 'android:exported'}},
+            {$: {'android:name': LOCATION_SERVICE, 'android:foregroundServiceType': 'location'}},
+            {$: {'android:name': 'another.Service'}},
+          ],
+        }],
+      },
+    };
+    const result = applyConnectedDeviceForegroundService(manifest);
+    const services = result.manifest.application[0].service;
+    expect(services.find((item: any) => item.$['android:name'] === SDK_SERVICE).$).toEqual({
+      'android:name': SDK_SERVICE,
+      'android:exported': 'false',
+      'android:foregroundServiceType': 'connectedDevice',
+      'tools:replace': 'android:exported,android:foregroundServiceType',
+    });
+    expect(services.find((item: any) => item.$['android:name'] === LOCATION_SERVICE).$).toEqual({
+      'android:name': LOCATION_SERVICE, 'tools:node': 'remove',
+    });
+    expect(services.some((item: any) => item.$['android:name'] === 'another.Service')).toBe(true);
+    expect(applyConnectedDeviceForegroundService(structuredClone(result))).toEqual(result);
+  });
+
+  test('creates the override before library manifests are merged', () => {
+    const result = applyConnectedDeviceForegroundService({manifest: {$: {}, application: [{$: {'android:name': '.MainApplication'}}]}});
+    expect(result.manifest.application[0].service).toHaveLength(2);
+    expect(result.manifest.application[0].service[0].$['android:foregroundServiceType']).toBe('connectedDevice');
+  });
+
+  test('blocks unused FGS permissions and opts out of Expo background audio', () => {
+    expect(appConfig.expo.android.blockedPermissions).toEqual([
+      'android.permission.FOREGROUND_SERVICE_DATA_SYNC',
+      'android.permission.FOREGROUND_SERVICE_LOCATION',
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+      'android.permission.FOREGROUND_SERVICE_MICROPHONE',
+    ]);
+    expect(appConfig.expo.plugins).toContainEqual(['expo-audio', {
+      enableBackgroundPlayback: false,
+      enableBackgroundRecording: false,
+    }]);
+    expect(appConfig.expo.plugins).toContain('./plugins/withConnectedDeviceForegroundService');
+    expect(appConfig.expo.ios.infoPlist.UIBackgroundModes).toEqual(['audio']);
+  });
+});


### PR DESCRIPTION
## Summary
- Limit the React Native example's SDK foreground service to connectedDevice.
- Block unused data-sync, location, microphone, and media-playback FGS permissions.
- Disable unused Expo background audio services and remove the unused Expo location task service.
- Preserve the example's existing iOS background-audio setting and ordinary connectivity permissions.
- Pin @mentra/bluetooth-sdk and @mentra/engine to the publicly published 3.2.0-dev.200 and update the lockfile.

## SDK Dependency Resolved
https://github.com/Mentra-Community/MentraOS/pull/3990 is merged. The public 3.2.0-dev.200 SDK tarball was verified to contain its manifest-aware foreground-service implementation. Validation below uses installed public npm packages, not a local SDK source override.

## Validation
- Cherry-picked only the fix onto dev; no staging-only changes included.
- Public-package frozen-lockfile installation passed.
- 41 example tests passed; TypeScript and git diff --check passed.
- Expo Android prebuild and Gradle processReleaseMainManifest passed against the installed public SDK.
- Parsed the final merged release manifest: only FOREGROUND_SERVICE and FOREGROUND_SERVICE_CONNECTED_DEVICE permissions; only the SDK connectedDevice typed service; no Expo location/audio foreground services; CHANGE_WIFI_STATE retained.
- Manifest-only Gradle validation excluded the unrelated GStreamer SDK installation after an earlier download exhausted disk space. Temporary files were cleaned up. This is not a full APK build.
- Physical Android validation, a replacement Play build, and the connected-device demonstration video remain pending.
