### PR TITLE
fix(android-example): remove dataSync foreground-service timeout path

### DIFF
--- a/.github/workflows/example-app-builds.yml
+++ b/.github/workflows/example-app-builds.yml
@@ -133,6 +133,11 @@ jobs:
         run: |
           ./gradlew :app:assembleDebug --no-daemon
 
+      - name: Verify foreground service types
+        if: steps.availability.outputs.available == 'true'
+        working-directory: examples/android
+        run: python3 scripts/check-foreground-service.py app/build/intermediates/merged_manifests/debug/processDebugManifest/AndroidManifest.xml
+
       - name: Collect APK
         if: steps.availability.outputs.available == 'true'
         id: collect

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -21,6 +21,26 @@ Use the latest SDK version published by Mentra. If a future release note lists a
 
 ## Run
 
+### Foreground Service Lifetime
+
+The host manifest excludes `dataSync` from the SDK service and removes its
+typed permission. SDK `3.2.0-dev.200` or newer honors this override and starts
+with `connectedDevice`, using the existing `CHANGE_WIFI_STATE` permission
+before Bluetooth runtime permission is granted. Microphone, location and media
+playback types remain available under their existing permission checks.
+
+This removes the Android 15 data-sync six-hour timeout path; it does not prove
+the cause of a historical background crash or prevent other Android service
+restrictions. Rebuild and install the native APK for this change to take effect.
+Before release, test a fresh install with permissions denied, granted-permission
+background sessions, reconnect, and service restart on Android 15+.
+
+CI checks the merged manifest, including the published SDK's declarations:
+
+```bash
+python3 scripts/check-foreground-service.py app/build/intermediates/merged_manifests/debug/processDebugManifest/AndroidManifest.xml
+```
+
 ### Android Studio
 
 1. Open this `examples/android` folder in Android Studio.

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Device sessions must not acquire Android 15's six-hour dataSync budget. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" tools:node="remove" />
 
     <application
         android:label="@string/app_name"
@@ -27,6 +29,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.MentraExample">
+        <service
+            android:name="com.mentra.bluetoothsdk.services.ForegroundService"
+            android:foregroundServiceType="connectedDevice|location|mediaPlayback|microphone"
+            tools:replace="android:foregroundServiceType" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/examples/android/scripts/check-foreground-service.py
+++ b/examples/android/scripts/check-foreground-service.py
@@ -1,0 +1,35 @@
+"""Check the final native example manifest, not just its merge directives."""
+
+import sys
+import xml.etree.ElementTree as ET
+
+ANDROID = "{http://schemas.android.com/apk/res/android}"
+EXPECTED_TYPES = {"connectedDevice", "location", "mediaPlayback", "microphone"}
+
+
+def check_manifest(root):
+    permissions = {node.get(ANDROID + "name") for node in root.findall("uses-permission")}
+    if "android.permission.FOREGROUND_SERVICE_DATA_SYNC" in permissions:
+        raise ValueError("Merged manifest must not request dataSync foreground-service permission")
+    required = {
+        "android.permission.FOREGROUND_SERVICE",
+        "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE",
+        "android.permission.CHANGE_WIFI_STATE",
+    }
+    if not required <= permissions:
+        raise ValueError(f"Missing connectedDevice startup permissions: {required - permissions}")
+    services = root.findall("application/service")
+    for service in services:
+        if "dataSync" in service.get(ANDROID + "foregroundServiceType", "").split("|"):
+            raise ValueError("Merged service must not select dataSync")
+    sdk_services = [service for service in services if service.get(ANDROID + "name") ==
+                    "com.mentra.bluetoothsdk.services.ForegroundService"]
+    if len(sdk_services) != 1:
+        raise ValueError("Expected exactly one SDK foreground service")
+    if set(sdk_services[0].get(ANDROID + "foregroundServiceType", "").split("|")) != EXPECTED_TYPES:
+        raise ValueError("SDK service must retain all non-dataSync types")
+
+
+if __name__ == "__main__":
+    check_manifest(ET.parse(sys.argv[1]).getroot())
+    print("Foreground-service manifest verified: connectedDevice startup, no dataSync")


### PR DESCRIPTION
## Summary
- Override the native Android example SDK service to exclude dataSync, and remove its typed permission from the merged manifest.
- Preserve connectedDevice, microphone, location, and mediaPlayback capabilities. Existing SDK dev.200 honors the host override and bootstraps with connectedDevice using existing CHANGE_WIFI_STATE permission.
- Add a CI check of the final merged manifest to prevent dataSync from returning and preserve startup prerequisites and the other service types.

## Motivation
The reported historical background crash is assumed to be the Android 15 dataSync timeout for this targeted fix. Its stack trace is unavailable, so this PR removes that specific path but does not claim the historical crash is reproduced or diagnosed. Unlike #201, this changes the native Kotlin Android example.

## Validation
- Public Maven SDK dev.200: Gradle processDebugManifest passed.
- Final merged-manifest checker passed.
- Checker rejected four simulated regressions: dataSync permission, dataSync service type, missing startup permission, and removed non-dataSync capabilities.
- Seven coordinated-release tests and git diff --check passed.
- Local manifest-only build skipped unrelated GStreamer SDK installation; no full APK build or hardware validation claimed. CI runs full native builds and the manifest check.

## Device Qualification Pending
Install a rebuilt APK on Android 15+; test denied/granted permissions, background sessions, reconnect, and service restart. The previously installed app does not receive manifest changes until rebuilt and replaced.